### PR TITLE
feat(ui): add ToastProvider queue with info/warning variants and migr…

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import Layout from "./components/Layout";
 import AppNavbar from "./components/navigation/AppNavbar";
 import { WalletProvider } from "./components/wallet-connect/Walletcontext";
+import { ToastProvider } from "./components/toast/ToastProvider";
 import Home from "./pages/Home";
 import Dashboard from "./pages/Dashboard";
 import Streams from "./pages/Streams";
@@ -47,6 +48,7 @@ export default function App() {
   return (
     <BrowserRouter>
       <WalletProvider>
+        <ToastProvider>
         <a href="#main-content" className="skip-link">
           Skip to content
         </a>
@@ -80,6 +82,7 @@ export default function App() {
           <Route path="/connect-wallet" element={<ConnectWallet />} />
           <Route path="*" element={<NotFound />} />
         </Routes>
+      </ToastProvider>
       </WalletProvider>
     </BrowserRouter>
   );

--- a/src/components/ToastNotification.css
+++ b/src/components/ToastNotification.css
@@ -1,8 +1,41 @@
-.toast-notification {
+/* Stack container — ToastProvider renders toasts inside this */
+.toast-stack {
   position: fixed;
   right: 1.5rem;
   bottom: 1.5rem;
   z-index: 1200;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  align-items: flex-end;
+  pointer-events: none;
+}
+
+.toast-stack > * {
+  pointer-events: auto;
+}
+
+.toast-stack__overflow {
+  font: var(--font-label-md, 600 0.75rem/1.2 "Plus Jakarta Sans", sans-serif);
+  color: var(--muted);
+  text-align: right;
+  padding: 0 0.25rem;
+}
+
+@media (max-width: 768px) {
+  .toast-stack {
+    right: 1rem;
+    bottom: 1rem;
+    left: 1rem;
+    align-items: stretch;
+  }
+}
+
+.toast-notification {
+  position: relative;
+  right: auto;
+  bottom: auto;
+  z-index: auto;
   display: grid;
   grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: start;
@@ -28,6 +61,14 @@
   border-color: rgba(255, 77, 79, 0.4);
 }
 
+.toast-notification--info {
+  border-color: rgba(99, 179, 237, 0.4);
+}
+
+.toast-notification--warning {
+  border-color: rgba(246, 173, 85, 0.4);
+}
+
 .toast-notification__icon {
   display: inline-flex;
   align-items: center;
@@ -47,6 +88,16 @@
 .toast-notification--error .toast-notification__icon {
   background: rgba(255, 77, 79, 0.14);
   color: var(--danger);
+}
+
+.toast-notification--info .toast-notification__icon {
+  background: rgba(99, 179, 237, 0.14);
+  color: #63b3ed;
+}
+
+.toast-notification--warning .toast-notification__icon {
+  background: rgba(246, 173, 85, 0.14);
+  color: #f6ad55;
 }
 
 .toast-notification__content {
@@ -112,9 +163,6 @@
 
 @media (max-width: 768px) {
   .toast-notification {
-    right: 1rem;
-    bottom: 1rem;
-    left: 1rem;
     width: auto;
   }
 }

--- a/src/components/ToastNotification.tsx
+++ b/src/components/ToastNotification.tsx
@@ -1,6 +1,6 @@
 import "./ToastNotification.css";
 
-export type ToastVariant = "success" | "error";
+export type ToastVariant = "success" | "error" | "info" | "warning";
 
 interface ToastNotificationProps {
   message: string;
@@ -9,14 +9,10 @@ interface ToastNotificationProps {
 }
 
 const TOAST_COPY: Record<ToastVariant, { label: string; icon: string }> = {
-  success: {
-    label: "Success",
-    icon: "✓",
-  },
-  error: {
-    label: "Error",
-    icon: "!",
-  },
+  success: { label: "Success", icon: "✓" },
+  error: { label: "Error", icon: "!" },
+  info: { label: "Info", icon: "i" },
+  warning: { label: "Warning", icon: "⚠" },
 };
 
 export default function ToastNotification({
@@ -25,15 +21,9 @@ export default function ToastNotification({
   onClose,
 }: ToastNotificationProps) {
   const semantics =
-    variant === "error"
-      ? {
-          role: "alert" as const,
-          "aria-live": "assertive" as const,
-        }
-      : {
-          role: "status" as const,
-          "aria-live": "polite" as const,
-        };
+    variant === "error" || variant === "warning"
+      ? { role: "alert" as const, "aria-live": "assertive" as const }
+      : { role: "status" as const, "aria-live": "polite" as const };
 
   const { label, icon } = TOAST_COPY[variant];
 

--- a/src/components/toast/ToastProvider.tsx
+++ b/src/components/toast/ToastProvider.tsx
@@ -1,0 +1,106 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import ToastNotification from "../ToastNotification";
+import type { ToastVariant } from "../ToastNotification";
+
+export type { ToastVariant };
+
+export interface Toast {
+  id: string;
+  message: string;
+  variant: ToastVariant;
+  timeout: number;
+}
+
+interface ToastContextValue {
+  /** Add a toast to the queue. Returns the generated id. */
+  addToast: (message: string, variant: ToastVariant, timeout?: number) => string;
+  /** Manually dismiss a toast by id. */
+  dismiss: (id: string) => void;
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+const MAX_VISIBLE = 3;
+const DEFAULT_TIMEOUT = 4000;
+
+/**
+ * ToastProvider — wraps the app and manages a stacked toast queue.
+ *
+ * @example
+ * ```tsx
+ * <ToastProvider>
+ *   <App />
+ * </ToastProvider>
+ * ```
+ */
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+  const timers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+
+  const dismiss = useCallback((id: string) => {
+    clearTimeout(timers.current.get(id));
+    timers.current.delete(id);
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  const addToast = useCallback(
+    (message: string, variant: ToastVariant, timeout = DEFAULT_TIMEOUT): string => {
+      const id = `toast-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+      setToasts((prev) => [...prev, { id, message, variant, timeout }]);
+      const timer = setTimeout(() => dismiss(id), timeout);
+      timers.current.set(id, timer);
+      return id;
+    },
+    [dismiss],
+  );
+
+  const visible = toasts.slice(-MAX_VISIBLE);
+  const overflow = toasts.length - MAX_VISIBLE;
+
+  return (
+    <ToastContext.Provider value={{ addToast, dismiss }}>
+      {children}
+      <div className="toast-stack" aria-label="Notifications">
+        {overflow > 0 && (
+          <div className="toast-stack__overflow" aria-live="polite">
+            +{overflow} more notification{overflow > 1 ? "s" : ""}
+          </div>
+        )}
+        {visible.map((toast) => (
+          <ToastNotification
+            key={toast.id}
+            message={toast.message}
+            variant={toast.variant}
+            onClose={() => dismiss(toast.id)}
+          />
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+}
+
+/**
+ * useToast — consume the toast queue from any component inside ToastProvider.
+ *
+ * @example
+ * ```tsx
+ * const { addToast } = useToast();
+ * addToast("Stream created!", "success");
+ * addToast("Something went wrong.", "error");
+ * addToast("Wallet connected.", "info", 3000);
+ * ```
+ */
+export function useToast(): ToastContextValue {
+  const ctx = useContext(ToastContext);
+  if (!ctx) {
+    throw new Error("useToast must be used inside <ToastProvider>");
+  }
+  return ctx;
+}

--- a/src/components/toast/__tests__/ToastProvider.test.tsx
+++ b/src/components/toast/__tests__/ToastProvider.test.tsx
@@ -1,0 +1,230 @@
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ToastProvider, useToast } from "../ToastProvider";
+
+// Helper: a button that adds a toast when clicked
+function AddButton({
+  message = "Hello",
+  variant = "success" as const,
+  timeout,
+}: {
+  message?: string;
+  variant?: "success" | "error" | "info" | "warning";
+  timeout?: number;
+}) {
+  const { addToast } = useToast();
+  return (
+    <button onClick={() => addToast(message, variant, timeout)}>
+      Add {variant}
+    </button>
+  );
+}
+
+function renderWithProvider(ui: React.ReactNode) {
+  return render(<ToastProvider>{ui}</ToastProvider>);
+}
+
+describe("ToastProvider / useToast", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("renders a toast when addToast is called", () => {
+    renderWithProvider(<AddButton />);
+    fireEvent.click(screen.getByRole("button", { name: /add success/i }));
+    expect(screen.getByText("Hello")).toBeInTheDocument();
+  });
+
+  it("auto-dismisses after the default timeout (4000ms)", () => {
+    renderWithProvider(<AddButton />);
+    fireEvent.click(screen.getByRole("button", { name: /add success/i }));
+    expect(screen.getByText("Hello")).toBeInTheDocument();
+
+    act(() => vi.advanceTimersByTime(4000));
+    expect(screen.queryByText("Hello")).not.toBeInTheDocument();
+  });
+
+  it("respects a custom timeout", () => {
+    renderWithProvider(<AddButton timeout={1000} />);
+    fireEvent.click(screen.getByRole("button", { name: /add success/i }));
+
+    act(() => vi.advanceTimersByTime(999));
+    expect(screen.getByText("Hello")).toBeInTheDocument();
+
+    act(() => vi.advanceTimersByTime(1));
+    expect(screen.queryByText("Hello")).not.toBeInTheDocument();
+  });
+
+  it("dismisses on close button click", () => {
+    renderWithProvider(<AddButton />);
+    fireEvent.click(screen.getByRole("button", { name: /add success/i }));
+    const dismiss = screen.getByRole("button", {
+      name: /dismiss success notification/i,
+    });
+    act(() => fireEvent.click(dismiss));
+    expect(screen.queryByText("Hello")).not.toBeInTheDocument();
+  });
+
+  it("stacks multiple toasts", () => {
+    renderWithProvider(
+      <>
+        <AddButton message="First" />
+        <AddButton message="Second" variant="error" />
+      </>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /add success/i }));
+    fireEvent.click(screen.getByRole("button", { name: /add error/i }));
+
+    expect(screen.getByText("First")).toBeInTheDocument();
+    expect(screen.getByText("Second")).toBeInTheDocument();
+  });
+
+  it("dismissing one toast does not cancel others", () => {
+    renderWithProvider(
+      <>
+        <AddButton message="A" timeout={2000} />
+        <AddButton message="B" variant="error" timeout={6000} />
+      </>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /add success/i }));
+    fireEvent.click(screen.getByRole("button", { name: /add error/i }));
+
+    // Dismiss "A" manually
+    const [dismissA] = screen.getAllByRole("button", {
+      name: /dismiss .* notification/i,
+    });
+    act(() => fireEvent.click(dismissA!));
+
+    expect(screen.queryByText("A")).not.toBeInTheDocument();
+    // "B" must still be present
+    expect(screen.getByText("B")).toBeInTheDocument();
+
+    // "B" auto-dismisses after its own timer
+    act(() => vi.advanceTimersByTime(6000));
+    expect(screen.queryByText("B")).not.toBeInTheDocument();
+  });
+
+  it("caps visible toasts at 3 and shows overflow count", () => {
+    function ManyAdder() {
+      const { addToast } = useToast();
+      return (
+        <button
+          onClick={() => {
+            addToast("T1", "success", 99999);
+            addToast("T2", "info", 99999);
+            addToast("T3", "warning", 99999);
+            addToast("T4", "error", 99999);
+          }}
+        >
+          Add 4
+        </button>
+      );
+    }
+    renderWithProvider(<ManyAdder />);
+    fireEvent.click(screen.getByRole("button", { name: /add 4/i }));
+
+    // Only the last 3 are shown (T2, T3, T4)
+    expect(screen.getByText("T2")).toBeInTheDocument();
+    expect(screen.getByText("T3")).toBeInTheDocument();
+    expect(screen.getByText("T4")).toBeInTheDocument();
+    expect(screen.queryByText("T1")).not.toBeInTheDocument();
+    // Overflow indicator
+    expect(screen.getByText(/\+1 more notification/i)).toBeInTheDocument();
+  });
+
+  it("rapid additions don't clobber each other's timers", () => {
+    function RapidAdder() {
+      const { addToast } = useToast();
+      return (
+        <button
+          onClick={() => {
+            for (let i = 1; i <= 3; i++) {
+              addToast(`Msg ${i}`, "info", 2000);
+            }
+          }}
+        >
+          rapid
+        </button>
+      );
+    }
+    renderWithProvider(<RapidAdder />);
+    fireEvent.click(screen.getByRole("button", { name: /rapid/i }));
+
+    expect(screen.getByText("Msg 1")).toBeInTheDocument();
+    expect(screen.getByText("Msg 2")).toBeInTheDocument();
+    expect(screen.getByText("Msg 3")).toBeInTheDocument();
+
+    act(() => vi.advanceTimersByTime(2000));
+    expect(screen.queryByText("Msg 1")).not.toBeInTheDocument();
+    expect(screen.queryByText("Msg 2")).not.toBeInTheDocument();
+    expect(screen.queryByText("Msg 3")).not.toBeInTheDocument();
+  });
+
+  describe("info variant", () => {
+    it("renders with polite aria-live semantics", () => {
+      renderWithProvider(<AddButton variant="info" message="Heads up" />);
+      fireEvent.click(screen.getByRole("button", { name: /add info/i }));
+
+      const toast = screen.getByRole("status");
+      expect(toast).toHaveAttribute("aria-live", "polite");
+      expect(toast).toHaveAttribute("aria-atomic", "true");
+      expect(screen.getByText("Heads up")).toBeInTheDocument();
+      // Label shown
+      expect(screen.getByText("Info")).toBeInTheDocument();
+    });
+  });
+
+  describe("warning variant", () => {
+    it("renders with assertive aria-live semantics", () => {
+      renderWithProvider(<AddButton variant="warning" message="Watch out" />);
+      fireEvent.click(screen.getByRole("button", { name: /add warning/i }));
+
+      const toast = screen.getByRole("alert");
+      expect(toast).toHaveAttribute("aria-live", "assertive");
+      expect(screen.getByText("Watch out")).toBeInTheDocument();
+    });
+  });
+
+  describe("error variant", () => {
+    it("renders with assertive aria-live semantics", () => {
+      renderWithProvider(<AddButton variant="error" message="Oh no" />);
+      fireEvent.click(screen.getByRole("button", { name: /add error/i }));
+
+      const toast = screen.getByRole("alert");
+      expect(toast).toHaveAttribute("aria-live", "assertive");
+    });
+  });
+
+  describe("security", () => {
+    it("renders toast message as text, not HTML", () => {
+      const xss = '<img src=x onerror="alert(1)">';
+      renderWithProvider(<AddButton message={xss} />);
+      fireEvent.click(screen.getByRole("button", { name: /add success/i }));
+
+      const el = screen.getByText(xss);
+      // textContent equals the raw string, meaning it was not parsed as HTML
+      expect(el.textContent).toBe(xss);
+      expect(el.querySelector("img")).toBeNull();
+    });
+  });
+
+  it("throws if useToast is used outside provider", () => {
+    // Suppress console.error for this expected throw
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    function Bad() {
+      useToast();
+      return null;
+    }
+    expect(() => render(<Bad />)).toThrow(
+      "useToast must be used inside <ToastProvider>",
+    );
+    spy.mockRestore();
+  });
+});

--- a/src/pages/Streams.test.tsx
+++ b/src/pages/Streams.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import Streams from "./Streams";
 import { streamRecords } from "../data/streamRecords";
+import { ToastProvider } from "../components/toast/ToastProvider";
 
 type MatchMediaChangeHandler = (event: MediaQueryListEvent) => void;
 
@@ -39,11 +40,13 @@ function mockMatchMedia(matches: boolean) {
 
 function renderStreams() {
   return render(
-    <MemoryRouter initialEntries={["/app/streams"]}>
-      <Routes>
-        <Route path="/app/streams" element={<Streams />} />
-      </Routes>
-    </MemoryRouter>,
+    <ToastProvider>
+      <MemoryRouter initialEntries={["/app/streams"]}>
+        <Routes>
+          <Route path="/app/streams" element={<Streams />} />
+        </Routes>
+      </MemoryRouter>
+    </ToastProvider>,
   );
 }
 

--- a/src/pages/Streams.tsx
+++ b/src/pages/Streams.tsx
@@ -10,9 +10,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import CreateStreamModal from "../components/CreateStreamModal";
 import EmptyState from "../components/EmptyState";
 import StreamCreatedModal from "../components/Streams/StreamCreatedModal";
-import ToastNotification, {
-  type ToastVariant,
-} from "../components/ToastNotification";
+import { useToast } from "../components/toast/ToastProvider";
 import StreamsLoading from "../components/StreamsLoading";
 import Input from "../components/Input";
 import ZeroAccrualBanner from "../components/ZeroAccrualBanner";
@@ -696,6 +694,7 @@ export default function Streams() {
   const navigate = useNavigate();
   const { streamId } = useParams();
   const { announcement, announce } = useLiveAnnouncer();
+  const { addToast } = useToast();
 
   const [loading, setLoading] = useState(true);
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("All");
@@ -711,10 +710,6 @@ export default function Streams() {
     id: "STR-NEW",
     url: "https://fluxora.io/stream/STR-NEW",
   });
-  const [toast, setToast] = useState<{
-    message: string;
-    variant: ToastVariant;
-  } | null>(null);
 
   // Pagination state
   const [currentPage, setCurrentPage] = useState(1);
@@ -726,13 +721,6 @@ export default function Streams() {
     const timer = window.setTimeout(() => setLoading(false), 2000);
     return () => window.clearTimeout(timer);
   }, []);
-
-  useEffect(() => {
-    if (!toast) return undefined;
-
-    const timer = window.setTimeout(() => setToast(null), 4000);
-    return () => window.clearTimeout(timer);
-  }, [toast]);
 
   if (loading) return <StreamsLoading />;
 
@@ -798,16 +786,15 @@ export default function Streams() {
   const handleCopyRecipient = async (stream: StreamRecord) => {
     try {
       await navigator.clipboard.writeText(stream.recipientAddress);
-      setToast({
-        message: `Recipient for ${stream.name} copied to your clipboard.`,
-        variant: "success",
-      });
+      addToast(
+        `Recipient for ${stream.name} copied to your clipboard.`,
+        "success",
+      );
     } catch {
-      setToast({
-        message:
-          "Clipboard access is unavailable in this browser. Copy the address manually instead.",
-        variant: "error",
-      });
+      addToast(
+        "Clipboard access is unavailable in this browser. Copy the address manually instead.",
+        "error",
+      );
     }
   };
 
@@ -1035,14 +1022,6 @@ export default function Streams() {
             />
           </section>
         </>
-      )}
-
-      {toast && (
-        <ToastNotification
-          message={toast.message}
-          variant={toast.variant}
-          onClose={() => setToast(null)}
-        />
       )}
 
       <CreateStreamModal


### PR DESCRIPTION
…ate Streams toasts

closes #263 

## Problem

src/pages/Streams.tsx held a single local toast state object and rendered one ToastNotification at a time. Triggering a second action (e.g. copy address while a stream-created toast was visible) silently overwrote the first notification. ToastNotification.tsx only supported 'success' | 'error', and there was no shared system that other pages (Recipient.tsx) could reuse.

## What was done

### 1. src/components/toast/ToastProvider.tsx (new file) Created a centralized ToastProvider React context component and a useToast() hook. The provider:
- Maintains a queue of Toast objects, each with a unique id, message, variant, and per-toast timeout.
- Schedules an independent setTimeout for every toast; dismissing one toast calls clearTimeout only for that toast's timer, leaving all others intact.
- Caps the visible stack at MAX_VISIBLE=3 and shows a '+N more notifications' overflow indicator above the stack for any additional toasts.
- Renders a .toast-stack positioned container that holds ToastNotification instances stacked bottom-to-top.
- Exposes addToast(message, variant, timeout?) and dismiss(id) via context.
- Throws a clear error when useToast() is called outside the provider.
- Includes full TSDoc on both ToastProvider and useToast.

### 2. src/components/ToastNotification.tsx (modified)
- Extended ToastVariant from 'success' | 'error' to include 'info' and 'warning'.
- Added TOAST_COPY entries for the two new variants (label + icon).
- Updated aria semantics: 'warning' now uses role=alert + aria-live=assertive (same as 'error'); 'info' uses role=status + aria-live=polite.

### 3. src/components/ToastNotification.css (modified)
- Removed fixed positioning from .toast-notification (position, right, bottom, z-index) — the .toast-stack container now owns all positioning.
- Added .toast-stack and .toast-stack__overflow rules with responsive mobile overrides.
- Added .toast-notification--info and .toast-notification--warning border and icon colour tokens.

### 4. src/App.tsx (modified)
- Imported ToastProvider and wrapped the entire app (inside WalletProvider) so every route including Streams and Recipient can call useToast().

### 5. src/pages/Streams.tsx (modified)
- Removed the local toast state object and the associated useEffect auto-dismiss timer (previously lines ~714-731).
- Replaced the ToastNotification import with useToast from the new provider.
- Replaced both setToast() call-sites in handleCopyRecipient with addToast(message, variant) — no local state, no single-toast limit.
- Removed the {toast && <ToastNotification .../>} render block entirely.

### 6. src/pages/Streams.test.tsx (modified)
- Wrapped the renderStreams helper in <ToastProvider> so Streams can call useToast() without throwing during existing disclosure-motion tests.

### 7. src/components/toast/__tests__/ToastProvider.test.tsx (new file) 13 tests covering:
- Toast renders on addToast call.
- Auto-dismiss after default (4000ms) and custom timeout.
- Manual dismiss via close button.
- Multiple toasts stack and co-exist.
- Dismissing one toast does not cancel others' independent timers.
- Overflow cap: 4 toasts added → only last 3 visible, '+1 more' shown.
- Rapid additions all fire and all dismiss at their own timer.
- info variant: role=status, aria-live=polite.
- warning variant: role=alert, aria-live=assertive.
- error variant: role=alert, aria-live=assertive.
- Security: message rendered as text node, not parsed HTML (XSS guard).
- useToast outside provider throws a descriptive error.

## How it was done

The queue is a React state array. addToast appends to it; dismiss filters it. Timer IDs are stored in a useRef<Map<string, ReturnType<typeof setTimeout>>> so they survive re-renders without causing unnecessary effects and each timer remains independently cancellable. useCallback memoises both addToast and dismiss so consumers do not re-render on unrelated state changes.

Security: toast messages are passed as {message} children to a <p> element — React renders them as text nodes. No dangerouslySetInnerHTML is used anywhere in the toast stack, so arbitrary HTML strings are safely escaped.

## Tests passing
All 13 new ToastProvider tests pass. The 2 existing Streams disclosure-motion tests continue to pass after being wrapped in ToastProvider.