### PR TITLE
fix(streams): slice visibleStreams by active page so Pagination works

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: set this to true or false

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -1,11 +1,32 @@
 import React from "react";
 import "./Pagination.css";
 
+/**
+ * Props for the {@link Pagination} control.
+ *
+ * The component is purely presentational: it renders the "Showing X – Y of N"
+ * summary and page-navigation buttons, but does **not** slice data itself.
+ * Callers are responsible for passing a pre-sliced list to their render loop
+ * and for keeping `currentPage` in sync (see `paginate()` in Streams.tsx).
+ */
 interface PaginationProps {
+  /** 1-based index of the currently visible page. Must be ≥ 1. */
   currentPage: number;
+  /** Total number of items across all pages (length of the unsliced array). */
   totalItems: number;
+  /** Maximum number of items shown per page. One of 10 | 25 | 50. */
   itemsPerPage: number;
+  /**
+   * Fired when the user selects a different page.
+   * Receives the raw 1-based page number from the button; the caller is
+   * responsible for clamping it before committing to state.
+   */
   onPageChange: (page: number) => void;
+  /**
+   * Fired when the user changes the "Per page" selector.
+   * Receives the raw numeric value from the `<select>`; the caller should
+   * validate it against the allowed set (10 | 25 | 50) before committing.
+   */
   onItemsPerPageChange: (limit: number) => void;
 }
 

--- a/src/components/RecentStreams.md
+++ b/src/components/RecentStreams.md
@@ -57,3 +57,20 @@ interface Stream {
 - Active: Green (#00875a on #d1f4e8)
 - Paused: Yellow (#cc8800 on #fff4cc)
 - Completed: Blue (#0065cc on #d4e7ff)
+
+## Pagination
+
+`RecentStreams` intentionally renders a **fixed, small slice** of streams (the
+most recent few) and exposes a "View all" link rather than embedding page
+controls.  Full pagination — with per-page selection, page-number buttons, and
+an accessible "Showing X – Y of N" summary — lives in `src/pages/Streams.tsx`
+and is powered by two collaborating pieces:
+
+| Piece | Responsibility |
+|---|---|
+| `paginate<T>()` in `Streams.tsx` | Slices the filtered array, clamps `currentPage` to a valid range, and coerces both `page` and `limit` to safe integers. |
+| `<Pagination>` in `Pagination.tsx` | Purely presentational: renders the summary text and page-navigation buttons; never touches the data array. |
+
+**Reset rule:** `currentPage` resets to 1 whenever `searchQuery`,
+`statusFilter`, or `sortBy` changes, so users never land on an out-of-range
+empty page after filtering.

--- a/src/pages/Streams.test.tsx
+++ b/src/pages/Streams.test.tsx
@@ -2,7 +2,52 @@ import { act, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import Streams from "./Streams";
-import { streamRecords } from "../data/streamRecords";
+import { streamRecords } from "../data/streamRecords"; // mocked below
+
+// 15 records spanning STR-001..STR-015.
+// STR-008 is placed first in the array so the component's initial
+// expandedStreamId = "STR-008".  After "recent" sort (desc by ID) the page-1
+// window is STR-015..STR-006, meaning STR-008 lands at position 8 of page 1
+// and is NOT paginatedStreams[0] (STR-015).  This lets the collapse-animation
+// tests toggle STR-008 off while the fallback moves to STR-015, so
+// aria-expanded correctly switches to "false" — matching the original test intent.
+//
+// Status assignment keeps the page split clean:
+//   Active  → STR-006..STR-015  (10 streams, all on page 1)
+//   Paused  → STR-001..STR-005  (5 streams, all on page 2)
+vi.mock("../data/streamRecords", () => {
+  // Start with STR-008 so records[0].id = "STR-008".
+  const ids = [8, 15, 14, 13, 12, 11, 10, 9, 7, 6, 5, 4, 3, 2, 1];
+  const records = ids.map((n) => ({
+    id: `STR-${String(n).padStart(3, "0")}`,
+    name: `Test Stream ${String(n).padStart(2, "0")}`,
+    recipientName: `Recipient ${n}`,
+    recipientAddress: `GADR...0${n}`,
+    treasuryName: "Test Treasury",
+    treasuryAddress: "GTRE...001",
+    asset: "USDC",
+    status: n >= 6 ? ("Active" as const) : ("Paused" as const),
+    monthlyRate: 1000,
+    depositAmount: 12000,
+    streamedAmount: 0,
+    withdrawableAmount: 1000,
+    remainingAmount: 12000,
+    progress: 0,
+    startDate: "2026-01-01",
+    endDate: "2026-12-31",
+    summary: `Test stream ${n}`,
+    health: "Healthy" as const,
+    healthNote: "OK",
+    auditNote: "OK",
+    tags: [],
+    timeline: [],
+  }));
+  return {
+    streamRecords: records,
+    getStreamRecord: (id: string) =>
+      records.find((s: { id: string }) => s.id === id),
+  };
+});
 
 type MatchMediaChangeHandler = (event: MediaQueryListEvent) => void;
 
@@ -69,11 +114,17 @@ describe("Streams disclosure motion", () => {
     renderStreams();
     await finishLoading();
 
-    const firstStream = streamRecords[0]!;
-    const disclosureId = `stream-expanded-${firstStream.id}`;
+    // Derive the expanded stream from the DOM so the test is resilient to
+    // changes in mock data order.  streamRecords[0] = STR-008, which is
+    // expanded on page 1 and is not paginatedStreams[0] (STR-015), so
+    // clicking collapse correctly toggles aria-expanded to "false".
     const collapseButton = screen.getByRole("button", {
       name: /collapse deep dive/i,
     });
+    const disclosureId = collapseButton.getAttribute("aria-controls")!;
+    const streamName =
+      collapseButton.closest('[role="article"]')!.querySelector("h3")!
+        .textContent!;
 
     expect(document.getElementById(disclosureId)).toBeInTheDocument();
 
@@ -85,7 +136,7 @@ describe("Streams disclosure motion", () => {
     expect(collapseButton).toHaveFocus();
     expect(collapseButton).toHaveAttribute("aria-expanded", "false");
     expect(
-      screen.getByText(`${firstStream.name} deep dive collapsed.`),
+      screen.getByText(`${streamName} deep dive collapsed.`),
     ).toBeInTheDocument();
     expect(document.getElementById(disclosureId)).toBeInTheDocument();
 
@@ -101,15 +152,201 @@ describe("Streams disclosure motion", () => {
     renderStreams();
     await finishLoading();
 
-    const firstStream = streamRecords[0]!;
-    const disclosureId = `stream-expanded-${firstStream.id}`;
     const collapseButton = screen.getByRole("button", {
       name: /collapse deep dive/i,
     });
+    const disclosureId = collapseButton.getAttribute("aria-controls")!;
 
     fireEvent.click(collapseButton);
 
     expect(collapseButton).toHaveAttribute("aria-expanded", "false");
     expect(document.getElementById(disclosureId)).not.toBeInTheDocument();
+  });
+});
+
+describe("Streams pagination slicing", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(window, "scrollTo").mockImplementation(() => {});
+    mockMatchMedia(false);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("renders exactly 10 stream cards on page 1 of 15 total streams", async () => {
+    renderStreams();
+    await finishLoading();
+
+    expect(screen.getAllByRole("article")).toHaveLength(10);
+  });
+
+  it("renders the remaining 5 stream cards after navigating to page 2", async () => {
+    renderStreams();
+    await finishLoading();
+
+    fireEvent.click(screen.getByRole("button", { name: "2" }));
+
+    expect(screen.getAllByRole("article")).toHaveLength(5);
+  });
+
+  it("page 1 shows the first 10 streams and not the 11th", async () => {
+    renderStreams();
+    await finishLoading();
+
+    // Default sort is "recent" (desc by ID): STR-015 first, STR-001 last.
+    // streamRecords[0] = STR-015, which sorts to position 1.
+    expect(screen.getByText(streamRecords[0]!.name)).toBeInTheDocument();
+    // The 11th stream in sorted order is streamRecords[10] (STR-005).
+    expect(screen.queryByText(streamRecords[10]!.name)).not.toBeInTheDocument();
+  });
+
+  it("page 2 shows the 11th stream and not the 1st", async () => {
+    renderStreams();
+    await finishLoading();
+
+    fireEvent.click(screen.getByRole("button", { name: "2" }));
+
+    expect(screen.getByText(streamRecords[10]!.name)).toBeInTheDocument();
+    expect(screen.queryByText(streamRecords[0]!.name)).not.toBeInTheDocument();
+  });
+
+  it("Showing summary reflects the correct window on page 1", async () => {
+    renderStreams();
+    await finishLoading();
+
+    const highlights = screen.getAllByText(/\d+/, { selector: ".highlight" });
+    const values = highlights.map((el) => el.textContent);
+    expect(values).toContain("1");
+    expect(values).toContain("10");
+    expect(values).toContain("15");
+  });
+
+  it("Showing summary reflects the correct window on page 2", async () => {
+    renderStreams();
+    await finishLoading();
+
+    fireEvent.click(screen.getByRole("button", { name: "2" }));
+
+    const highlights = screen.getAllByText(/\d+/, { selector: ".highlight" });
+    const values = highlights.map((el) => el.textContent);
+    expect(values).toContain("11");
+    expect(values).toContain("15");
+  });
+
+  it("resets to page 1 when the search query changes", async () => {
+    renderStreams();
+    await finishLoading();
+
+    fireEvent.click(screen.getByRole("button", { name: "2" }));
+    expect(screen.getAllByRole("article")).toHaveLength(5);
+
+    const searchInput = screen.getByRole("textbox", {
+      name: /search streams/i,
+    });
+    fireEvent.change(searchInput, { target: { value: "Test Stream" } });
+
+    // All 15 match → page 1 shows 10
+    expect(screen.getAllByRole("article")).toHaveLength(10);
+  });
+
+  it("resets to page 1 when the status filter changes", async () => {
+    renderStreams();
+    await finishLoading();
+
+    fireEvent.click(screen.getByRole("button", { name: "2" }));
+    expect(screen.getAllByRole("article")).toHaveLength(5);
+
+    // 5 Paused streams → all fit on page 1
+    fireEvent.click(screen.getByRole("button", { name: "Paused" }));
+
+    expect(screen.getAllByRole("article")).toHaveLength(5);
+    expect(screen.queryByRole("button", { name: "2" })).not.toBeInTheDocument();
+  });
+
+  it("resets to page 1 when the sort order changes", async () => {
+    renderStreams();
+    await finishLoading();
+
+    fireEvent.click(screen.getByRole("button", { name: "2" }));
+    expect(screen.getAllByRole("article")).toHaveLength(5);
+
+    const sortSelect = screen.getByRole("combobox", { name: /sort streams/i });
+    fireEvent.change(sortSelect, { target: { value: "name" } });
+
+    // All 15 streams, sorted by name, page 1 → 10 cards
+    expect(screen.getAllByRole("article")).toHaveLength(10);
+  });
+
+  it("resets to page 1 and shows all streams when itemsPerPage increases", async () => {
+    renderStreams();
+    await finishLoading();
+
+    fireEvent.click(screen.getByRole("button", { name: "2" }));
+    expect(screen.getAllByRole("article")).toHaveLength(5);
+
+    const perPageSelect = screen.getByRole("combobox", { name: /per page/i });
+    fireEvent.change(perPageSelect, { target: { value: "25" } });
+
+    // 25 per page means all 15 fit on page 1
+    expect(screen.getAllByRole("article")).toHaveLength(15);
+    expect(screen.queryByRole("button", { name: "2" })).not.toBeInTheDocument();
+  });
+
+  it("clamps safePage so an out-of-range currentPage never renders an empty list", async () => {
+    renderStreams();
+    await finishLoading();
+
+    // Go to page 2 (5 cards)
+    fireEvent.click(screen.getByRole("button", { name: "2" }));
+    expect(screen.getAllByRole("article")).toHaveLength(5);
+
+    // Filter down to "Active" (10 streams, 1 page) — page 2 would be out of range
+    fireEvent.click(screen.getByRole("button", { name: "Active" }));
+
+    // safePage clamps to 1; 10 Active streams render
+    expect(screen.getAllByRole("article")).toHaveLength(10);
+    expect(screen.queryByRole("button", { name: "2" })).not.toBeInTheDocument();
+  });
+
+  it("shows empty search message and no cards when no streams match", async () => {
+    renderStreams();
+    await finishLoading();
+
+    const searchInput = screen.getByRole("textbox", {
+      name: /search streams/i,
+    });
+    fireEvent.change(searchInput, { target: { value: "zzz-no-match" } });
+
+    expect(
+      screen.getByText(/no streams match your search or filter/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("article")).not.toBeInTheDocument();
+  });
+
+  it("scrolls to top when navigating to a new page", async () => {
+    renderStreams();
+    await finishLoading();
+
+    fireEvent.click(screen.getByRole("button", { name: "2" }));
+
+    expect(window.scrollTo).toHaveBeenCalledWith({
+      top: 0,
+      behavior: "smooth",
+    });
+  });
+
+  it("coerces unsafe itemsPerPage values to the default of 10", async () => {
+    renderStreams();
+    await finishLoading();
+
+    const perPageSelect = screen.getByRole("combobox", { name: /per page/i });
+    // Simulate an out-of-band value (e.g. programmatic change to an unlisted option)
+    fireEvent.change(perPageSelect, { target: { value: "999" } });
+
+    // Falls back to 10 → still 10 cards on page 1
+    expect(screen.getAllByRole("article")).toHaveLength(10);
   });
 });

--- a/src/pages/Streams.tsx
+++ b/src/pages/Streams.tsx
@@ -43,6 +43,29 @@ type StatusFilter = "All" | StreamStatus;
 const STATUS_FILTERS: StatusFilter[] = ["All", "Active", "Paused", "Completed"];
 const DISCLOSURE_DURATION_MS = 200;
 
+/**
+ * Slices `items` to the active-page window, clamping `page` so it is always
+ * within [1, totalPages].  Both arguments are coerced to safe integers before
+ * use so that NaN or floating-point values from UI events cannot produce an
+ * out-of-bounds array access.
+ *
+ * @param items - The full sorted, filtered array to paginate.
+ * @param page  - 1-based current page number; clamped to [1, totalPages].
+ * @param limit - Maximum items per page; must be ≥ 1 (coerced to at least 1).
+ * @returns `items` for the resolved page, the clamped `safePage`, and `totalPages`.
+ */
+function paginate<T>(
+  items: T[],
+  page: number,
+  limit: number,
+): { items: T[]; safePage: number; totalPages: number } {
+  const safeLimit = Math.max(1, Math.trunc(limit));
+  const totalPages = Math.max(1, Math.ceil(items.length / safeLimit));
+  const safePage = Math.min(Math.max(1, Math.trunc(page)), totalPages);
+  const start = (safePage - 1) * safeLimit;
+  return { items: items.slice(start, start + safeLimit), safePage, totalPages };
+}
+
 function formatUsdc(value: number) {
   return `${new Intl.NumberFormat("en-US", {
     maximumFractionDigits: 0,
@@ -734,6 +757,10 @@ export default function Streams() {
     return () => window.clearTimeout(timer);
   }, [toast]);
 
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [searchQuery, statusFilter, sortBy]);
+
   if (loading) return <StreamsLoading />;
 
   const activeStreams = streamRecords.filter((stream) => stream.status === "Active");
@@ -765,6 +792,12 @@ export default function Streams() {
       // Default to recent (higher ID first for demo)
       return b.id.localeCompare(a.id);
     });
+  const {
+    items: paginatedStreams,
+    safePage,
+    totalPages,
+  } = paginate(visibleStreams, currentPage, itemsPerPage);
+
   const selectedStream = streamId ? getStreamRecord(streamId) : undefined;
   const hasStreams = streamRecords.length > 0;
   const showEmptyState = !selectedStream && (!walletConnected || !hasStreams);
@@ -775,11 +808,11 @@ export default function Streams() {
     hasStreams &&
     withdrawableNow === 0 &&
     activeStreams.length > 0;
-  const effectiveExpandedId = visibleStreams.some(
+  const effectiveExpandedId = paginatedStreams.some(
     (stream) => stream.id === expandedStreamId,
   )
     ? expandedStreamId
-    : visibleStreams[0]?.id;
+    : paginatedStreams[0]?.id;
 
   const handleCreateStream = () => {
     setIsCreateModalOpen(true);
@@ -992,7 +1025,7 @@ export default function Streams() {
 
             <div className="streams-list" role="list" aria-label="Stream cards">
               {visibleStreams.length > 0 ? (
-                visibleStreams.map((stream) => (
+                paginatedStreams.map((stream) => (
                   <StreamCard
                     key={stream.id}
                     stream={stream}
@@ -1021,15 +1054,20 @@ export default function Streams() {
             </div>
 
             <Pagination
-              currentPage={currentPage}
+              currentPage={safePage}
               totalItems={visibleStreams.length}
               itemsPerPage={itemsPerPage}
               onPageChange={(page) => {
-                setCurrentPage(page);
+                const clamped = Math.min(Math.max(1, Math.trunc(page)), totalPages);
+                setCurrentPage(clamped);
                 window.scrollTo({ top: 0, behavior: "smooth" });
               }}
               onItemsPerPageChange={(limit) => {
-                setItemsPerPage(limit);
+                const safeLimitOptions = [10, 25, 50];
+                const safeLimit = safeLimitOptions.includes(Math.trunc(limit))
+                  ? Math.trunc(limit)
+                  : 10;
+                setItemsPerPage(safeLimit);
                 setCurrentPage(1);
               }}
             />


### PR DESCRIPTION
- Add paginate<T>() helper to clamp page/limit and slice the array
- Reset currentPage to 1 when search, filter, or sort changes
- Render paginatedStreams and validate itemsPerPage against allowlist
- Add tests for slicing, clamping, and page reset

Closes #260