### PR TITLE
chore(uiux): add prefers-reduced-motion variants for animated/glowing elements

### DIFF
--- a/src/components/GlowingDot.tsx
+++ b/src/components/GlowingDot.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useState } from "react";
+
 interface GlowingDotProps {
   top?: string;
   left?: string;
@@ -7,9 +9,36 @@ interface GlowingDotProps {
   opacity?: number;
 }
 
-export default function GlowingDot({ top, left, right, bottom, size = 12, opacity = 0.5 }: GlowingDotProps) {
+/**
+ * Decorative glowing dot used as a background accent.
+ * Respects the user's `prefers-reduced-motion` setting:
+ * when reduced motion is preferred the glow (box-shadow) is removed
+ * so the element becomes a plain static dot.
+ */
+export default function GlowingDot({
+  top,
+  left,
+  right,
+  bottom,
+  size = 12,
+  opacity = 0.5,
+}: GlowingDotProps) {
+  const [reducedMotion, setReducedMotion] = useState(
+    () =>
+      typeof window !== "undefined" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches
+  );
+
+  useEffect(() => {
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const handler = (e: MediaQueryListEvent) => setReducedMotion(e.matches);
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, []);
+
   return (
     <div
+      aria-hidden="true"
       style={{
         position: "fixed",
         top,
@@ -20,7 +49,9 @@ export default function GlowingDot({ top, left, right, bottom, size = 12, opacit
         height: size,
         borderRadius: "50%",
         background: `rgba(34,211,238,${opacity})`,
-        boxShadow: `0 0 ${size + 4}px ${Math.floor(size / 3)}px rgba(34,211,238,${opacity * 0.6})`,
+        boxShadow: reducedMotion
+          ? "none"
+          : `0 0 ${size + 4}px ${Math.floor(size / 3)}px rgba(34,211,238,${opacity * 0.6})`,
         pointerEvents: "none",
       }}
     />

--- a/src/components/__tests__/GlowingDot.test.tsx
+++ b/src/components/__tests__/GlowingDot.test.tsx
@@ -1,0 +1,168 @@
+import { render, act } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import GlowingDot from "../GlowingDot";
+
+type ChangeHandler = (e: MediaQueryListEvent) => void;
+
+// jsdom does not implement window.matchMedia, so we define it ourselves.
+function mockMatchMedia(matches: boolean) {
+  const listeners: ChangeHandler[] = [];
+  const mq = {
+    matches,
+    addEventListener: vi.fn((_: string, cb: ChangeHandler) => {
+      listeners.push(cb);
+    }),
+    removeEventListener: vi.fn((_: string, cb: ChangeHandler) => {
+      const idx = listeners.indexOf(cb);
+      if (idx !== -1) listeners.splice(idx, 1);
+    }),
+    /** Simulate the OS preference changing at runtime. */
+    dispatchChange: (newMatches: boolean) => {
+      listeners.forEach((cb) => cb({ matches: newMatches } as MediaQueryListEvent));
+    },
+  };
+
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    configurable: true,
+    value: vi.fn().mockReturnValue(mq),
+  });
+
+  return mq;
+}
+
+describe("GlowingDot", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ─── default rendering ────────────────────────────────────────────────────
+
+  it("renders a div with aria-hidden", () => {
+    mockMatchMedia(false);
+    render(<GlowingDot />);
+    const dot = document.querySelector("[aria-hidden='true']");
+    expect(dot).toBeInTheDocument();
+  });
+
+  it("applies default size (12px)", () => {
+    mockMatchMedia(false);
+    render(<GlowingDot />);
+    const dot = document.querySelector("[aria-hidden='true']") as HTMLElement;
+    expect(dot.style.width).toBe("12px");
+    expect(dot.style.height).toBe("12px");
+  });
+
+  it("applies custom size prop", () => {
+    mockMatchMedia(false);
+    render(<GlowingDot size={24} />);
+    const dot = document.querySelector("[aria-hidden='true']") as HTMLElement;
+    expect(dot.style.width).toBe("24px");
+    expect(dot.style.height).toBe("24px");
+  });
+
+  it("applies position props", () => {
+    mockMatchMedia(false);
+    render(<GlowingDot top="10px" left="20px" right="30px" bottom="40px" />);
+    const dot = document.querySelector("[aria-hidden='true']") as HTMLElement;
+    expect(dot.style.top).toBe("10px");
+    expect(dot.style.left).toBe("20px");
+    expect(dot.style.right).toBe("30px");
+    expect(dot.style.bottom).toBe("40px");
+  });
+
+  it("has pointerEvents none", () => {
+    mockMatchMedia(false);
+    render(<GlowingDot />);
+    const dot = document.querySelector("[aria-hidden='true']") as HTMLElement;
+    expect(dot.style.pointerEvents).toBe("none");
+  });
+
+  it("has border-radius 50%", () => {
+    mockMatchMedia(false);
+    render(<GlowingDot />);
+    const dot = document.querySelector("[aria-hidden='true']") as HTMLElement;
+    expect(dot.style.borderRadius).toBe("50%");
+  });
+
+  // ─── motion allowed ───────────────────────────────────────────────────────
+
+  it("renders with a glow box-shadow when motion is allowed", () => {
+    mockMatchMedia(false);
+    render(<GlowingDot size={12} opacity={0.5} />);
+    const dot = document.querySelector("[aria-hidden='true']") as HTMLElement;
+    expect(dot.style.boxShadow).not.toBe("none");
+    expect(dot.style.boxShadow).toMatch(/rgba\(34,?\s*211,?\s*238/);
+  });
+
+  // ─── reduced motion ───────────────────────────────────────────────────────
+
+  it("renders with no box-shadow when prefers-reduced-motion: reduce", () => {
+    mockMatchMedia(true);
+    render(<GlowingDot size={12} opacity={0.5} />);
+    const dot = document.querySelector("[aria-hidden='true']") as HTMLElement;
+    expect(dot.style.boxShadow).toBe("none");
+  });
+
+  it("still renders the dot background color when reduced motion is set", () => {
+    mockMatchMedia(true);
+    render(<GlowingDot opacity={0.5} />);
+    const dot = document.querySelector("[aria-hidden='true']") as HTMLElement;
+    // jsdom normalises rgba values with spaces; match the channel values loosely
+    expect(dot.style.background).toMatch(/rgba\(34,?\s*211,?\s*238/);
+  });
+
+  // ─── dynamic media query change ───────────────────────────────────────────
+
+  it("removes glow when user switches to reduced-motion at runtime", () => {
+    const mq = mockMatchMedia(false);
+    render(<GlowingDot size={12} opacity={0.5} />);
+
+    const dot = document.querySelector("[aria-hidden='true']") as HTMLElement;
+    expect(dot.style.boxShadow).not.toBe("none");
+
+    act(() => {
+      mq.dispatchChange(true);
+    });
+
+    expect(dot.style.boxShadow).toBe("none");
+  });
+
+  it("restores glow when user switches back to motion-allowed at runtime", () => {
+    const mq = mockMatchMedia(true);
+    render(<GlowingDot size={12} opacity={0.5} />);
+
+    const dot = document.querySelector("[aria-hidden='true']") as HTMLElement;
+    expect(dot.style.boxShadow).toBe("none");
+
+    act(() => {
+      mq.dispatchChange(false);
+    });
+
+    expect(dot.style.boxShadow).not.toBe("none");
+  });
+
+  it("cleans up the media query listener on unmount", () => {
+    const mq = mockMatchMedia(false);
+    const { unmount } = render(<GlowingDot />);
+    unmount();
+    expect(mq.removeEventListener).toHaveBeenCalledWith("change", expect.any(Function));
+  });
+
+  // ─── opacity prop ─────────────────────────────────────────────────────────
+
+  it("uses custom opacity in background color", () => {
+    mockMatchMedia(false);
+    render(<GlowingDot opacity={0.8} />);
+    const dot = document.querySelector("[aria-hidden='true']") as HTMLElement;
+    expect(dot.style.background).toContain("0.8");
+  });
+
+  it("uses custom opacity in box-shadow when motion is allowed", () => {
+    mockMatchMedia(false);
+    render(<GlowingDot opacity={0.8} />);
+    const dot = document.querySelector("[aria-hidden='true']") as HTMLElement;
+    // box-shadow opacity = opacity * 0.6 = 0.48
+    expect(dot.style.boxShadow).toContain("0.48");
+  });
+});

--- a/src/index.css
+++ b/src/index.css
@@ -447,6 +447,24 @@ button:has(+ button[aria-label*="Connect"]):hover,
   100% { background-position: -200% 0; }
 }
 
+/* ═══════════════════════════════════════════════════════════
+   REDUCED MOTION
+   Disable all CSS animations, transitions, and the shimmer /
+   spin keyframe animations for users who prefer reduced motion.
+   JS-driven animations (e.g. GlowingDot glow) are handled in
+   the component via the matchMedia API.
+   ═══════════════════════════════════════════════════════════ */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
 /* Screen-reader only utility */
 .sr-only {
   position: absolute;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,27 @@
+/// <reference types="vitest" />
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+// Separate vitest config that omits the @tailwindcss/vite plugin.
+// The tailwindcss plugin requires a native binary (@tailwindcss/oxide)
+// that is not needed during unit tests (jsdom environment).
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    globals: true,
+    environment: "jsdom",
+    setupFiles: "./src/test/setup.ts",
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "json", "html"],
+      include: ["src/components/**/*.tsx"],
+      exclude: ["src/components/**/*.test.tsx"],
+      thresholds: {
+        lines: 95,
+        functions: 95,
+        branches: 95,
+        statements: 95,
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary

Closes #136

Implements  support for all animated and glowing UI elements.

## Changes

### `src/components/GlowingDot.tsx`
- Added `useReducedMotion` logic via `window.matchMedia('(prefers-reduced-motion: reduce)')`
- Removes the glow `box-shadow` when the user prefers reduced motion; the dot remains visible as a plain static circle
- Listens for runtime OS preference changes and updates reactively
- Added `aria-hidden="true"` since the dot is purely decorative

### `src/index.css`
- Added `@media (prefers-reduced-motion: reduce)` block that collapses all CSS `animation-duration` and `transition-duration` to `0.01ms` — covers the spinner (`@keyframes spin`), skeleton shimmer (`@keyframes shimmer`), hover transitions, and any future animations

### `vitest.config.ts` (new)
- Separate Vitest config that omits `@tailwindcss/vite` plugin (the native `@tailwindcss/oxide` binary is unavailable in the jsdom test environment)

### `src/components/__tests__/GlowingDot.test.tsx` (new)
- 14 tests covering: default rendering, motion-allowed glow, reduced-motion no-glow, runtime MQ change (both directions), cleanup on unmount, and opacity prop
- All 14 pass ✅

## Accessibility
- Respects WCAG 2.1 SC 2.3.3 (Animation from Interactions)
- Works with OS-level reduced-motion settings on macOS, Windows, iOS, Android
- No visual regression for users who have not enabled reduced motion

## Testing checklist
- [x] `npx vitest run --config vitest.config.ts src/components/__tests__/GlowingDot.test.tsx` — 14/14 pass
- [x] Manual: toggle System Preferences → Accessibility → Reduce Motion — glow disappears instantly
- [x] No TypeScript errors (`tsc --noEmit`)