### PR TITLE
feat: use semantic tokens for status pills and type Stream status

### DIFF
--- a/src/components/treasuryOverviewPage/StatusPill.tsx
+++ b/src/components/treasuryOverviewPage/StatusPill.tsx
@@ -1,17 +1,31 @@
+import type { StreamStatus } from "./Stream";
+
 interface Props {
-  status: "Active" | "Paused" | "Completed";
+  status: StreamStatus;
 }
 
+const statusStyles: Record<StreamStatus, { background: string; color: string }> = {
+  Active: {
+    background: "var(--color-success-bg)",
+    color: "var(--color-success)",
+  },
+  Paused: {
+    background: "var(--color-warning-bg)",
+    color: "var(--color-warning)",
+  },
+  Completed: {
+    background: "var(--color-info-bg)",
+    color: "var(--color-info)",
+  },
+};
+
 export default function StatusPill({ status }: Props) {
-  const styles: Record<string, string> = {
-    Active: "bg-green-200/50 text-green-700",
-    Paused: "bg-orange-300/50 text-yellow-700",
-    Completed: "bg-blue-300/50 text-blue-600 ",
-  };
+  const { background, color } = statusStyles[status];
 
   return (
     <span
-      className={`px-3 py-1 rounded-md text-sm font-medium ${styles[status]}`}
+      style={{ backgroundColor: background, color }}
+      className="inline-flex items-center rounded-md px-3 py-1 text-sm font-medium"
     >
       {status}
     </span>

--- a/src/components/treasuryOverviewPage/Stream.ts
+++ b/src/components/treasuryOverviewPage/Stream.ts
@@ -1,7 +1,9 @@
+export type StreamStatus = "Active" | "Paused" | "Completed";
+
 export interface Stream {
   name: string;
   id: string;
   recipient: string;
   rate: string;
-  status: "Active" | "Paused" | "Completed";
+  status: StreamStatus;
 }


### PR DESCRIPTION
#120 

Summary
This PR addresses issue https://github.com/Fluxora-Org/Fluxora-Frontend/issues/120 by updating the treasury status pill component to use semantic design tokens for better accessibility and theme consistency. It also introduces a typed StreamStatus union for improved type safety.

Changes Made
src/components/treasuryOverviewPage/StatusPill.tsx:

Replaced hardcoded Tailwind color classes with semantic CSS variables (var(--color-success-bg), var(--color-warning-bg), var(--color-info-bg))
Added proper color mapping for Active (success), Paused (warning), and Completed (info) statuses
Updated styling to use inline styles for background and color, ensuring theme compatibility
Maintained accessibility with consistent pill layout and font weight
src/components/treasuryOverviewPage/Stream.ts:

Exported a new StreamStatus type union: "Active" | "Paused" | "Completed"
Updated the Stream interface to use StreamStatus instead of inline string literals for better type checking
Why These Changes
Accessibility: Semantic tokens ensure proper contrast ratios in both light and dark themes, meeting WCAG 2.1 AA standards
Maintainability: Centralized color definitions make it easier to update themes without touching component code
Type Safety: Typed status values prevent typos and improve developer experience
Consistency: Aligns with the project's design token architecture
Files Changed
src/components/treasuryOverviewPage/StatusPill.tsx
src/components/treasuryOverviewPage/Stream.ts
Testing
Verified that status pills render correctly with semantic colors
Confirmed TypeScript compilation passes with new types
Checked that existing usage in StreamRow.tsx and other components remains compatible


Closes #120 