### PR TITLE
docs: add social metadata to app shell

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,26 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Fluxora is a treasury streaming dashboard for managing continuous capital flows, USDC streams, and recipient withdrawals on Stellar."
+    />
+    <meta name="theme-color" content="#0f172a" />
+    <link rel="canonical" href="https://fluxora.io/" />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Fluxora" />
+    <meta property="og:url" content="https://fluxora.io/" />
+    <meta property="og:title" content="Fluxora — Continuous Capital" />
+    <meta
+      property="og:description"
+      content="Manage treasury streams, recipient withdrawals, and continuous capital flows on Stellar."
+    />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="Fluxora — Continuous Capital" />
+    <meta
+      name="twitter:description"
+      content="Manage treasury streams, recipient withdrawals, and continuous capital flows on Stellar."
+    />
     <title>Fluxora — Continuous Capital</title>
   </head>
   <body>


### PR DESCRIPTION
## Summary
- Adds a static page description for Fluxora's treasury streaming dashboard
- Adds canonical, theme-color, Open Graph, and Twitter Card metadata to the Vite app shell
- Leaves `og:image` out for now because the repository does not include a dedicated social preview asset

Closes #288

## Validation
- `git diff --check -- index.html`
- Confirmed the expected description, canonical, Open Graph, and Twitter Card tags are present in `index.html`

## Existing validation blockers
- `npm run build` currently fails on pre-existing TypeScript errors outside this change, including `StatusPill.tsx` undefined `label`/`Icon`, `StreamTimeline.tsx` unused/nullability errors, and `Streams.tsx` type/prop errors.
- `npm test` currently fails in existing `ErrorPage.test.tsx` and `StatusPill.test.tsx` cases unrelated to this HTML metadata change.