### PR TITLE
Add keyboard focus affordance to Breadcrumb links

### DIFF
--- a/src/components/navigation/Breadcrumb.tsx
+++ b/src/components/navigation/Breadcrumb.tsx
@@ -92,6 +92,14 @@ export default function Breadcrumb({ items }: BreadcrumbProps) {
                     (e.currentTarget as HTMLAnchorElement).style.color =
                       "var(--breadcrumb-color)";
                   }}
+                  onFocus={(e) => {
+                    (e.currentTarget as HTMLAnchorElement).style.color =
+                      "var(--breadcrumb-color-hover)";
+                  }}
+                  onBlur={(e) => {
+                    (e.currentTarget as HTMLAnchorElement).style.color =
+                      "var(--breadcrumb-color)";
+                  }}
                   className="breadcrumb-link"
                 >
                   {displayLabel}

--- a/src/components/navigation/__tests__/Breadcrumb.accessibility.test.tsx
+++ b/src/components/navigation/__tests__/Breadcrumb.accessibility.test.tsx
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import Breadcrumb from "../Breadcrumb";
+
+function renderBreadcrumb() {
+  return render(
+    <MemoryRouter>
+      <Breadcrumb
+        items={[
+          { label: "Dashboard", to: "/" },
+          { label: "Streams", to: "/streams" },
+          { label: "Stream ABC123", to: "/streams/abc123" },
+        ]}
+      />
+    </MemoryRouter>
+  );
+}
+
+describe("Breadcrumb accessibility", () => {
+  it("keeps intermediate crumbs as focusable links and marks the current page", () => {
+    renderBreadcrumb();
+
+    const dashboardLink = screen.getByRole("link", { name: "Dashboard" });
+    const streamsLink = screen.getByRole("link", { name: "Streams" });
+    const currentPage = screen.getByText("Stream ABC123");
+
+    expect(dashboardLink).toHaveAttribute("href", "/");
+    expect(streamsLink).toHaveAttribute("href", "/streams");
+    expect(dashboardLink).toHaveClass("breadcrumb-link");
+    expect(streamsLink).toHaveClass("breadcrumb-link");
+    expect(currentPage).toHaveAttribute("aria-current", "page");
+    expect(
+      screen.queryByRole("link", { name: "Stream ABC123" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("mirrors the hover affordance while a breadcrumb link has keyboard focus", () => {
+    renderBreadcrumb();
+
+    const streamsLink = screen.getByRole("link", { name: "Streams" });
+
+    fireEvent.focus(streamsLink);
+    expect(streamsLink).toHaveStyle({
+      color: "var(--breadcrumb-color-hover)",
+    });
+
+    fireEvent.blur(streamsLink);
+    expect(streamsLink).toHaveStyle({ color: "var(--breadcrumb-color)" });
+  });
+
+  it("tabs through only linked breadcrumb items", async () => {
+    const user = userEvent.setup();
+    renderBreadcrumb();
+
+    await user.tab();
+    expect(screen.getByRole("link", { name: "Dashboard" })).toHaveFocus();
+
+    await user.tab();
+    expect(screen.getByRole("link", { name: "Streams" })).toHaveFocus();
+
+    expect(
+      screen.queryByRole("link", { name: "Stream ABC123" })
+    ).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Add keyboard onFocus / onBlur handlers to breadcrumb links so focus mirrors the existing hover color affordance.
- Keep the visible focus ring class-based through the existing readcrumb-link:focus-visible CSS rule.
- Add focused accessibility coverage for linked crumbs, ria-current="page", current-page non-link rendering, and tab order.

Closes #296

## Validation
- 
pm run test -- src/components/navigation/__tests__/Breadcrumb.accessibility.test.tsx passed (3 tests).
- git diff --check -- src/components/navigation/Breadcrumb.tsx src/components/navigation/__tests__/Breadcrumb.accessibility.test.tsx passed.
- Sensitive scan of changed files returned no account/payment/private-key markers.

## Existing upstream failures observed
- 
pm run build is currently blocked by pre-existing TypeScript errors outside this change, including ConnectWalletModal.test.tsx, StreamTimeline.tsx, StatusPill.tsx, StreamRow.tsx, and Streams.tsx.
- Full 
pm run test currently has unrelated failures in ErrorPage.test.tsx and StatusPill.test.tsx; the new focused Breadcrumb test passes.