### PR TITLE
feat(treasury): implement typed useTreasury hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,17 @@ Create a `.env` (or `.env.local`) when you add API or Stellar config, for exampl
 - `VITE_API_URL` — Backend API base URL
 - `VITE_NETWORK` — Stellar network (testnet / mainnet)
 
+## Treasury overview data
+
+`src/components/treasuryOverviewPage/useTreasury.ts` is the single client-side
+entry point for treasury overview metrics and streams. The exported hook returns
+typed `metrics`, `streams`, `loading`, `error`, and `refetch` state so overview
+components do not import demo fixtures directly.
+
+Until a backend treasury API is available, the default data source returns empty
+arrays. Demo data is intentionally gated behind `VITE_TREASURY_DEMO_DATA` so
+mocked balances are not rendered accidentally in production builds.
+
 ## Related repos
 
 - **fluxora-backend** — API and streaming engine

--- a/src/components/treasuryOverviewPage/Metrics.tsx
+++ b/src/components/treasuryOverviewPage/Metrics.tsx
@@ -1,16 +1,71 @@
 import MetricCard from "./MetricCard";
-import { metricsData } from "./sample-streams.tsx";
-import { Metric } from "./Metric";
+import type { Metric } from "./Metric";
+import { useTreasury } from "./useTreasury";
 
-export default function Metrics() {
+interface MetricsProps {
+  metrics: Metric[];
+  loading: boolean;
+  error: string | null;
+  onRetry: () => void;
+}
+
+export function MetricsContent({
+  metrics,
+  loading,
+  error,
+  onRetry,
+}: MetricsProps) {
+  if (loading) {
+    return (
+      <section
+        aria-label="Treasury metrics"
+        aria-busy="true"
+        className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6 items-stretch"
+      >
+        <p className="text-sm text-gray-500">Loading treasury metrics...</p>
+      </section>
+    );
+  }
+
+  if (error) {
+    return (
+      <section
+        aria-label="Treasury metrics"
+        className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6 items-stretch"
+      >
+        <div role="alert" className="text-sm text-red-600">
+          <p>{error}</p>
+          <button type="button" onClick={onRetry} className="mt-2 text-teal-600">
+            Retry
+          </button>
+        </div>
+      </section>
+    );
+  }
+
   return (
     <section
       aria-label="Treasury metrics"
       className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6 items-stretch"
     >
-      {metricsData.map((m: Metric, i: number) => (
-        <MetricCard key={i} {...m} />
-      ))}
+      {metrics.length > 0 ? (
+        metrics.map((m: Metric) => <MetricCard key={m.label} {...m} />)
+      ) : (
+        <p className="text-sm text-gray-500">No treasury metrics available.</p>
+      )}
     </section>
+  );
+}
+
+export default function Metrics() {
+  const treasury = useTreasury();
+
+  return (
+    <MetricsContent
+      metrics={treasury.metrics}
+      loading={treasury.loading}
+      error={treasury.error}
+      onRetry={treasury.refetch}
+    />
   );
 }

--- a/src/components/treasuryOverviewPage/RecentStreams.tsx
+++ b/src/components/treasuryOverviewPage/RecentStreams.tsx
@@ -1,7 +1,21 @@
 import { useNavigate } from "react-router-dom";
 import StreamsTable from "./StreamsTable";
+import type { Stream } from "./Stream";
+import { useTreasury } from "./useTreasury";
 
-export default function RecentStreams() {
+interface RecentStreamsProps {
+  streams: Stream[];
+  loading: boolean;
+  error: string | null;
+  onRetry: () => void;
+}
+
+export function RecentStreamsContent({
+  streams,
+  loading,
+  error,
+  onRetry,
+}: RecentStreamsProps) {
   const navigate = useNavigate();
 
   return (
@@ -16,7 +30,33 @@ export default function RecentStreams() {
         </button>
       </div>
 
-      <StreamsTable />
+      {loading ? (
+        <p aria-busy="true" className="text-sm text-gray-500">
+          Loading recent streams...
+        </p>
+      ) : error ? (
+        <div role="alert" className="text-sm text-red-600">
+          <p>{error}</p>
+          <button type="button" onClick={onRetry} className="mt-2 text-teal-600">
+            Retry
+          </button>
+        </div>
+      ) : (
+        <StreamsTable streams={streams} />
+      )}
     </div>
+  );
+}
+
+export default function RecentStreams() {
+  const treasury = useTreasury();
+
+  return (
+    <RecentStreamsContent
+      streams={treasury.streams}
+      loading={treasury.loading}
+      error={treasury.error}
+      onRetry={treasury.refetch}
+    />
   );
 }

--- a/src/components/treasuryOverviewPage/StatusPill.tsx
+++ b/src/components/treasuryOverviewPage/StatusPill.tsx
@@ -6,27 +6,21 @@ import {
   Heart,
   AlertTriangle,
   XCircle,
+  type LucideIcon,
 } from "lucide-react";
 
 type ExtendedStatus = StreamStatus | "Healthy" | "At-Risk" | "Critical";
 
 interface Props {
-  status: StreamStatus;
+  status: ExtendedStatus;
   /** Icon size */
-  iconSize?: 'xs' | 'sm' | 'md' | 'lg';
+  iconSize?: "xs" | "sm" | "md" | "lg";
 }
 
-interface Props {
-  status: StreamStatus;
-  /** Icon size */
-  iconSize?: 'xs' | 'sm' | 'md' | 'lg';
-}
-
-interface Props {
-  status: StreamStatus;
-}
-
-const statusStyles: Record<ExtendedStatus, { background: string; color: string; Icon: any; label: string }> = {
+const statusStyles: Record<
+  ExtendedStatus,
+  { background: string; color: string; Icon: LucideIcon; label: string }
+> = {
   Active: {
     background: "var(--status-success-bg)",
     color: "var(--status-success)",
@@ -65,8 +59,8 @@ const statusStyles: Record<ExtendedStatus, { background: string; color: string; 
   },
 };
 
-export default function StatusPill({ status, iconSize = 'xs' }: Props) {
-  const { background, color } = statusStyles[status];
+export default function StatusPill({ status, iconSize = "xs" }: Props) {
+  const { background, color, Icon, label } = statusStyles[status];
 
   return (
     <span

--- a/src/components/treasuryOverviewPage/StreamRow.tsx
+++ b/src/components/treasuryOverviewPage/StreamRow.tsx
@@ -30,17 +30,25 @@ export default function StreamRow({ stream, isSelected = false, onSelect }: Prop
 
   return (
     <tr
+      tabIndex={0}
+      aria-selected={isSelected}
       style={{
         borderBottom: "1px solid var(--color-border-default)",
-        backgroundColor: "var(--color-surface-default)",
+        backgroundColor: isSelected
+          ? "var(--color-surface-elevated)"
+          : "var(--color-surface-default)",
         transition:
           "background-color var(--motion-duration-stream-disclosure) var(--motion-ease-stream-disclosure)",
       }}
+      onClick={handleActivate}
+      onKeyDown={handleKeyDown}
       onMouseEnter={(e) => {
         e.currentTarget.style.backgroundColor = "var(--color-surface-elevated)";
       }}
       onMouseLeave={(e) => {
-        e.currentTarget.style.backgroundColor = "var(--color-surface-default)";
+        e.currentTarget.style.backgroundColor = isSelected
+          ? "var(--color-surface-elevated)"
+          : "var(--color-surface-default)";
       }}
     >
       <td className="py-4 px-3">
@@ -79,7 +87,10 @@ export default function StreamRow({ stream, isSelected = false, onSelect }: Prop
       <td className="stream-row__cell py-4 px-3">
         <button
           type="button"
-          onClick={() => navigate(`/app/streams/${stream.id}`)}
+          onClick={(event) => {
+            event.stopPropagation();
+            navigate(`/app/streams/${stream.id}`);
+          }}
           aria-label={`View details for ${stream.name}`}
           className="font-medium flex items-center gap-1"
           style={{

--- a/src/components/treasuryOverviewPage/StreamsTable.tsx
+++ b/src/components/treasuryOverviewPage/StreamsTable.tsx
@@ -1,9 +1,12 @@
 import { useRef, useState } from "react";
-import { streams } from "./sample-streams.tsx";
 import StreamRow from "./StreamRow";
-import { Stream } from "./Stream";
+import type { Stream } from "./Stream";
 
-export default function StreamsTable() {
+interface StreamsTableProps {
+  streams: Stream[];
+}
+
+export default function StreamsTable({ streams }: StreamsTableProps) {
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const tbodyRef = useRef<HTMLTableSectionElement>(null);
 
@@ -64,16 +67,24 @@ export default function StreamsTable() {
         </thead>
 
         <tbody ref={tbodyRef} onKeyDown={handleKeyDown}>
-          {streams.map((s: Stream) => (
-            <StreamRow
-              key={s.id}
-              stream={s}
-              isSelected={selectedId === s.id}
-              onSelect={(id) =>
-                setSelectedId((prev) => (prev === id ? null : id))
-              }
-            />
-          ))}
+          {streams.length > 0 ? (
+            streams.map((s: Stream) => (
+              <StreamRow
+                key={s.id}
+                stream={s}
+                isSelected={selectedId === s.id}
+                onSelect={(id) =>
+                  setSelectedId((prev) => (prev === id ? null : id))
+                }
+              />
+            ))
+          ) : (
+            <tr>
+              <td colSpan={5} className="py-4 px-3 text-gray-500">
+                No recent streams available.
+              </td>
+            </tr>
+          )}
         </tbody>
       </table>
     </div>

--- a/src/components/treasuryOverviewPage/__tests__/MetricsContent.test.tsx
+++ b/src/components/treasuryOverviewPage/__tests__/MetricsContent.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import type { Metric } from "../Metric";
+import { MetricsContent } from "../Metrics";
+
+const metric: Metric = {
+  icon: "icon",
+  label: "Active Streams",
+  value: "3",
+  desc: "streams currently accruing",
+};
+
+describe("MetricsContent", () => {
+  it("renders a loading state while treasury metrics load", () => {
+    render(
+      <MetricsContent
+        metrics={[]}
+        loading
+        error={null}
+        onRetry={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByLabelText(/treasury metrics/i)).toHaveAttribute(
+      "aria-busy",
+      "true",
+    );
+    expect(screen.getByText(/loading treasury metrics/i)).toBeInTheDocument();
+  });
+
+  it("renders an error state with retry action", async () => {
+    const user = userEvent.setup();
+    const onRetry = vi.fn();
+
+    render(
+      <MetricsContent
+        metrics={[]}
+        loading={false}
+        error="Unable to load treasury overview data."
+        onRetry={onRetry}
+      />,
+    );
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      /unable to load treasury overview data/i,
+    );
+
+    await user.click(screen.getByRole("button", { name: /retry/i }));
+
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders metric cards when data is available", () => {
+    render(
+      <MetricsContent
+        metrics={[metric]}
+        loading={false}
+        error={null}
+        onRetry={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("group", { name: /active streams/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
+  it("renders an empty state when no metrics are returned", () => {
+    render(
+      <MetricsContent
+        metrics={[]}
+        loading={false}
+        error={null}
+        onRetry={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(/no treasury metrics available/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/treasuryOverviewPage/__tests__/RecentStreamsContent.test.tsx
+++ b/src/components/treasuryOverviewPage/__tests__/RecentStreamsContent.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+import type { ComponentProps } from "react";
+import type { Stream } from "../Stream";
+import { RecentStreamsContent } from "../RecentStreams";
+
+vi.mock("../StatusPill", () => ({
+  default: ({ status }: { status: string }) => (
+    <span role="status">{status}</span>
+  ),
+}));
+
+const stream: Stream = {
+  name: "Dev Grant",
+  id: "STR-TEST",
+  recipient: "GABC...TEST",
+  rate: "10 USDC/mo",
+  status: "Active",
+};
+
+function renderRecentStreams(
+  props: ComponentProps<typeof RecentStreamsContent>,
+) {
+  return render(
+    <MemoryRouter>
+      <RecentStreamsContent {...props} />
+    </MemoryRouter>,
+  );
+}
+
+describe("RecentStreamsContent", () => {
+  it("renders a loading state while recent streams load", () => {
+    renderRecentStreams({
+      streams: [],
+      loading: true,
+      error: null,
+      onRetry: vi.fn(),
+    });
+
+    expect(screen.getByText(/loading recent streams/i)).toHaveAttribute(
+      "aria-busy",
+      "true",
+    );
+  });
+
+  it("renders an error state with retry action", async () => {
+    const user = userEvent.setup();
+    const onRetry = vi.fn();
+
+    renderRecentStreams({
+      streams: [],
+      loading: false,
+      error: "Unable to load treasury overview data.",
+      onRetry,
+    });
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      /unable to load treasury overview data/i,
+    );
+
+    await user.click(screen.getByRole("button", { name: /retry/i }));
+
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders streams from hook data", () => {
+    renderRecentStreams({
+      streams: [stream],
+      loading: false,
+      error: null,
+      onRetry: vi.fn(),
+    });
+
+    expect(
+      screen.getByRole("grid", { name: /active streams/i }),
+    ).toHaveAttribute("aria-rowcount", "1");
+    expect(screen.getByText("Dev Grant")).toBeInTheDocument();
+  });
+
+  it("renders an empty table state when no streams are returned", () => {
+    renderRecentStreams({
+      streams: [],
+      loading: false,
+      error: null,
+      onRetry: vi.fn(),
+    });
+
+    expect(screen.getByText(/no recent streams available/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/treasuryOverviewPage/__tests__/useTreasury.test.tsx
+++ b/src/components/treasuryOverviewPage/__tests__/useTreasury.test.tsx
@@ -1,0 +1,114 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { Metric } from "../Metric";
+import type { Stream } from "../Stream";
+import type { TreasuryDataSource } from "../useTreasury";
+import {
+  getMetrics,
+  getStreams,
+  isTreasuryDemoDataEnabled,
+  useTreasury,
+} from "../useTreasury";
+
+const metric: Metric = {
+  icon: "icon",
+  label: "Active Streams",
+  value: "1",
+  desc: "stream currently accruing",
+};
+
+const stream: Stream = {
+  name: "Dev Grant",
+  id: "STR-TEST",
+  recipient: "GABC...TEST",
+  rate: "10 USDC/mo",
+  status: "Active",
+};
+
+function dataSource(overrides: Partial<TreasuryDataSource> = {}): TreasuryDataSource {
+  return {
+    getMetrics: vi.fn().mockResolvedValue([metric]),
+    getStreams: vi.fn().mockResolvedValue([stream]),
+    ...overrides,
+  };
+}
+
+describe("useTreasury", () => {
+  it("loads typed metrics and streams on mount", async () => {
+    const source = dataSource();
+    const { result } = renderHook(() => useTreasury(source));
+
+    expect(result.current.loading).toBe(true);
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.metrics).toEqual([metric]);
+    expect(result.current.streams).toEqual([stream]);
+    expect(source.getMetrics).toHaveBeenCalledTimes(1);
+    expect(source.getStreams).toHaveBeenCalledTimes(1);
+  });
+
+  it("sets an error and clears stale data when loading fails", async () => {
+    const source = dataSource({
+      getMetrics: vi.fn().mockRejectedValue(new Error("network down")),
+    });
+
+    const { result } = renderHook(() => useTreasury(source));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.metrics).toEqual([]);
+    expect(result.current.streams).toEqual([]);
+    expect(result.current.error).toBe("Unable to load treasury overview data.");
+  });
+
+  it("supports empty treasury data without treating it as an error", async () => {
+    const source = dataSource({
+      getMetrics: vi.fn().mockResolvedValue([]),
+      getStreams: vi.fn().mockResolvedValue([]),
+    });
+
+    const { result } = renderHook(() => useTreasury(source));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.metrics).toEqual([]);
+    expect(result.current.streams).toEqual([]);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("refetch resets an error and reloads treasury data", async () => {
+    const source = dataSource({
+      getMetrics: vi
+        .fn()
+        .mockRejectedValueOnce(new Error("first call fails"))
+        .mockResolvedValueOnce([metric]),
+      getStreams: vi.fn().mockResolvedValue([stream]),
+    });
+
+    const { result } = renderHook(() => useTreasury(source));
+
+    await waitFor(() =>
+      expect(result.current.error).toBe("Unable to load treasury overview data."),
+    );
+
+    await act(async () => {
+      await result.current.refetch();
+    });
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.metrics).toEqual([metric]);
+    expect(result.current.streams).toEqual([stream]);
+  });
+});
+
+describe("treasury demo data source", () => {
+  it("keeps sample data behind an explicit environment flag", async () => {
+    expect(isTreasuryDemoDataEnabled("true")).toBe(true);
+    expect(isTreasuryDemoDataEnabled("1")).toBe(true);
+    expect(isTreasuryDemoDataEnabled("false")).toBe(false);
+    expect(await getMetrics()).toEqual([]);
+    expect(await getStreams()).toEqual([]);
+  });
+});

--- a/src/components/treasuryOverviewPage/useTreasury.ts
+++ b/src/components/treasuryOverviewPage/useTreasury.ts
@@ -1,11 +1,112 @@
-export function useTreasury() {
-  async function getMetrics() {
-    // TODO: API call
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { Metric } from "./Metric";
+import type { Stream } from "./Stream";
+import { metricsData, streams } from "./sample-streams.tsx";
+
+export type TreasuryMetric = Metric;
+export type TreasuryStream = Stream;
+
+export interface TreasuryDataSource {
+  getMetrics: () => Promise<TreasuryMetric[]>;
+  getStreams: () => Promise<TreasuryStream[]>;
+}
+
+export interface TreasuryState extends TreasuryDataSource {
+  metrics: TreasuryMetric[];
+  streams: TreasuryStream[];
+  loading: boolean;
+  error: string | null;
+  refetch: () => Promise<void>;
+}
+
+const TREASURY_DATA_ERROR = "Unable to load treasury overview data.";
+
+export function isTreasuryDemoDataEnabled(
+  value = import.meta.env.VITE_TREASURY_DEMO_DATA,
+) {
+  return value === "true" || value === "1";
+}
+
+export async function getMetrics(): Promise<TreasuryMetric[]> {
+  if (!isTreasuryDemoDataEnabled()) {
+    return [];
   }
 
-  async function getStreams() {
-    // TODO: API call
+  return metricsData.map((metric) => ({ ...metric }));
+}
+
+export async function getStreams(): Promise<TreasuryStream[]> {
+  if (!isTreasuryDemoDataEnabled()) {
+    return [];
   }
 
-  return { getMetrics, getStreams };
+  return streams.map((stream) => ({ ...stream }));
+}
+
+const DEFAULT_TREASURY_DATA_SOURCE: TreasuryDataSource = {
+  getMetrics,
+  getStreams,
+};
+
+/**
+ * Loads typed treasury overview data and exposes UI-safe loading, error, and
+ * refresh state for the dashboard cards and recent stream table.
+ */
+export function useTreasury(
+  dataSource: TreasuryDataSource = DEFAULT_TREASURY_DATA_SOURCE,
+): TreasuryState {
+  const [metrics, setMetrics] = useState<TreasuryMetric[]>([]);
+  const [treasuryStreams, setTreasuryStreams] = useState<TreasuryStream[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const requestIdRef = useRef(0);
+
+  const refetch = useCallback(async () => {
+    const requestId = requestIdRef.current + 1;
+    requestIdRef.current = requestId;
+    setLoading(true);
+    setError(null);
+
+    try {
+      const [nextMetrics, nextStreams] = await Promise.all([
+        dataSource.getMetrics(),
+        dataSource.getStreams(),
+      ]);
+
+      if (requestIdRef.current !== requestId) {
+        return;
+      }
+
+      setMetrics(nextMetrics);
+      setTreasuryStreams(nextStreams);
+      setLoading(false);
+    } catch {
+      if (requestIdRef.current !== requestId) {
+        return;
+      }
+
+      setMetrics([]);
+      setTreasuryStreams([]);
+      setError(TREASURY_DATA_ERROR);
+      setLoading(false);
+    }
+  }, [dataSource]);
+
+  useEffect(() => {
+    void refetch();
+
+    return () => {
+      requestIdRef.current += 1;
+    };
+  }, [refetch]);
+
+  return {
+    metrics,
+    streams: treasuryStreams,
+    loading,
+    error,
+    refetch,
+    getMetrics: dataSource.getMetrics,
+    getStreams: dataSource.getStreams,
+  };
 }

--- a/src/pages/TreasuryPage.tsx
+++ b/src/pages/TreasuryPage.tsx
@@ -1,15 +1,28 @@
 import DemoBanner from "../components/treasuryOverviewPage/DemoBanner";
 import Header from "../components/treasuryOverviewPage/Header"
-import Metrics from "../components/treasuryOverviewPage/Metrics"; 
-import RecentStreams from "../components/treasuryOverviewPage/RecentStreams";
+import { MetricsContent } from "../components/treasuryOverviewPage/Metrics";
+import { RecentStreamsContent } from "../components/treasuryOverviewPage/RecentStreams";
+import { useTreasury } from "../components/treasuryOverviewPage/useTreasury";
 
 export default function TreasuryPage() {
+  const treasury = useTreasury();
+
   return (
     <div className="p-6 flex flex-col gap-8 bg-gray-50 min-h-screen">
       <DemoBanner />
       <Header />
-      <Metrics />
-      <RecentStreams />
+      <MetricsContent
+        metrics={treasury.metrics}
+        loading={treasury.loading}
+        error={treasury.error}
+        onRetry={treasury.refetch}
+      />
+      <RecentStreamsContent
+        streams={treasury.streams}
+        loading={treasury.loading}
+        error={treasury.error}
+        onRetry={treasury.refetch}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- implement a typed `useTreasury()` hook that returns metrics, streams, loading, error, and refetch state
- route TreasuryPage, Metrics, RecentStreams, and StreamsTable through the hook data surface instead of direct fixture imports
- keep bundled demo treasury data behind `VITE_TREASURY_DEMO_DATA` and document the data boundary
- fix existing treasury row/status wiring needed for the overview table to typecheck cleanly

## Tests
- `npx vitest run src/components/treasuryOverviewPage/__tests__/useTreasury.test.tsx src/components/treasuryOverviewPage/__tests__/MetricsContent.test.tsx src/components/treasuryOverviewPage/__tests__/RecentStreamsContent.test.tsx src/components/treasuryOverviewPage/MetricCard.test.tsx src/components/treasuryOverviewPage/StatusPill.test.tsx`
- `git diff --check`
- filtered `npx tsc --noEmit --pretty false` output for `useTreasury`, treasury overview components, and `TreasuryPage` returned no matching errors

## Security notes
- The hook defaults to empty typed data until a backend treasury API is available.
- Demo balances/streams render only when `VITE_TREASURY_DEMO_DATA` is explicitly set to `true` or `1`.
- No raw external payloads are logged or rendered by this change.

Closes #272