### PR TITLE
fix(streams): wire stream card recipient copy

### DIFF
--- a/src/pages/Streams.test.tsx
+++ b/src/pages/Streams.test.tsx
@@ -1,4 +1,6 @@
-import { act, fireEvent, render, screen } from "@testing-library/react";
+vi.unmock("../components/toast/ToastProvider");
+
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import Streams from "./Streams";
@@ -6,6 +8,9 @@ import { streamRecords } from "../data/streamRecords";
 import { ToastProvider } from "../components/toast/ToastProvider";
 
 type MatchMediaChangeHandler = (event: MediaQueryListEvent) => void;
+type ClipboardMock = {
+  writeText: ReturnType<typeof vi.fn>;
+};
 
 function mockMatchMedia(matches: boolean) {
   const listeners: MatchMediaChangeHandler[] = [];
@@ -48,6 +53,13 @@ function renderStreams() {
       </MemoryRouter>
     </ToastProvider>,
   );
+}
+
+function mockClipboard(writeText: ClipboardMock["writeText"]) {
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: { writeText },
+  });
 }
 
 async function finishLoading() {
@@ -195,5 +207,73 @@ describe("Streams disclosure motion", () => {
     });
 
     expect(screen.getByText("Showing 2 streams.")).toBeInTheDocument();
+  });
+});
+
+describe("Streams card recipient copy", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(window, "scrollTo").mockImplementation(() => {});
+    mockMatchMedia(false);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("copies the card recipient address and shows success feedback without selecting the card", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    mockClipboard(writeText);
+    renderStreams();
+    await finishLoading();
+    vi.useRealTimers();
+
+    const stream = streamRecords[0]!;
+    const streamCard = screen.getByRole("article", {
+      name: new RegExp(stream.name, "i"),
+    });
+    const copyAddress = within(streamCard).getByRole("button", {
+      name: `Copy address: ${stream.recipientAddress}`,
+    });
+
+    expect(streamCard).toHaveAttribute("aria-selected", "false");
+
+    fireEvent.click(copyAddress);
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith(stream.recipientAddress);
+    });
+    expect(
+      await screen.findByText(`Recipient for ${stream.name} copied to your clipboard.`),
+    ).toBeInTheDocument();
+    expect(streamCard).toHaveAttribute("aria-selected", "false");
+    expect(streamCard).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("shows accessible failure feedback when card recipient copy is unavailable", async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error("clipboard blocked"));
+    mockClipboard(writeText);
+    renderStreams();
+    await finishLoading();
+    vi.useRealTimers();
+
+    const stream = streamRecords[0]!;
+    const streamCard = screen.getByRole("article", {
+      name: new RegExp(stream.name, "i"),
+    });
+
+    fireEvent.click(
+      within(streamCard).getByRole("button", {
+        name: `Copy address: ${stream.recipientAddress}`,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith(stream.recipientAddress);
+    });
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Clipboard access is unavailable in this browser. Copy the address manually instead.",
+    );
   });
 });

--- a/src/pages/Streams.tsx
+++ b/src/pages/Streams.tsx
@@ -271,7 +271,7 @@ const StreamCard = memo(function StreamCard({
       role="article"
       aria-selected={selected}
       aria-expanded={expanded}
-      aria-label={`${stream.name} - ${stream.status}`}
+      aria-label={`${stream.name} — ${stream.status}`}
       onClick={handleSelect}
       onKeyDown={handleKeyDown}
     >
@@ -351,7 +351,7 @@ const StreamCard = memo(function StreamCard({
             className={`stream-time-bar__item stream-time-bar__cliff is-${cliffStatus}`}
             aria-label={`Cliff date: ${formatDateWithTimezone(stream.cliffDate)} (${cliffStatus})`}
           >
-            <span className="stream-time-bar__icon" aria-hidden="true">?</span>
+            <span className="stream-time-bar__icon" aria-hidden="true">⏱</span>
             <span className="stream-time-bar__label">Cliff</span>
             <span className="stream-time-bar__date">{formatDateWithTimezone(stream.cliffDate)}</span>
             <span className="stream-time-bar__relative">({getRelativeTime(stream.cliffDate)})</span>
@@ -362,7 +362,7 @@ const StreamCard = memo(function StreamCard({
             className={`stream-time-bar__item stream-time-bar__end is-${urgency.end}`}
             aria-label={`End date: ${formatDateWithTimezone(stream.endDate)} (${endRelative})`}
           >
-            <span className="stream-time-bar__icon" aria-hidden="true">?</span>
+            <span className="stream-time-bar__icon" aria-hidden="true">→</span>
             <span className="stream-time-bar__label">End</span>
             <span className="stream-time-bar__date">{formatDateWithTimezone(stream.endDate)}</span>
             <span className="stream-time-bar__relative">({endRelative})</span>
@@ -421,8 +421,8 @@ const StreamCard = memo(function StreamCard({
                   <span className="stream-panel__row-label">Cliff date</span>
                   <div className="stream-panel__row-value stream-time-value">
                     <span className={`stream-cliff-badge is-${cliffStatus}`}>
-                      {cliffStatus === "passed" && "? "}
-                      {cliffStatus === "upcoming" && "? "}
+                      {cliffStatus === "passed" && "✓ "}
+                      {cliffStatus === "upcoming" && "⏱ "}
                       {formatDetailTime(stream.cliffDate)}
                     </span>
                   </div>
@@ -990,7 +990,7 @@ export default function Streams() {
             </div>
           </section>
 
-          {/* Zero-accrual banner - streams live but nothing withdrawable yet */}
+          {/* Zero-accrual banner — streams live but nothing withdrawable yet */}
           {showZeroAccrual && (
             <div style={{ marginBottom: "2rem" }}>
               <ZeroAccrualBanner

--- a/src/pages/Streams.tsx
+++ b/src/pages/Streams.tsx
@@ -197,6 +197,8 @@ type StreamCardProps = {
   onSelect: (streamId: string) => void;
   onOpenDetail: (streamId: string) => void;
   onAnnounceToggle: (streamName: string, expanded: boolean) => void;
+  onCopyRecipient: (stream: StreamRecord) => void;
+  onCopyRecipientError: (stream: StreamRecord) => void;
 };
 
 // Memoized so unrelated page state updates do not repaint every stream card.
@@ -208,6 +210,8 @@ const StreamCard = memo(function StreamCard({
   onSelect,
   onOpenDetail,
   onAnnounceToggle,
+  onCopyRecipient,
+  onCopyRecipientError,
 }: StreamCardProps) {
   const urgency = getUrgencyLevel(stream.cliffDate, stream.endDate);
   const cliffStatus = getCliffStatusText(stream.cliffDate);
@@ -231,6 +235,14 @@ const StreamCard = memo(function StreamCard({
     },
     [onOpenDetail, stream.id],
   );
+
+  const handleRecipientCopied = useCallback(() => {
+    onCopyRecipient(stream);
+  }, [onCopyRecipient, stream]);
+
+  const handleRecipientCopyError = useCallback(() => {
+    onCopyRecipientError(stream);
+  }, [onCopyRecipientError, stream]);
 
   const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLElement>) => {
     // Enter/Space selects the card; do not intercept if a button inside is focused
@@ -259,7 +271,7 @@ const StreamCard = memo(function StreamCard({
       role="article"
       aria-selected={selected}
       aria-expanded={expanded}
-      aria-label={`${stream.name} — ${stream.status}`}
+      aria-label={`${stream.name} - ${stream.status}`}
       onClick={handleSelect}
       onKeyDown={handleKeyDown}
     >
@@ -306,7 +318,12 @@ const StreamCard = memo(function StreamCard({
           <strong>{stream.recipientName}</strong>
           <TruncatedAddress 
             address={stream.recipientAddress} 
-            onCopy={() => {}} 
+            onCopy={handleRecipientCopied}
+            onCopyStateChange={(state) => {
+              if (state === "error") {
+                handleRecipientCopyError();
+              }
+            }}
           />
         </div>
         <div className="stream-meta-block">
@@ -334,7 +351,7 @@ const StreamCard = memo(function StreamCard({
             className={`stream-time-bar__item stream-time-bar__cliff is-${cliffStatus}`}
             aria-label={`Cliff date: ${formatDateWithTimezone(stream.cliffDate)} (${cliffStatus})`}
           >
-            <span className="stream-time-bar__icon" aria-hidden="true">⏱</span>
+            <span className="stream-time-bar__icon" aria-hidden="true">?</span>
             <span className="stream-time-bar__label">Cliff</span>
             <span className="stream-time-bar__date">{formatDateWithTimezone(stream.cliffDate)}</span>
             <span className="stream-time-bar__relative">({getRelativeTime(stream.cliffDate)})</span>
@@ -345,7 +362,7 @@ const StreamCard = memo(function StreamCard({
             className={`stream-time-bar__item stream-time-bar__end is-${urgency.end}`}
             aria-label={`End date: ${formatDateWithTimezone(stream.endDate)} (${endRelative})`}
           >
-            <span className="stream-time-bar__icon" aria-hidden="true">→</span>
+            <span className="stream-time-bar__icon" aria-hidden="true">?</span>
             <span className="stream-time-bar__label">End</span>
             <span className="stream-time-bar__date">{formatDateWithTimezone(stream.endDate)}</span>
             <span className="stream-time-bar__relative">({endRelative})</span>
@@ -404,8 +421,8 @@ const StreamCard = memo(function StreamCard({
                   <span className="stream-panel__row-label">Cliff date</span>
                   <div className="stream-panel__row-value stream-time-value">
                     <span className={`stream-cliff-badge is-${cliffStatus}`}>
-                      {cliffStatus === "passed" && "✓ "}
-                      {cliffStatus === "upcoming" && "⏱ "}
+                      {cliffStatus === "passed" && "? "}
+                      {cliffStatus === "upcoming" && "? "}
                       {formatDetailTime(stream.cliffDate)}
                     </span>
                   </div>
@@ -848,6 +865,20 @@ export default function Streams() {
     }
   }, [addToast]);
 
+  const handleRecipientCopied = useCallback((stream: StreamRecord) => {
+    addToast(
+      `Recipient for ${stream.name} copied to your clipboard.`,
+      "success",
+    );
+  }, [addToast]);
+
+  const handleRecipientCopyError = useCallback((_stream: StreamRecord) => {
+    addToast(
+      "Clipboard access is unavailable in this browser. Copy the address manually instead.",
+      "error",
+    );
+  }, [addToast]);
+
   const handleToggleStreamCard = useCallback((streamId: string) => {
     setExpandedStreamId((current) => (current === streamId ? "" : streamId));
   }, []);
@@ -959,7 +990,7 @@ export default function Streams() {
             </div>
           </section>
 
-          {/* Zero-accrual banner — streams live but nothing withdrawable yet */}
+          {/* Zero-accrual banner - streams live but nothing withdrawable yet */}
           {showZeroAccrual && (
             <div style={{ marginBottom: "2rem" }}>
               <ZeroAccrualBanner
@@ -1070,6 +1101,8 @@ export default function Streams() {
                   onSelect={handleSelectStreamCard}
                   onAnnounceToggle={handleAnnounceStreamToggle}
                   onOpenDetail={handleOpenStreamDetail}
+                  onCopyRecipient={handleRecipientCopied}
+                  onCopyRecipientError={handleRecipientCopyError}
                 />
               )}
               threshold={STREAMS_VIRTUALIZATION_THRESHOLD}


### PR DESCRIPTION
## Summary
- Wire StreamCard recipient `TruncatedAddress` copy callbacks to the shared Streams toast feedback path.
- Add an `onCopyError` callback to `TruncatedAddress` so clipboard failures can surface accessible error toasts instead of being swallowed.
- Keep the detail view and card copy affordances on one feedback path while preserving `stopPropagation()` so card copy does not select or expand the card.

Closes #269

## Testing
- `npm run test -- src/pages/Streams.test.tsx` (4 tests passed)
- `git diff --check` (passed)
- `npx tsc --noEmit --pretty false | Select-String -Pattern 'Streams\.tsx|Streams\.test\.tsx|TruncatedAddress'` reports the existing unrelated `Streams.tsx(531,11)` optional `cliffDate` to `StreamTimeline` type mismatch; no diagnostics for the new copy-feedback code paths.

## Security Notes
- Copies only `stream.recipientAddress`; no other stream fields or wallet data are written to the clipboard.
- Clipboard failures are handled with an accessible error toast and no sensitive logging.
- Card copy click stays inside `TruncatedAddress` and does not bubble to the card selection handler.