### PR TITLE
feat(landing): Implement value proposition section with 4 feature cards (#16)

### DIFF
--- a/src/components/ValuePropositionSection.tsx
+++ b/src/components/ValuePropositionSection.tsx
@@ -1,0 +1,66 @@
+import type { LucideIcon } from "lucide-react";
+import { Clock, PauseCircle, Settings, Star } from "lucide-react";
+
+export default function ValuePropositionSection() {
+	return (
+		<section className='px-6 py-24 transition-colors duration-300'>
+			<div className='max-w-6xl mx-auto text-center'>
+				<h2 className='text-4xl font-semibold font-jakarta-sans text-slate-900 dark:text-white'>
+					Treasury streaming infrastructure
+				</h2>
+				<p className='mt-4 text-lg text-slate-500 dark:text-slate-400'>
+					Everything you need to manage continuous capital flow on Stellar
+				</p>
+
+				<div className='mt-16 grid grid-cols-1 md:grid-cols-2 gap-8'>
+					<FeatureCard
+						icon={Clock}
+						title='Real-time USDC streaming'
+						description='Funds accrue per second; recipients withdraw anytime. No batch delays, no waiting for payment cycles—continuous capital flow.'
+					/>
+					<FeatureCard
+						icon={Settings}
+						title='Configurable rate & cliff'
+						description='Set streaming rate, start/end timestamps, and optional cliff periods. Vesting schedules and grant programs in one primitive.'
+					/>
+					<FeatureCard
+						icon={PauseCircle}
+						title='Pause and cancel controls'
+						description='Treasury or admin can pause or cancel active streams. Unstreamed amounts return to sender automatically. Full control, always.'
+					/>
+					<FeatureCard
+						icon={Star}
+						title='Built on Stellar & Soroban'
+						description='Native Stellar infrastructure. Soroban smart contracts. Native USDC support. Built specifically for the Stellar ecosystem.'
+					/>
+				</div>
+			</div>
+		</section>
+	);
+}
+
+function FeatureCard({
+	icon,
+	title,
+	description,
+}: {
+	icon: LucideIcon;
+	title: string;
+	description: string;
+}) {
+	const Icon = icon;
+
+	return (
+		<div className='rounded-2xl border border-slate-200 bg-white p-8 text-left transition-all duration-300 hover:shadow-lg dark:border-cyan-500/10 dark:bg-slate-900/60 dark:hover:border-cyan-500/25 dark:hover:shadow-[0_8px_30px_rgba(8,145,178,0.12)]'>
+			<div className='mb-6 flex h-12 w-12 items-center justify-center rounded-xl bg-cyan-50 text-cyan-500 dark:bg-cyan-500/15 dark:text-cyan-300'>
+				<Icon className='h-6 w-6 stroke-2' />
+			</div>
+			<h3 className='text-lg font-semibold font-jakarta-sans text-slate-700 dark:text-slate-100'>
+				{title}
+			</h3>
+			<p className='mt-3 text-sm leading-relaxed font-jakarta-sans text-slate-500 dark:text-slate-400'>
+				{description}
+			</p>
+		</div>
+	);
+}

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -1,4 +1,27 @@
+import { useEffect, useState } from "react";
+import ValuePropositionSection from "@/components/ValuePropositionSection";
+
 function LandingPage() {
-	return <div>LandingPage</div>;
+	const [isDark, setIsDark] = useState(true);
+
+	useEffect(() => {
+		document.documentElement.classList.toggle("dark", isDark);
+	}, [isDark]);
+
+	return (
+		<div className='min-h-screen bg-slate-100 px-6 py-8 transition-colors duration-300 dark:bg-[#030a1c]'>
+			<div className='mx-auto max-w-6xl'>
+				<div className='mb-6 flex justify-end'>
+					<button
+						type='button'
+						onClick={() => setIsDark((prev) => !prev)}
+						className='rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-50 dark:border-cyan-500/40 dark:bg-cyan-500/10 dark:text-cyan-200 dark:hover:bg-cyan-500/20'>
+						Switch to {isDark ? "Light" : "Dark"} Mode
+					</button>
+				</div>
+			</div>
+			<ValuePropositionSection />
+		</div>
+	);
 }
 export default LandingPage;


### PR DESCRIPTION
Closes #16

## Changes
- Implemented the "Treasury streaming infrastructure" value section
- Added heading and supporting subtext
- Built responsive 2x2 feature card grid
- Styled to match Figma reference
- Implemented using Tailwind utility classes

## Testing
- Verified responsive behavior on mobile and desktop
- Confirmed layout matches Figma spacing and structure
- Ensured no layout break within existing app structure

## Notes
- Section implemented as a reusable component
- No changes made to existing dashboard functionality
<img width="1278" height="807" alt="image" src="https://github.com/user-attachments/assets/189fd515-030f-4f1a-b8d0-d3a69318a5cc" />
<img width="1278" height="807" alt="image" src="https://github.com/user-attachments/assets/d068875f-e92f-4458-ba6c-2699f98fda40" />
<img width="573" height="1038" alt="image" src="https://github.com/user-attachments/assets/92697a5e-547c-47f3-bae1-66715100f881" />
<img width="573" height="1038" alt="image" src="https://github.com/user-attachments/assets/45ab4786-9712-43aa-9f72-606efe045f8f" />
