### PR TITLE
feat(streams): improved time presentation for cliffs and end dates (#174)

### DIFF
--- a/TIME_PRESENTATION_DESIGN_SPEC.md
+++ b/TIME_PRESENTATION_DESIGN_SPEC.md
@@ -1,0 +1,203 @@
+# Time Presentation: Cliffs, End Dates, and Ledger-Relative Clarity
+
+**Issue**: #174  
+**Domain**: Fluxora-Frontend (Treasury Streaming Product)  
+**Status**: Design Specification  
+**Created**: April 29, 2026
+
+---
+
+## 1. Executive Summary
+
+This design specification addresses the presentation of time-related information in Fluxora-Frontend, specifically:
+- **Cliff dates**: When funds become available to recipients
+- **End dates**: When streams conclude
+- **Ledger-relative clarity**: Clear communication of time zones and temporal context
+
+The goal is to ensure treasury managers, recipients, and auditors can easily understand temporal boundaries without ambiguity.
+
+---
+
+## 2. Current State Analysis
+
+### 2.1 Existing Implementation
+
+| Component | Current Behavior |
+|-----------|------------------|
+| `formatDate()` | Uses `Intl.DateTimeFormat` with "short" format (e.g., "Jan 15, 2026") |
+| Cliff date display | Shown in expanded view only |
+| End date display | Shown in card header and detail view |
+| Time zone info | Not displayed |
+| Relative time | Not displayed |
+
+### 2.2 Identified Issues
+
+1. **No time zone context**: Users cannot tell if dates are in local time, UTC, or Stellar ledger time
+2. **Missing relative time**: No "in X days" or "X days ago" context
+3. **Inconsistent hierarchy**: Cliff and end dates have similar visual weight
+4. **No cliff status**: Users cannot quickly see if cliff has passed or is upcoming
+5. **Loading states**: Time values show empty skeletons inconsistently
+
+---
+
+## 3. Design Specifications
+
+### 3.1 Time Display Formats
+
+| Context | Format | Example |
+|---------|--------|---------|
+| Card header (end date) | Relative + Absolute | "Ends in 45 days (Oct 15, 2026)" |
+| Expanded view (cliff) | Status badge + Date | "⏱ Cliff passed (Jan 31, 2026)" |
+| Expanded view (end) | Relative + Absolute | "Ends Oct 15, 2026 (in 168 days)" |
+| Detail page | Full date + Time zone | "October 15, 2026 at 11:59 PM UTC" |
+| Timeline events | Relative only | "3 days ago", "Next week" |
+
+### 3.2 Time Zone Display
+
+All time displays MUST include a time zone indicator:
+
+```
+Format: "{date} {time} {timezone}"
+Examples:
+- "Oct 15, 2026 11:59 PM UTC" (ledger time)
+- "Jan 15, 2026" (date only, local implied)
+- "In 45 days" (relative, no timezone needed)
+```
+
+**Ledger Time Note**: Stellar ledger time is UTC. Display "UTC" to indicate this is the canonical time.
+
+### 3.3 Visual Hierarchy
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  STREAM NAME                              [Status] [Health] │
+│  ─────────────────────────────────────────────────────────  │
+│  Recipient: Alice M. • Treasury: Protocol Growth           │
+│                                                             │
+│  Streaming: $5,000/mo                                      │
+│  ┌─────────────────────────────────────────────────────┐   │
+│  │ ⏱ Cliff: Jan 31, 2026 (passed)     End: Oct 15     │   │
+│  │ ████████████░░░░░░░░░░░░░░░░░░░░░░ 40% complete    │   │
+│  └─────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**Hierarchy Rules**:
+1. End date is more prominent than cliff date
+2. Passed cliffs show "passed" badge in muted style
+3. Upcoming cliffs show "in X days" in accent color
+4. Time zone indicator is subtle (secondary text color)
+
+### 3.4 Component States
+
+| State | Cliff Display | End Date Display |
+|-------|---------------|------------------|
+| Default | Date + relative | Date + relative + progress |
+| Cliff upcoming (< 7 days) | Warning color + "soon" | — |
+| Cliff passed | Muted + "passed" badge | — |
+| End upcoming (< 14 days) | — | Accent color + "ending soon" |
+| Stream completed | — | "Completed" badge |
+| Loading | Skeleton placeholder | Skeleton placeholder |
+| Empty | "No cliff set" | "No end date" |
+
+### 3.5 Accessibility Requirements
+
+| Requirement | Implementation |
+|-------------|-----------------|
+| Screen reader | `aria-label="Cliff date: January 31, 2026 (passed), End date: October 15, 2026"` |
+| Focus order | Date elements follow logical reading order |
+| Color independence | Status conveyed by text, not just color |
+| Keyboard navigation | All date actions keyboard-accessible |
+| Contrast | Minimum 4.5:1 for date text |
+
+---
+
+## 4. Implementation Specifications
+
+### 4.1 New Utility Functions
+
+```typescript
+// src/lib/timePresentation.ts
+
+/**
+ * Format date with optional time zone
+ */
+function formatDateWithTimezone(date: string | undefined, showTimezone?: boolean): string
+
+/**
+ * Get relative time string (e.g., "in 45 days", "3 days ago")
+ */
+function getRelativeTime(date: string | undefined): string
+
+/**
+ * Get cliff status (upcoming, passed, or none)
+ */
+function getCliffStatus(cliffDate: string | undefined): CliffStatus
+
+/**
+ * Combined time display for cards
+ */
+function formatStreamTimeRange(startDate: string, cliffDate?: string, endDate?: string): TimeDisplay
+```
+
+### 4.2 CSS Tokens
+
+```css
+/* Time display tokens */
+--time-cliff-upcoming: var(--color-warning);
+--time-cliff-passed: var(--color-text-muted);
+--time-end-upcoming: var(--color-accent-primary);
+--time-end-completed: var(--color-success);
+--time-timezone: var(--color-text-tertiary);
+```
+
+### 4.3 Responsive Behavior
+
+| Breakpoint | Time Display Behavior |
+|------------|----------------------|
+| Mobile (< 640px) | Stack: date on separate line, hide timezone |
+| Tablet (640-1024px) | Inline with abbreviated relative |
+| Desktop (> 1024px) | Full format with timezone |
+
+---
+
+## 5. File Changes
+
+### 5.1 New Files
+
+- `src/lib/timePresentation.ts` - Time formatting utilities
+
+### 5.2 Modified Files
+
+- `src/pages/Streams.tsx` - Update time display in cards and detail view
+- `src/pages/Streams.css` - Add time hierarchy styles
+- `src/data/streamRecords.ts` - Add `cliffStatus` field to records
+
+---
+
+## 6. Acceptance Criteria
+
+- [ ] All stream cards show cliff date with status (passed/upcoming/none)
+- [ ] All stream cards show end date with relative time
+- [ ] Time zone (UTC) displayed on detail pages
+- [ ] Loading states show consistent skeletons
+- [ ] Screen readers announce cliff and end dates with status
+- [ ] Mobile responsive: time info readable on small screens
+- [ ] Color independence: passed cliffs identifiable without color
+
+---
+
+## 7. Open Questions
+
+1. **Ledger time vs local time**: Should we show both? (Current: UTC only)
+2. **Historical streams**: How to display end dates for completed streams?
+3. **Time zone preference**: Allow users to set their local timezone?
+
+---
+
+## 8. Deferred Items
+
+| Item | Rationale | Owner |
+|------|-----------|-------|
+| User timezone preference | Requires backend storage | Future sprint |
+| Time zone selector UI | Low priority, most users accept UTC | Future sprint |

--- a/src/lib/timePresentation.ts
+++ b/src/lib/timePresentation.ts
@@ -1,0 +1,249 @@
+/**
+ * Time Presentation Utilities
+ * ──────────────────────────────────────
+ * Functions for displaying cliff dates, end dates,
+ * and ledger-relative time information.
+ *
+ * Issue: #174 Time presentation: cliffs, end dates, and ledger-relative clarity
+ */
+
+export type CliffStatus = "upcoming" | "passed" | "none";
+
+export interface TimeDisplay {
+  cliff: string;
+  cliffStatus: CliffStatus;
+  cliffRelative: string;
+  end: string;
+  endRelative: string;
+  hasCliff: boolean;
+  hasEnd: boolean;
+}
+
+/**
+ * Get current date as Date object
+ */
+function getCurrentDate(): Date {
+  return new Date();
+}
+
+/**
+ * Calculate days between two dates
+ * @returns positive number if future, negative if past
+ */
+function getDaysBetween(dateString: string | undefined): number | null {
+  if (!dateString) return null;
+
+  const targetDate = new Date(dateString);
+  const today = getCurrentDate();
+
+  // Reset to midnight for day-level comparison
+  today.setHours(0, 0, 0, 0);
+  targetDate.setHours(0, 0, 0, 0);
+
+  const diffTime = targetDate.getTime() - today.getTime();
+  const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+
+  return diffDays;
+}
+
+/**
+ * Format date with optional time zone
+ * @param dateString - ISO date string
+ * @param options - Formatting options
+ */
+export function formatDateWithTimezone(
+  dateString: string | undefined,
+  options?: {
+    showTime?: boolean;
+    showTimezone?: boolean;
+    format?: "short" | "medium" | "long";
+  }
+): string {
+  if (!dateString) return "Not set";
+
+  const date = new Date(dateString);
+  const { showTime = false, showTimezone = false, format = "short" } = options || {};
+
+  const formatOptions: Intl.DateTimeFormatOptions = {
+    year: "numeric",
+    month: format === "long" ? "long" : format === "medium" ? "short" : "numeric",
+    day: "numeric",
+  };
+
+  if (showTime) {
+    formatOptions.hour = "numeric";
+    formatOptions.minute = "2-digit";
+  }
+
+  let formatted = new Intl.DateTimeFormat("en-US", formatOptions).format(date);
+
+  if (showTimezone) {
+    formatted += " UTC";
+  }
+
+  return formatted;
+}
+
+/**
+ * Get relative time string (e.g., "in 45 days", "3 days ago")
+ */
+export function getRelativeTime(dateString: string | undefined): string {
+  const days = getDaysBetween(dateString);
+
+  if (days === null) return "No date";
+
+  if (days === 0) return "Today";
+  if (days === 1) return "Tomorrow";
+  if (days === -1) return "Yesterday";
+
+  if (days > 365) {
+    const years = Math.floor(days / 365);
+    return years === 1 ? "in 1 year" : `in ${years} years`;
+  }
+
+  if (days > 30) {
+    const months = Math.floor(days / 30);
+    return months === 1 ? "in 1 month" : `in ${months} months`;
+  }
+
+  if (days > 0) {
+    return days === 1 ? "in 1 day" : `in ${days} days`;
+  }
+
+  // Past dates
+  const pastDays = Math.abs(days);
+
+  if (pastDays > 30) {
+    const months = Math.floor(pastDays / 30);
+    return months === 1 ? "1 month ago" : `${months} months ago`;
+  }
+
+  return pastDays === 1 ? "1 day ago" : `${pastDays} days ago`;
+}
+
+/**
+ * Get cliff status (upcoming, passed, or none)
+ */
+export function getCliffStatus(cliffDate: string | undefined): CliffStatus {
+  if (!cliffDate) return "none";
+
+  const days = getDaysBetween(cliffDate);
+
+  if (days === null) return "none";
+  if (days < 0) return "passed";
+
+  return "upcoming";
+}
+
+/**
+ * Get human-readable cliff status text
+ */
+export function getCliffStatusText(cliffDate: string | undefined): string {
+  const status = getCliffStatus(cliffDate);
+
+  switch (status) {
+    case "passed":
+      return "passed";
+    case "upcoming":
+      const days = getDaysBetween(cliffDate);
+      if (days !== null && days <= 7) return "soon";
+      return "upcoming";
+    default:
+      return "no cliff";
+  }
+}
+
+/**
+ * Combined time display for stream cards
+ */
+export function formatStreamTimeRange(
+  startDate: string,
+  cliffDate?: string,
+  endDate?: string
+): TimeDisplay {
+  const hasCliff = !!cliffDate;
+  const hasEnd = !!endDate;
+
+  const cliffStatus = getCliffStatus(cliffDate);
+
+  return {
+    cliff: formatDateWithTimezone(cliffDate),
+    cliffStatus,
+    cliffRelative: getRelativeTime(cliffDate),
+    end: formatDateWithTimezone(endDate),
+    endRelative: getRelativeTime(endDate),
+    hasCliff,
+    hasEnd,
+  };
+}
+
+/**
+ * Format time for detail view with full context
+ */
+export function formatDetailTime(
+  dateString: string | undefined,
+  options?: {
+    includeRelative?: boolean;
+    includeTimezone?: boolean;
+  }
+): string {
+  if (!dateString) return "Not scheduled";
+
+  const { includeRelative = true, includeTimezone = false } = options || {};
+
+  const absolute = formatDateWithTimezone(dateString, {
+    showTime: includeTimezone,
+    showTimezone,
+    format: "medium",
+  });
+
+  if (!includeRelative) return absolute;
+
+  const relative = getRelativeTime(dateString);
+  return `${absolute} (${relative})`;
+}
+
+/**
+ * Check if a date is within a certain number of days
+ */
+export function isWithinDays(dateString: string | undefined, days: number): boolean {
+  const diff = getDaysBetween(dateString);
+  if (diff === null) return false;
+  return diff >= 0 && diff <= days;
+}
+
+/**
+ * Get urgency level for UI styling
+ */
+export type UrgencyLevel = "none" | "low" | "medium" | "high";
+
+export function getUrgencyLevel(
+  cliffDate?: string,
+  endDate?: string
+): { cliff: UrgencyLevel; end: UrgencyLevel } {
+  // Cliff urgency
+  let cliffUrgency: UrgencyLevel = "none";
+  if (cliffDate) {
+    const cliffDays = getDaysBetween(cliffDate);
+    if (cliffDays !== null) {
+      if (cliffDays < 0) cliffUrgency = "none"; // Passed
+      else if (cliffDays <= 7) cliffUrgency = "high";
+      else if (cliffDays <= 14) cliffUrgency = "medium";
+      else cliffUrgency = "low";
+    }
+  }
+
+  // End date urgency
+  let endUrgency: UrgencyLevel = "none";
+  if (endDate) {
+    const endDays = getDaysBetween(endDate);
+    if (endDays !== null) {
+      if (endDays < 0) endUrgency = "none"; // Completed
+      else if (endDays <= 14) endUrgency = "high";
+      else if (endDays <= 30) endUrgency = "medium";
+      else endUrgency = "low";
+    }
+  }
+
+  return { cliff: cliffUrgency, end: endUrgency };
+}

--- a/src/pages/Streams.css
+++ b/src/pages/Streams.css
@@ -561,3 +561,157 @@
     grid-template-columns: 1fr;
   }
 }
+
+/* ═══════════════════════════════════════════════════════════
+   TIME PRESENTATION STYLES (Issue #174)
+   Cliffs, end dates, and ledger-relative clarity
+   ═══════════════════════════════════════════════════════════ */
+
+/* Time bar - displays cliff and end dates in card header */
+.stream-time-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  padding: 0.85rem 1rem;
+  margin-top: 0.75rem;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(148, 163, 184, 0.1);
+}
+
+.stream-time-bar__item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 10px;
+  font-size: 0.85rem;
+}
+
+.stream-time-bar__icon {
+  font-size: 0.9rem;
+}
+
+.stream-time-bar__label {
+  font-weight: 600;
+  color: var(--muted);
+  text-transform: uppercase;
+  font-size: 0.7rem;
+  letter-spacing: 0.05em;
+}
+
+.stream-time-bar__date {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.stream-time-bar__relative {
+  color: var(--muted);
+  font-size: 0.8rem;
+}
+
+/* Cliff time bar variations */
+.stream-time-bar__cliff.is-passed {
+  background: rgba(107, 114, 128, 0.12);
+}
+
+.stream-time-bar__cliff.is-passed .stream-time-bar__date,
+.stream-time-bar__cliff.is-passed .stream-time-bar__relative {
+  color: var(--muted);
+}
+
+.stream-time-bar__cliff.is-upcoming {
+  background: rgba(245, 158, 11, 0.1);
+}
+
+.stream-time-bar__cliff.is-upcoming .stream-time-bar__date {
+  color: var(--status-warning);
+}
+
+.stream-time-bar__cliff.is-soon {
+  background: rgba(239, 68, 68, 0.1);
+}
+
+.stream-time-bar__cliff.is-soon .stream-time-bar__date {
+  color: var(--status-error);
+}
+
+/* End time bar variations */
+.stream-time-bar__end.is-high {
+  background: rgba(0, 184, 212, 0.1);
+}
+
+.stream-time-bar__end.is-high .stream-time-bar__date {
+  color: var(--color-accent-primary);
+}
+
+.stream-time-bar__end.is-medium {
+  background: rgba(45, 212, 191, 0.08);
+}
+
+.stream-time-bar__end.is-medium .stream-time-bar__date {
+  color: var(--accent);
+}
+
+.stream-time-bar__end.is-low {
+  background: rgba(107, 114, 128, 0.08);
+}
+
+/* Cliff badge in expanded view */
+.stream-cliff-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.65rem;
+  border-radius: 8px;
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+
+.stream-cliff-badge.is-passed {
+  background: rgba(107, 114, 128, 0.15);
+  color: var(--muted);
+}
+
+.stream-cliff-badge.is-upcoming {
+  background: rgba(245, 158, 11, 0.12);
+  color: var(--status-warning);
+}
+
+.stream-cliff-badge.is-soon {
+  background: rgba(239, 68, 68, 0.12);
+  color: var(--status-error);
+}
+
+.stream-cliff-badge.is-none {
+  background: rgba(107, 114, 128, 0.08);
+  color: var(--muted);
+}
+
+/* Time value in panel rows */
+.stream-time-value {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+/* Responsive adjustments for time display */
+@media (max-width: 640px) {
+  .stream-time-bar {
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .stream-time-bar__item {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .stream-time-bar__relative {
+    display: none;
+  }
+
+  .stream-time-bar__date {
+    font-size: 0.9rem;
+  }
+}

--- a/src/pages/Streams.tsx
+++ b/src/pages/Streams.tsx
@@ -15,6 +15,14 @@ import {
   type StreamRecord,
   type StreamStatus,
 } from "../data/streamRecords";
+import {
+  formatDateWithTimezone,
+  getRelativeTime,
+  getCliffStatus,
+  getCliffStatusText,
+  formatDetailTime,
+  getUrgencyLevel,
+} from "../lib/timePresentation";
 import "./Streams.css";
 
 type StatusFilter = "All" | StreamStatus;
@@ -33,11 +41,7 @@ function formatMonthlyRate(value: number) {
 
 function formatDate(value?: string) {
   if (!value) return "Not scheduled";
-  return new Intl.DateTimeFormat("en-US", {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  }).format(new Date(value));
+  return formatDateWithTimezone(value);
 }
 
 function getStatusClassName(status: StreamStatus) {
@@ -93,6 +97,10 @@ function StreamCard({
   onToggle: () => void;
   onOpenDetail: () => void;
 }) {
+  const urgency = getUrgencyLevel(stream.cliffDate, stream.endDate);
+  const cliffStatus = getCliffStatusText(stream.cliffDate);
+  const endRelative = getRelativeTime(stream.endDate);
+
   return (
     <article className={`stream-card is-${getStatusClassName(stream.status)}`}>
       <div className="stream-card__header">
@@ -141,16 +149,44 @@ function StreamCard({
           <span>Streaming rate</span>
           <strong>{formatMonthlyRate(stream.monthlyRate)}</strong>
           <div className="stream-card__meta-label">
-            Runs through {formatDate(stream.endDate)}
+            {stream.endDate ? `Ends ${endRelative}` : "No end date set"}
           </div>
         </div>
         <div className="stream-meta-block">
           <span>Withdrawable now</span>
           <strong>{formatUsdc(stream.withdrawableAmount)}</strong>
           <div className="stream-card__meta-label">
-            Next unlock {formatDate(stream.nextUnlockDate)}
+            {stream.nextUnlockDate
+              ? `Next unlock ${getRelativeTime(stream.nextUnlockDate)}`
+              : "No upcoming unlock"}
           </div>
         </div>
+      </div>
+
+      {/* Time display bar with cliff and end dates */}
+      <div className="stream-time-bar" aria-label="Stream timeline">
+        {stream.cliffDate && (
+          <div
+            className={`stream-time-bar__item stream-time-bar__cliff is-${cliffStatus}`}
+            aria-label={`Cliff date: ${formatDateWithTimezone(stream.cliffDate)} (${cliffStatus})`}
+          >
+            <span className="stream-time-bar__icon" aria-hidden="true">⏱</span>
+            <span className="stream-time-bar__label">Cliff</span>
+            <span className="stream-time-bar__date">{formatDateWithTimezone(stream.cliffDate)}</span>
+            <span className="stream-time-bar__relative">({getRelativeTime(stream.cliffDate)})</span>
+          </div>
+        )}
+        {stream.endDate && (
+          <div
+            className={`stream-time-bar__item stream-time-bar__end is-${urgency.end}`}
+            aria-label={`End date: ${formatDateWithTimezone(stream.endDate)} (${endRelative})`}
+          >
+            <span className="stream-time-bar__icon" aria-hidden="true">→</span>
+            <span className="stream-time-bar__label">End</span>
+            <span className="stream-time-bar__date">{formatDateWithTimezone(stream.endDate)}</span>
+            <span className="stream-time-bar__relative">({endRelative})</span>
+          </div>
+        )}
       </div>
 
       <div className="stream-progress">
@@ -201,8 +237,18 @@ function StreamCard({
                 </div>
                 <div className="stream-panel__row">
                   <span className="stream-panel__row-label">Cliff date</span>
+                  <div className="stream-panel__row-value stream-time-value">
+                    <span className={`stream-cliff-badge is-${cliffStatus}`}>
+                      {cliffStatus === "passed" && "✓ "}
+                      {cliffStatus === "upcoming" && "⏱ "}
+                      {formatDetailTime(stream.cliffDate)}
+                    </span>
+                  </div>
+                </div>
+                <div className="stream-panel__row">
+                  <span className="stream-panel__row-label">End date</span>
                   <div className="stream-panel__row-value">
-                    {formatDate(stream.cliffDate)}
+                    {formatDetailTime(stream.endDate, { includeTimezone: true })}
                   </div>
                 </div>
                 <div className="stream-panel__row">


### PR DESCRIPTION
Closes #174

---

feat(streams): enhanced time presentation with relative dates and cliff status badges

- Added time bar component showing cliff and end dates with relative context
- Implemented getRelativeTime() for "in X days" / "X days ago" formatting
- Added cliff status badges: passed (✓), upcoming (⏱), soon (< 7 days)
- Added urgency level styling for end dates (high/medium/low)
- Included UTC timezone indicator for ledger-relative clarity
- Added accessibility: aria-labels for screen reader announcements
- Responsive design: stacked layout on mobile, inline on desktop