### PR TITLE
fix(newsletter): validate email and block duplicate submits

### DIFF
--- a/src/components/NewsletterSection.tsx
+++ b/src/components/NewsletterSection.tsx
@@ -1,27 +1,59 @@
 import { FormEvent, useState } from "react";
 
+const EMAIL_PATTERN =
+  /^[A-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?(?:\.[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?)+$/i;
+
+export function normalizeNewsletterEmail(value: string) {
+  return value.trim().toLowerCase();
+}
+
+export function isValidNewsletterEmail(value: string) {
+  const normalized = normalizeNewsletterEmail(value);
+
+  if (normalized.length > 254 || normalized.includes("..")) {
+    return false;
+  }
+
+  const [localPart, domain] = normalized.split("@");
+  if (
+    !localPart ||
+    !domain ||
+    localPart.length > 64 ||
+    localPart.startsWith(".") ||
+    localPart.endsWith(".")
+  ) {
+    return false;
+  }
+
+  return EMAIL_PATTERN.test(normalized);
+}
+
 export default function NewsletterSection() {
   const [email, setEmail] = useState("");
   const [error, setError] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [success, setSuccess] = useState(false);
 
-  const validateEmail = (value: string) => {
-    return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
-  };
-
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
 
-    if (!validateEmail(email)) {
+    if (submitting) {
+      return;
+    }
+
+    const normalizedEmail = normalizeNewsletterEmail(email);
+
+    if (!isValidNewsletterEmail(normalizedEmail)) {
       setError("Please enter a valid email address.");
+      setSuccess(false);
       return;
     }
 
     setError("");
+    setSuccess(false);
     setSubmitting(true);
 
-    // 🔹 Replace with real newsletter endpoint later
+    // Replace with a real newsletter endpoint when the backend is available.
     await new Promise((resolve) => setTimeout(resolve, 1000));
 
     setSubmitting(false);
@@ -51,9 +83,21 @@ export default function NewsletterSection() {
             type="email"
             placeholder="Enter your email"
             value={email}
-            onChange={(e) => setEmail(e.target.value)}
+            onChange={(e) => {
+              setEmail(e.target.value);
+              setError("");
+              setSuccess(false);
+            }}
             style={styles.input}
             aria-invalid={!!error}
+            aria-describedby={
+              error
+                ? "newsletter-error"
+                : success
+                  ? "newsletter-success"
+                  : undefined
+            }
+            disabled={submitting}
           />
 
           <button
@@ -69,9 +113,20 @@ export default function NewsletterSection() {
           </button>
         </form>
 
-        {error && <p style={styles.error}>{error}</p>}
+        {error && (
+          <p id="newsletter-error" role="alert" style={styles.error}>
+            {error}
+          </p>
+        )}
         {success && (
-          <p style={styles.success}>Thanks for subscribing!</p>
+          <p
+            id="newsletter-success"
+            role="status"
+            aria-live="polite"
+            style={styles.success}
+          >
+            Thanks for subscribing!
+          </p>
         )}
       </div>
     </section>

--- a/src/components/__tests__/NewsletterSection.test.tsx
+++ b/src/components/__tests__/NewsletterSection.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import NewsletterSection, {
+  isValidNewsletterEmail,
+  normalizeNewsletterEmail,
+} from "../NewsletterSection";
+
+describe("newsletter email helpers", () => {
+  it("normalizes surrounding whitespace and casing", () => {
+    expect(normalizeNewsletterEmail("  User@Example.COM  ")).toBe(
+      "user@example.com",
+    );
+  });
+
+  it("accepts ordinary valid email addresses", () => {
+    expect(isValidNewsletterEmail("user@example.com")).toBe(true);
+    expect(isValidNewsletterEmail("first.last+news@sub.example.co")).toBe(true);
+  });
+
+  it("rejects malformed addresses that the old loose pattern allowed", () => {
+    expect(isValidNewsletterEmail("user@example..com")).toBe(false);
+    expect(isValidNewsletterEmail(".user@example.com")).toBe(false);
+    expect(isValidNewsletterEmail("user@-example.com")).toBe(false);
+    expect(isValidNewsletterEmail("user@example")).toBe(false);
+  });
+});
+
+describe("NewsletterSection", () => {
+  it("shows an accessible validation error for invalid email", async () => {
+    const user = userEvent.setup();
+    render(<NewsletterSection />);
+
+    await user.type(screen.getByLabelText("Email address"), "bad@example");
+    await user.click(screen.getByRole("button", { name: "Subscribe" }));
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Please enter a valid email address.",
+    );
+    expect(screen.getByLabelText("Email address")).toHaveAttribute(
+      "aria-invalid",
+      "true",
+    );
+  });
+
+  it("prevents duplicate submits while the request is in flight", async () => {
+    const user = userEvent.setup();
+    render(<NewsletterSection />);
+
+    const email = screen.getByLabelText("Email address");
+    const button = screen.getByRole("button", { name: "Subscribe" });
+
+    await user.type(email, "user@example.com");
+    await user.dblClick(button);
+
+    expect(button).toBeDisabled();
+    expect(email).toBeDisabled();
+    expect(button).toHaveTextContent("Subscribing...");
+
+    await waitFor(() =>
+      expect(screen.getByRole("status")).toHaveTextContent(
+        "Thanks for subscribing!",
+      ),
+    );
+    expect(button).toBeEnabled();
+    expect(email).toBeEnabled();
+    expect(email).toHaveValue("");
+  });
+
+  it("clears stale success and error feedback when the email changes", async () => {
+    const user = userEvent.setup();
+    render(<NewsletterSection />);
+
+    const email = screen.getByLabelText("Email address");
+
+    await user.type(email, "user@example.com");
+    await user.click(screen.getByRole("button", { name: "Subscribe" }));
+
+    expect(await screen.findByRole("status")).toHaveTextContent(
+      "Thanks for subscribing!",
+    );
+
+    await user.type(email, "next");
+
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #287.

## Summary
- add normalized newsletter email validation that rejects malformed domains, double dots, leading/trailing local-part dots, and overlong addresses
- guard the submit handler against duplicate in-flight submits
- disable the email input and submit button while subscribing
- clear stale success/error feedback when the email changes
- expose accessible alert/status feedback with `aria-describedby`

## Verification
- `npx vitest run src/components/__tests__/NewsletterSection.test.tsx` - passed (6 tests)
- `npx tsc --noEmit --pretty false 2>&1 | Select-String -Pattern 'NewsletterSection'` - no matching errors
- `git diff --check` - passed