### PR TITLE
chore(uiux): ensure decorative SVGs are aria-hidden and alt text is correct

### DIFF
--- a/src/assets/images/success.svg
+++ b/src/assets/images/success.svg
@@ -1,4 +1,4 @@
-<svg width="511" height="104" viewBox="0 0 511 104" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="511" height="104" viewBox="0 0 511 104" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
 <g filter="url(#filter0_dd_1_6341)">
 <path d="M223.323 31.9967C223.323 14.3254 237.649 0 255.32 0C272.991 0 287.317 14.3254 287.317 31.9967C287.317 49.668 272.991 63.9934 255.32 63.9934C237.649 63.9934 223.323 49.668 223.323 31.9967Z" fill="url(#paint0_linear_1_6341)" shape-rendering="crispEdges"/>
 <path d="M255.314 46.9942C263.597 46.9942 270.311 40.2796 270.311 31.9968C270.311 23.714 263.597 16.9995 255.314 16.9995C247.031 16.9995 240.316 23.714 240.316 31.9968C240.316 40.2796 247.031 46.9942 255.314 46.9942Z" stroke="white" stroke-width="3.74933" stroke-linecap="round" stroke-linejoin="round"/>

--- a/src/components/__tests__/EmptyState.test.tsx
+++ b/src/components/__tests__/EmptyState.test.tsx
@@ -1,0 +1,132 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import EmptyState from "../EmptyState";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Returns all SVG elements inside the given container. */
+function getAllSvgs(container: HTMLElement) {
+  return Array.from(container.querySelectorAll("svg"));
+}
+
+// ── aria-hidden on decorative SVGs ────────────────────────────────────────────
+
+describe("EmptyState — decorative SVGs have aria-hidden='true'", () => {
+  const variants = ["treasury", "streams", "recipient"] as const;
+
+  variants.forEach((variant) => {
+    it(`all SVGs in the ${variant} variant are aria-hidden`, () => {
+      const { container } = render(
+        <EmptyState variant={variant} walletConnected={false} />
+      );
+      const svgs = getAllSvgs(container);
+      expect(svgs.length).toBeGreaterThan(0);
+      svgs.forEach((svg) => {
+        expect(svg).toHaveAttribute("aria-hidden", "true");
+      });
+    });
+
+    it(`all SVGs in the ${variant} variant (connected) are aria-hidden`, () => {
+      const { container } = render(
+        <EmptyState variant={variant} walletConnected={true} />
+      );
+      const svgs = getAllSvgs(container);
+      expect(svgs.length).toBeGreaterThan(0);
+      svgs.forEach((svg) => {
+        expect(svg).toHaveAttribute("aria-hidden", "true");
+      });
+    });
+  });
+
+  it("error banner SVG is aria-hidden", () => {
+    const { container } = render(
+      <EmptyState variant="treasury" walletConnected={true} error="Something went wrong" />
+    );
+    const svgs = getAllSvgs(container);
+    svgs.forEach((svg) => {
+      expect(svg).toHaveAttribute("aria-hidden", "true");
+    });
+  });
+});
+
+// ── Accessible region label ───────────────────────────────────────────────────
+
+describe("EmptyState — accessible region labels", () => {
+  it("treasury variant has correct region label", () => {
+    render(<EmptyState variant="treasury" />);
+    expect(screen.getByRole("region", { name: "Treasury empty state" })).toBeInTheDocument();
+  });
+
+  it("streams variant has correct region label", () => {
+    render(<EmptyState variant="streams" />);
+    expect(screen.getByRole("region", { name: "Streams empty state" })).toBeInTheDocument();
+  });
+
+  it("recipient variant has correct region label", () => {
+    render(<EmptyState variant="recipient" />);
+    expect(screen.getByRole("region", { name: "Recipient empty state" })).toBeInTheDocument();
+  });
+});
+
+// ── Loading skeleton ──────────────────────────────────────────────────────────
+
+describe("EmptyState — loading state", () => {
+  it("renders loading skeleton with role=status", () => {
+    render(<EmptyState variant="treasury" loading={true} />);
+    expect(screen.getByRole("status")).toBeInTheDocument();
+  });
+
+  it("loading skeleton has accessible label", () => {
+    render(<EmptyState variant="treasury" loading={true} />);
+    expect(screen.getByRole("status", { name: "Loading" })).toBeInTheDocument();
+  });
+});
+
+// ── Error banner ──────────────────────────────────────────────────────────────
+
+describe("EmptyState — error state", () => {
+  it("renders error message in an alert role", () => {
+    render(<EmptyState variant="treasury" error="Network error" />);
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(screen.getByText("Network error")).toBeInTheDocument();
+  });
+
+  it("renders retry button when onRetry is provided", () => {
+    const onRetry = vi.fn();
+    render(<EmptyState variant="treasury" error="Oops" onRetry={onRetry} />);
+    const btn = screen.getByRole("button", { name: /retry/i });
+    expect(btn).toBeInTheDocument();
+  });
+
+  it("calls onRetry when retry button is clicked", async () => {
+    const onRetry = vi.fn();
+    const { getByRole } = render(
+      <EmptyState variant="treasury" error="Oops" onRetry={onRetry} />
+    );
+    getByRole("button", { name: /retry/i }).click();
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ── CTA button ────────────────────────────────────────────────────────────────
+
+describe("EmptyState — CTA button", () => {
+  it("renders CTA with correct aria-label when disconnected", () => {
+    render(<EmptyState variant="treasury" walletConnected={false} />);
+    expect(screen.getByRole("button", { name: "Connect wallet" })).toBeInTheDocument();
+  });
+
+  it("renders CTA with correct aria-label when connected (treasury)", () => {
+    render(<EmptyState variant="treasury" walletConnected={true} />);
+    expect(screen.getByRole("button", { name: "Create stream" })).toBeInTheDocument();
+  });
+
+  it("calls onPrimaryAction when CTA is clicked", () => {
+    const onPrimaryAction = vi.fn();
+    render(
+      <EmptyState variant="treasury" walletConnected={true} onPrimaryAction={onPrimaryAction} />
+    );
+    screen.getByRole("button", { name: "Create stream" }).click();
+    expect(onPrimaryAction).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Resolves #133

### Changes

- **`src/assets/images/success.svg`** — Added `aria-hidden="true"` to the root `<svg>` element. This image is purely decorative (a success checkmark illustration used as visual feedback) and should be invisible to screen readers.

- **`src/components/EmptyState.tsx`** — Audited all inline SVGs. All 6 SVGs (treasury wave icon, streams play icon, recipient inbox icon, error banner warning icon, CTA plus icon) already carry `aria-hidden="true"`. The icon wrapper `<div>` also has `aria-hidden="true"`. No changes required.

- **`src/components/__tests__/EmptyState.test.tsx`** — New test file with 18 tests covering:
  - `aria-hidden="true"` on every SVG in all 3 variants (connected + disconnected)
  - Accessible `role="region"` labels for each variant
  - Loading skeleton `role="status"` with accessible label
  - Error banner `role="alert"` and retry button
  - CTA button `aria-label` and click handler

### Test results

```
✓ src/components/__tests__/EmptyState.test.tsx (18 tests) 848ms
```

All 18 new tests pass. Pre-existing failures in other test files (`fast-check` missing, `ConnectButton.tsx` JSX bug, CSS variable resolution in jsdom) are unrelated to this issue and present on `main` before this branch.

### Accessibility checklist

- [x] Decorative SVGs hidden from assistive technology via `aria-hidden="true"`
- [x] No meaningful SVGs lack descriptive text (none exist in scope)
- [x] All interactive elements retain accessible labels
- [x] Tests verify accessibility attributes at the unit level