### PR TITLE
feat(i18n): add typed message catalog

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -50,8 +50,11 @@ export default tseslint.config(
           allowExportNames: [
             "applyTheme",
             "initTheme",
+            "I18nProvider",
             "isTheme",
             "resolveInitialTheme",
+            "sanitizeDepositAmountInput",
+            "useI18n",
             "useTheme",
             "useToast",
             "useWallet",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { WalletProvider } from "./components/wallet-connect/Walletcontext";
 import { ToastProvider } from "./components/toast/ToastProvider";
 import ErrorBoundary from "./components/ErrorBoundary";
 import RequireWallet from "./components/RequireWallet";
+import { I18nProvider } from "./i18n";
 import Home from "./pages/Home";
 import ConnectWallet from "./pages/ConnectWallet";
 import ErrorPage from "./pages/ErrorPage";
@@ -90,16 +91,17 @@ export default function App() {
 
   return (
     <ThemeProvider>
-      <BrowserRouter>
-        <WalletProvider>
-          <ToastProvider>
-            <a href="#main-content" className="skip-link">
-              Skip to content
-            </a>
-            <AppNavbar
-              onSidebarToggle={handleSidebarToggle}
-              isSidebarOpen={isSidebarOpen}
-            />
+      <I18nProvider>
+        <BrowserRouter>
+          <WalletProvider>
+            <ToastProvider>
+              <a href="#main-content" className="skip-link">
+                Skip to content
+              </a>
+              <AppNavbar
+                onSidebarToggle={handleSidebarToggle}
+                isSidebarOpen={isSidebarOpen}
+              />
 
             <ErrorBoundary>
               <Routes>
@@ -130,10 +132,11 @@ export default function App() {
                 <Route path="/connect-wallet" element={<ConnectWallet />} />
                 <Route path="*" element={<NotFound />} />
               </Routes>
-            </ErrorBoundary>
-          </ToastProvider>
-        </WalletProvider>
-      </BrowserRouter>
+              </ErrorBoundary>
+            </ToastProvider>
+          </WalletProvider>
+        </BrowserRouter>
+      </I18nProvider>
     </ThemeProvider>
   );
 }

--- a/src/components/CreateStreamModal.tsx
+++ b/src/components/CreateStreamModal.tsx
@@ -14,6 +14,7 @@ import {
   isBeforeLocalDateTime,
   isDateTimeInPast,
 } from '../lib/createStreamDates';
+import { useI18n, type PluralFunction, type TFunction } from '../i18n';
 
 const USDC_DECIMAL_PLACES = 7;
 
@@ -65,33 +66,43 @@ function formatReviewDeposit(value: string): string {
 }
 
 /** Formats the daily duration unit with singular/plural copy. */
-function formatDurationUnit(value: string): string {
-  return parseStreamNumber(value) === 1 ? "day" : "days";
+function formatDurationUnit(value: string, plural: PluralFunction): string {
+  return plural(parseStreamNumber(value), {
+    one: "createStream.units.day.one",
+    other: "createStream.units.day.other",
+  });
 }
 
-function validateAccrualRate(value: string): string | undefined {
+function validateAccrualRate(
+  value: string,
+  t: TFunction,
+): string | undefined {
   const numericValue = parseFloat(value);
 
   if (!value.trim() || isNaN(numericValue) || numericValue <= 0) {
-    return 'Stream rate must be a positive number.';
+    return t("createStream.validation.ratePositive");
   }
 
   if (numericValue > MAX_ACCRUAL_RATE) {
-    return `Stream rate must be ${MAX_ACCRUAL_RATE.toLocaleString()} USDC/day or less.`;
+    return t("createStream.validation.rateMax", {
+      maxRate: MAX_ACCRUAL_RATE.toLocaleString(),
+    });
   }
 
   return undefined;
 }
 
-function validateDuration(value: string): string | undefined {
+function validateDuration(value: string, t: TFunction): string | undefined {
   const numericValue = parseFloat(value);
 
   if (!value.trim() || isNaN(numericValue) || numericValue <= 0) {
-    return 'Duration must be a positive number.';
+    return t("createStream.validation.durationPositive");
   }
 
   if (numericValue > MAX_DURATION_DAYS) {
-    return `Duration must be ${MAX_DURATION_DAYS.toLocaleString()} days or less.`;
+    return t("createStream.validation.durationMax", {
+      maxDays: MAX_DURATION_DAYS.toLocaleString(),
+    });
   }
 
   return undefined;
@@ -114,6 +125,7 @@ export default function CreateStreamModal({
 }: CreateStreamModalProps) {
   const wallet = useWallet();
   const { addToast } = useToast();
+  const { plural, t } = useI18n();
 
   const [recipient, setRecipient] = useState("");
   const [depositAmount, setDepositAmount] = useState("");
@@ -153,14 +165,14 @@ export default function CreateStreamModal({
   const isBusyCreating = isSubmitting || isConfirmationPending;
   const submitButtonLabel =
     currentStep === 3 && isSubmitting
-      ? "Submitting..."
+      ? t("createStream.buttons.submitting")
       : currentStep === 3 && isConfirmationPending
-        ? "Confirming..."
+        ? t("createStream.buttons.confirming")
         : currentStep === 3 && transactionStatus.status === "failed"
-          ? "Retry create stream"
+          ? t("createStream.buttons.retryCreate")
           : currentStep === 2
-            ? "Next"
-            : "Create stream";
+            ? t("common.next")
+            : t("createStream.buttons.create");
 
   useModalAccessibility({
     isOpen,
@@ -178,7 +190,7 @@ export default function CreateStreamModal({
     }
 
     setHasCompletedConfirmation(true);
-    addToast("Stream created successfully on-chain!", "success");
+    addToast(t("createStream.toast.created"), "success");
     onStreamCreated?.();
     onClose();
   }, [
@@ -186,6 +198,7 @@ export default function CreateStreamModal({
     hasCompletedConfirmation,
     onClose,
     onStreamCreated,
+    t,
     transactionStatus.status,
   ]);
 
@@ -197,18 +210,16 @@ export default function CreateStreamModal({
 
   const validateStep1 = (): boolean => {
     if (!recipient.trim()) {
-      setError("Recipient is required.");
+      setError(t("createStream.validation.recipientRequired"));
       return false;
     }
     if (!isValidStellarAddress(recipient.trim())) {
-      setError(
-        "Please enter a valid Stellar address (starts with G, 56 characters).",
-      );
+      setError(t("createStream.validation.invalidRecipient"));
       return false;
     }
     const amount = parseFloat(depositAmount.replace(/,/g, ""));
     if (!depositAmount.trim() || isNaN(amount) || amount <= 0) {
-      setError("Deposit amount must be a positive number.");
+      setError(t("createStream.validation.depositPositive"));
       return false;
     }
     setError(null);
@@ -229,10 +240,10 @@ export default function CreateStreamModal({
     }
     setTouched(prev => ({ ...prev, ...touchedFields }));
 
-    if (validateAccrualRate(accrualRate)) {
+    if (validateAccrualRate(accrualRate, t)) {
       return false;
     }
-    if (validateDuration(duration)) {
+    if (validateDuration(duration, t)) {
       return false;
     }
     if (
@@ -275,7 +286,7 @@ export default function CreateStreamModal({
     if (err instanceof Error && err.message.trim()) {
       return err.message;
     }
-    return "Stream creation failed. Please try again.";
+    return t("createStream.validation.streamCreationFallback");
   };
 
   const handleNext = async () => {
@@ -295,11 +306,14 @@ export default function CreateStreamModal({
       if (submitInFlightRef.current) return;
 
       if (!wallet.connected) {
-        setError("Please connect your wallet first.");
+        setError(t("createStream.validation.walletRequired"));
         return;
       }
       if (wallet.isNetworkMismatch) {
-        setError(`Wrong Stellar network. Expected ${wallet.expectedNetwork}, but wallet is connected to ${wallet.network?.toUpperCase()}. Please switch network in Freighter.`);
+        setError(t("createStream.validation.wrongNetwork", {
+          expectedNetwork: wallet.expectedNetwork,
+          walletNetwork: wallet.network?.toUpperCase(),
+        }));
         return;
       }
 
@@ -330,7 +344,7 @@ export default function CreateStreamModal({
           end,
         );
         if (!response.txHash) {
-          throw new Error("Missing transaction hash from Stellar RPC.");
+          throw new Error(t("createStream.validation.missingTransactionHash"));
         }
         // Hand off to the confirmation poller; the success toast,
         // onStreamCreated, and onClose fire once polling reports `confirmed`.
@@ -338,7 +352,7 @@ export default function CreateStreamModal({
       } catch (err) {
         const message = getStreamErrorMessage(err);
         setStreamError(message);
-        addToast(`Failed to create stream: ${message}`, "error");
+        addToast(t("createStream.toast.createFailed", { message }), "error");
         onStreamError?.(err);
       } finally {
         submitInFlightRef.current = false;
@@ -386,10 +400,9 @@ export default function CreateStreamModal({
       >
         <div className="modal-header">
           <div>
-            <h2 id="create-stream-title">Create stream</h2>
+            <h2 id="create-stream-title">{t("createStream.title")}</h2>
             <p id="create-stream-description" className="modal-description">
-              Set the recipient, funding, and schedule details for a new Stellar
-              stream.
+              {t("createStream.description")}
             </p>
           </div>
           <button
@@ -397,7 +410,7 @@ export default function CreateStreamModal({
             className="close-button"
             onClick={handleClose}
             disabled={isBusyCreating}
-            aria-label="Close create stream modal"
+            aria-label={t("createStream.closeAria")}
           >
             <svg
               width="24"
@@ -433,7 +446,9 @@ export default function CreateStreamModal({
                 <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
               </svg>
             ) : '1'}</div>
-            <div className="step-label">Recipient &<br />amount</div>
+            <div className="step-label">
+              {t("createStream.steps.recipientAmount")}
+            </div>
           </div>
           <div className={`step-item ${currentStep === 2 ? 'active' : currentStep > 2 ? 'completed' : ''}`}>
             <div className="step-circle">{currentStep > 2 ? (
@@ -441,11 +456,15 @@ export default function CreateStreamModal({
                 <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
               </svg>
             ) : '2'}</div>
-            <div className="step-label">Rate &<br />schedule</div>
+            <div className="step-label">
+              {t("createStream.steps.rateSchedule")}
+            </div>
           </div>
           <div className={`step-item ${currentStep === 3 ? 'active' : ''}`}>
             <div className="step-circle">3</div>
-            <div className="step-label">Review &<br />create</div>
+            <div className="step-label">
+              {t("createStream.steps.reviewCreate")}
+            </div>
           </div>
         </div>
 
@@ -464,16 +483,16 @@ export default function CreateStreamModal({
           <>
             <hr className="divider" />
             <div className="section-header">
-              <h3>Recipient & amount</h3>
-              <p>Set who receives the stream and how much USDC to lock.</p>
+              <h3>{t("createStream.step1.heading")}</h3>
+              <p>{t("createStream.step1.summary")}</p>
             </div>
             {(() => {
               // Derived per-field validation state (not stored, computed inline)
               const recipientError = touched.recipient
                 ? (!recipient.trim()
-                    ? 'Recipient is required.'
+                    ? t("createStream.validation.recipientRequired")
                     : !isValidStellarAddress(recipient.trim())
-                    ? 'Please enter a valid Stellar address (starts with G, 56 characters).'
+                    ? t("createStream.validation.invalidRecipient")
                     : undefined)
                 : undefined;
               const recipientSuccess = touched.recipient && !recipientError && recipient.trim().length > 0;
@@ -481,7 +500,7 @@ export default function CreateStreamModal({
               const depositAmountNum = parseFloat(depositAmount.replace(/,/g, ''));
               const depositError = touched.depositAmount
                 ? (!depositAmount.trim() || isNaN(depositAmountNum) || depositAmountNum <= 0
-                    ? 'Deposit amount must be a positive number.'
+                    ? t("createStream.validation.depositPositive")
                     : undefined)
                 : undefined;
               const depositSuccess = touched.depositAmount && !depositError && depositAmount.trim().length > 0;
@@ -490,10 +509,10 @@ export default function CreateStreamModal({
                 <>
                   <InputField
                     id="create-stream-recipient"
-                    label="Recipient"
+                    label={t("createStream.step1.recipientLabel")}
                     required
                     error={recipientError}
-                    helperText="Enter a valid Stellar address (starts with G, 56 characters)"
+                    helperText={t("createStream.step1.recipientHelper")}
                     success={recipientSuccess}
                   >
                     <input
@@ -506,17 +525,17 @@ export default function CreateStreamModal({
                         if (error) setError(null);
                       }}
                       onBlur={() => handleBlur('recipient')}
-                      placeholder="Paste Stellar address (G...)"
+                      placeholder={t("createStream.step1.recipientPlaceholder")}
                       autoComplete="off"
                     />
                   </InputField>
 
                   <InputField
                     id="create-stream-deposit"
-                    label="Deposit amount"
+                    label={t("createStream.step1.depositLabel")}
                     required
                     error={depositError}
-                    helperText="Enter the total USDC amount to deposit into the stream"
+                    helperText={t("createStream.step1.depositHelper")}
                     success={depositSuccess}
                   >
                     <input
@@ -530,16 +549,18 @@ export default function CreateStreamModal({
                         if (error) setError(null);
                       }}
                       onBlur={() => handleBlur('depositAmount')}
-                      placeholder="$ 0.00 USDC"
+                      placeholder={t("createStream.step1.depositPlaceholder")}
                     />
                   </InputField>
                 </>
               );
             })()}
             <div className="info-box" role="region" aria-labelledby="info-box-title">
-              <div id="info-box-title" className="info-box-title">Smart contract lock:</div>
+              <div id="info-box-title" className="info-box-title">
+                {t("createStream.step1.infoTitle")}
+              </div>
               <p className="info-box-text">
-                Your USDC will be locked in a Soroban smart contract. The recipient can withdraw their accrued portion at any time.
+                {t("createStream.step1.infoText")}
               </p>
             </div>
           </>
@@ -547,31 +568,31 @@ export default function CreateStreamModal({
         {currentStep === 2 && (() => {
           // Derived per-field validation state for step 2
           const accrualRateError = touched.accrualRate
-            ? validateAccrualRate(accrualRate)
+            ? validateAccrualRate(accrualRate, t)
             : undefined;
           const accrualRateSuccess = touched.accrualRate && !accrualRateError && accrualRate.trim().length > 0;
 
           const durationError = touched.duration
-            ? validateDuration(duration)
+            ? validateDuration(duration, t)
             : undefined;
           const durationSuccess = touched.duration && !durationError && duration.trim().length > 0;
 
           const customStartDateError = (startTimeOption === 'custom' && touched.customStartDate)
             ? (!customStartDate
-                ? 'Custom start date is required.'
+                ? t("createStream.validation.customStartRequired")
                 : isDateTimeInPast(customStartDate)
-                ? 'Start date must be in the future.'
+                ? t("createStream.validation.startPast")
                 : undefined)
             : undefined;
           const customStartDateSuccess = startTimeOption === 'custom' && touched.customStartDate && !customStartDateError && Boolean(customStartDate);
 
           const cliffDateError = (cliffEnabled && touched.cliffDate)
             ? (!cliffDate
-                ? 'Cliff date is required.'
+                ? t("createStream.validation.cliffDateRequired")
                 : isDateTimeInPast(cliffDate)
-                ? 'Cliff date must not be in the past.'
+                ? t("createStream.validation.cliffPast")
                 : (startTimeOption === 'custom' && customStartDate && isBeforeLocalDateTime(cliffDate, customStartDate))
-                ? 'Cliff date must be on or after the start date.'
+                ? t("createStream.validation.cliffAfterStart")
                 : undefined)
             : undefined;
           const cliffDateSuccess = cliffEnabled && touched.cliffDate && !cliffDateError && Boolean(cliffDate);
@@ -581,32 +602,29 @@ export default function CreateStreamModal({
             <hr className="divider" />
 
             <div className="section-header">
-              <h3>Rate & schedule</h3>
-              <p>Configure how fast USDC streams and when it starts.</p>
+              <h3>{t("createStream.step2.heading")}</h3>
+              <p>{t("createStream.step2.summary")}</p>
               <p className="text-xs text-[var(--text-muted)]">
-                Start and cliff times use your local timezone.
+                {t("createStream.step2.localTimezone")}
               </p>
             </div>
 
             {/* Stream Rate */}
             <div className="form-group">
               <label htmlFor="create-stream-accrual-rate" className="form-label">
-                Stream rate
+                {t("createStream.step2.rateLabel")}
                 {<span className="required" aria-hidden="true"> *</span>}
                 <InfoTooltip
                   id="stream-rate-tooltip"
-                  title="How is stream rate calculated?"
-                  ariaLabel="Learn more about stream rate calculation"
+                  title={t("createStream.step2.rateTooltipTitle")}
+                  ariaLabel={t("createStream.step2.rateTooltipAria")}
                   content={
                     <>
                       <p>
-                        The stream rate is the amount of USDC that accrues to the 
-                        recipient per day. For example, a rate of 38.62 USDC/day 
-                        means the recipient can withdraw approximately 270 USDC 
-                        after 7 days.
+                        {t("createStream.step2.rateTooltipText")}
                       </p>
                       <p style={{ marginTop: '8px', fontWeight: 500 }}>
-                        Formula: Total Deposit ÷ Duration = Stream Rate
+                        {t("createStream.step2.rateFormula")}
                       </p>
                     </>
                   }
@@ -640,7 +658,7 @@ export default function CreateStreamModal({
               )}
               {!accrualRateError && (
                 <span id="create-stream-accrual-rate-hint" className="validation-message validation-message--hint" role="status">
-                  How much USDC the recipient earns per day
+                  {t("createStream.step2.rateHelper")}
                 </span>
               )}
             </div>
@@ -648,23 +666,19 @@ export default function CreateStreamModal({
             {/* Stream Duration */}
             <div className="form-group">
               <label htmlFor="create-stream-duration" className="form-label">
-                Stream duration
+                {t("createStream.step2.durationLabel")}
                 {<span className="required" aria-hidden="true"> *</span>}
                 <InfoTooltip
                   id="stream-duration-tooltip"
-                  title="Understanding stream duration"
-                  ariaLabel="Learn more about stream duration"
+                  title={t("createStream.step2.durationTooltipTitle")}
+                  ariaLabel={t("createStream.step2.durationTooltipAria")}
                   content={
                     <>
                       <p>
-                        The duration defines the total length of the stream in days.
-                        After this period ends, the full deposit amount will have 
-                        been streamed to the recipient.
+                        {t("createStream.step2.durationTooltipText")}
                       </p>
                       <p style={{ marginTop: '8px' }}>
-                        Example: A 7-day stream transfers funds continuously over 
-                        one week. The recipient can withdraw at any time during 
-                        this period.
+                        {t("createStream.step2.durationExample")}
                       </p>
                     </>
                   }
@@ -673,7 +687,7 @@ export default function CreateStreamModal({
               <div className={`input-container ${durationError ? 'input-container--error' : durationSuccess ? 'input-container--success' : ''}`.trim()}>
                 <InputWithUnit
                   id="create-stream-duration"
-                  unit="days"
+                  unit={t("createStream.units.days")}
                   type="text"
                   inputMode="decimal"
                   value={duration}
@@ -698,36 +712,36 @@ export default function CreateStreamModal({
               )}
               {!durationError && (
                 <span id="create-stream-duration-hint" className="validation-message validation-message--hint" role="status">
-                  How many days the stream will run before ending
+                  {t("createStream.step2.durationHelper")}
                 </span>
               )}
             </div>
 
             {/* Start Time */}
             <div className="form-group">
-              <label className="form-label">Start time</label>
+              <label className="form-label">{t("createStream.step2.startTime")}</label>
               <div className="segmented-control">
                 <button
                   className={`segment-btn ${startTimeOption === 'now' ? 'active' : ''}`}
                   onClick={() => setStartTimeOption('now')}
                 >
-                  Start now
+                  {t("createStream.step2.startNow")}
                 </button>
                 <button
                   className={`segment-btn ${startTimeOption === 'custom' ? 'active' : ''}`}
                   onClick={() => setStartTimeOption('custom')}
                 >
-                  Custom date
+                  {t("createStream.step2.customDate")}
                 </button>
               </div>
               {startTimeOption === 'custom' && (
                 <div style={{ marginTop: '0.75rem' }}>
                   <InputField
                     id="create-stream-custom-start-date"
-                    label="Custom start date"
+                    label={t("createStream.step2.customStartLabel")}
                     required
                     error={customStartDateError}
-                    helperText="When the stream begins accruing USDC"
+                    helperText={t("createStream.step2.customStartHelper")}
                     success={customStartDateSuccess}
                   >
                     <input
@@ -745,30 +759,30 @@ export default function CreateStreamModal({
             {/* Cliff Period */}
             <div className="form-group">
               <label className="form-label">
-                Cliff period{' '}
-                <span style={{ color: 'var(--muted)', fontWeight: 'normal' }}>(optional)</span>
+                {t("createStream.step2.cliffLabel")}{' '}
+                <span style={{ color: 'var(--muted)', fontWeight: 'normal' }}>
+                  {t("createStream.step2.cliffOptional")}
+                </span>
                 <InfoTooltip
                   id="cliff-tooltip"
-                  title="What is a cliff?"
-                  ariaLabel="Learn more about cliff periods"
+                  title={t("createStream.step2.cliffTooltipTitle")}
+                  ariaLabel={t("createStream.step2.cliffTooltipAria")}
                   content={
                     <>
                       <p>
-                        A cliff is a vesting lockup period. During the cliff:
+                        {t("createStream.step2.cliffIntro")}
                       </p>
                       <ul style={{ marginTop: '4px', marginLeft: '16px', listStyle: 'disc' }}>
-                        <li>USDC continues to accrue normally</li>
-                        <li>The recipient CANNOT withdraw any funds</li>
-                        <li>After the cliff date, all accrued funds become withdrawable</li>
+                        <li>{t("createStream.step2.cliffItemAccrues")}</li>
+                        <li>{t("createStream.step2.cliffItemLocked")}</li>
+                        <li>{t("createStream.step2.cliffItemUnlocks")}</li>
                       </ul>
                       <p style={{ marginTop: '8px' }}>
-                        <strong>Common use case:</strong> Employee compensation where vesting 
-                        "cliff" prevents withdrawal for the first 3-6 months, 
-                        ensuring commitment before funds are accessible.
+                        <strong>{t("createStream.step2.cliffCommonUseLabel")}</strong>{" "}
+                        {t("createStream.step2.cliffCommonUseText")}
                       </p>
                       <p style={{ marginTop: '8px' }}>
-                        Example: 1-year stream with 3-month cliff = No withdrawals 
-                        for 3 months, then all accrued USDC becomes available.
+                        {t("createStream.step2.cliffExample")}
                       </p>
                     </>
                   }
@@ -778,16 +792,16 @@ export default function CreateStreamModal({
                 <div className={`toggle-switch ${cliffEnabled ? 'on' : ''}`}>
                   <div className="toggle-knob" />
                 </div>
-                <span>Enable cliff (vesting lockup until specific date)</span>
+                <span>{t("createStream.step2.cliffToggle")}</span>
               </div>
               {cliffEnabled && (
                 <div style={{ marginTop: '0.75rem' }}>
                   <InputField
                     id="create-stream-cliff-date"
-                    label="Cliff date"
+                    label={t("createStream.step2.cliffDateLabel")}
                     required
                     error={cliffDateError}
-                    helperText="The recipient cannot withdraw until this date, even though USDC accrues"
+                    helperText={t("createStream.step2.cliffDateHelper")}
                     success={cliffDateSuccess}
                   >
                     <input
@@ -805,13 +819,13 @@ export default function CreateStreamModal({
             {/* Deposit Summary */}
             <div className="deposit-summary">
               <div className="deposit-box">
-                <div className="deposit-label">Required deposit</div>
+                <div className="deposit-label">{t("createStream.step2.requiredDeposit")}</div>
                 <div className={`deposit-value ${parseFloat(requiredDeposit) > userDeposit ? 'required' : ''}`}>
                   {requiredDeposit} USDC
                 </div>
               </div>
               <div className="deposit-box">
-                <div className="deposit-label">Your deposit</div>
+                <div className="deposit-label">{t("createStream.step2.yourDeposit")}</div>
                 <div className="deposit-value">{userDeposit.toFixed(2)} USDC</div>
               </div>
             </div>
@@ -823,7 +837,7 @@ export default function CreateStreamModal({
             (() => {
               const reviewRecipient = recipient.trim();
               const reviewDeposit = formatReviewDeposit(depositAmount);
-              const durationUnit = formatDurationUnit(duration);
+              const durationUnit = formatDurationUnit(duration, plural);
               return (
                 <>
                   <hr className="divider" />
@@ -847,7 +861,7 @@ export default function CreateStreamModal({
                             />
                           </svg>
                         </span>
-                        <div className="review-card-title">Recipient</div>
+                        <div className="review-card-title">{t("createStream.review.recipient")}</div>
                         <button
                           type="button"
                           className="review-card-edit"
@@ -856,9 +870,9 @@ export default function CreateStreamModal({
                             setCurrentStep(1);
                           }}
                           disabled={isBusyCreating}
-                          aria-label="Edit recipient"
+                          aria-label={t("createStream.review.editRecipientAria")}
                         >
-                          Edit
+                          {t("common.edit")}
                           <svg
                             width="14"
                             height="14"
@@ -877,7 +891,7 @@ export default function CreateStreamModal({
                         </button>
                       </div>
                       <div className="review-card-content">
-                        <div className="review-card-sublabel">Address</div>
+                        <div className="review-card-sublabel">{t("createStream.review.address")}</div>
                         <div className="review-card-value">
                           {maskAddress(reviewRecipient)}
                         </div>
@@ -903,7 +917,7 @@ export default function CreateStreamModal({
                             />
                           </svg>
                         </span>
-                        <div className="review-card-title">Deposit</div>
+                        <div className="review-card-title">{t("createStream.review.deposit")}</div>
                         <button
                           type="button"
                           className="review-card-edit"
@@ -912,9 +926,9 @@ export default function CreateStreamModal({
                             setCurrentStep(1);
                           }}
                           disabled={isBusyCreating}
-                          aria-label="Edit deposit"
+                          aria-label={t("createStream.review.editDepositAria")}
                         >
-                          Edit
+                          {t("common.edit")}
                           <svg
                             width="14"
                             height="14"
@@ -959,7 +973,7 @@ export default function CreateStreamModal({
                             />
                           </svg>
                         </span>
-                        <div className="review-card-title">Rate & schedule</div>
+                        <div className="review-card-title">{t("createStream.review.rateSchedule")}</div>
                         <button
                           type="button"
                           className="review-card-edit"
@@ -968,9 +982,9 @@ export default function CreateStreamModal({
                             setCurrentStep(2);
                           }}
                           disabled={isBusyCreating}
-                          aria-label="Edit rate and schedule"
+                          aria-label={t("createStream.review.editRateScheduleAria")}
                         >
-                          Edit
+                          {t("common.edit")}
                           <svg
                             width="14"
                             height="14"
@@ -1009,9 +1023,11 @@ export default function CreateStreamModal({
                               />
                             </svg>
                           </span>
-                          <span className="review-card-row-label">Rate</span>
+                          <span className="review-card-row-label">{t("createStream.review.rate")}</span>
                           <span className="review-card-row-value">
-                            {accrualRate} USDC per day
+                            {t("createStream.review.rateValue", {
+                              rate: accrualRate,
+                            })}
                           </span>
                         </div>
                         <div className="review-card-row">
@@ -1035,7 +1051,7 @@ export default function CreateStreamModal({
                             </svg>
                           </span>
                           <span className="review-card-row-label">
-                            Duration
+                            {t("createStream.review.duration")}
                           </span>
                           <span className="review-card-row-value">
                             {duration} {durationUnit}
@@ -1061,10 +1077,10 @@ export default function CreateStreamModal({
                               />
                             </svg>
                           </span>
-                          <span className="review-card-row-label">Start</span>
+                          <span className="review-card-row-label">{t("createStream.review.start")}</span>
                           <span className="review-card-row-value">
                             {startTimeOption === "now"
-                              ? "Immediately"
+                              ? t("createStream.review.startImmediately")
                               : customStartDate
                                 ? formatLocalDateTime(customStartDate)
                                 : "—"}
@@ -1087,11 +1103,11 @@ export default function CreateStreamModal({
                               <path strokeLinecap="round" d="M12 6v6" />
                             </svg>
                           </span>
-                          <span className="review-card-row-label">Cliff</span>
+                          <span className="review-card-row-label">{t("createStream.review.cliff")}</span>
                           <span className="review-card-row-value">
                             {cliffEnabled && cliffDate
                               ? formatLocalDateTime(cliffDate)
-                              : "Not set"}
+                              : t("common.notSet")}
                           </span>
                         </div>
                       </div>
@@ -1101,7 +1117,7 @@ export default function CreateStreamModal({
                   {streamError && (
                     <div className="review-error-box" role="alert">
                       <div>
-                        <strong>Stream creation failed.</strong>
+                        <strong>{t("createStream.review.failedTitle")}</strong>
                         <p>{streamError}</p>
                       </div>
                       <button
@@ -1110,7 +1126,7 @@ export default function CreateStreamModal({
                         onClick={handleNext}
                         disabled={isSubmitting}
                       >
-                        Try again
+                        {t("createStream.review.tryAgain")}
                       </button>
                     </div>
                   )}
@@ -1120,10 +1136,10 @@ export default function CreateStreamModal({
                     role="region"
                     aria-live="polite"
                   >
-                    <strong>By creating this stream:</strong> {reviewDeposit} USDC
-                    will be locked in a Soroban smart contract. The recipient
-                    can withdraw their accrued amount at any time during the
-                    stream.
+                    <strong>{t("createStream.review.warningPrefix")}</strong>{" "}
+                    {t("createStream.review.warningBody", {
+                      amount: reviewDeposit,
+                    })}
                   </div>
                   {isSubmitting && (
                     <div
@@ -1131,7 +1147,7 @@ export default function CreateStreamModal({
                       role="status"
                       aria-live="polite"
                     >
-                      Submitting transaction to Stellar. Keep this window open.
+                      {t("createStream.review.submitStatus")}
                     </div>
                   )}
                   {!isSubmitting && transactionStatus.status === "pending" && (
@@ -1140,12 +1156,15 @@ export default function CreateStreamModal({
                       role="status"
                       aria-live="polite"
                     >
-                      Waiting for Stellar confirmation before opening the
-                      success receipt.
+                      {t("createStream.review.waitingForConfirmation")}
                       <span className="transaction-status-detail">
-                        Confirmation check {transactionStatus.attempts}
+                        {t("createStream.review.confirmationCheck", {
+                          attempts: transactionStatus.attempts,
+                        })}
                         {submittedTxHash
-                          ? ` - tx ${submittedTxHash.slice(0, 10)}...${submittedTxHash.slice(-8)}`
+                          ? ` - ${t("createStream.review.confirmationTx", {
+                              txHash: `${submittedTxHash.slice(0, 10)}...${submittedTxHash.slice(-8)}`,
+                            })}`
                           : ""}
                       </span>
                     </div>
@@ -1156,7 +1175,7 @@ export default function CreateStreamModal({
                       role="alert"
                     >
                       {transactionStatus.error ??
-                        "Transaction confirmation failed. Please retry."}
+                        t("createStream.validation.transactionConfirmationFailed")}
                     </div>
                   )}
                 </>
@@ -1174,7 +1193,7 @@ export default function CreateStreamModal({
                 onClick={handleCancel}
                 disabled={isBusyCreating}
               >
-                Cancel
+                {t("common.cancel")}
               </button>
               <button
                 type="button"
@@ -1182,7 +1201,7 @@ export default function CreateStreamModal({
                 onClick={handleNext}
                 disabled={isBusyCreating}
               >
-                Next
+                {t("common.next")}
               </button>
             </>
           ) : (
@@ -1193,7 +1212,7 @@ export default function CreateStreamModal({
                 onClick={handleBack}
                 disabled={isBusyCreating}
               >
-                Back
+                {t("common.back")}
               </button>
               <button
                 type="button"

--- a/src/components/__tests__/CreateStreamModal.step2.test.tsx
+++ b/src/components/__tests__/CreateStreamModal.step2.test.tsx
@@ -9,6 +9,7 @@ import * as fc from 'fast-check';
 import CreateStreamModal, {
   sanitizeDepositAmountInput,
 } from '../CreateStreamModal';
+import { createT } from '../../i18n';
 
 const VALID_STELLAR = 'GATDOSCZNJ5YZHNOX7IOD4QDCQSTMR2YNF5IXHFNX3H6B4ICCMSDLOWN';
 
@@ -79,6 +80,21 @@ describe('6.1 Step 2: all invalid fields show errors simultaneously on Next clic
 
     expect(accrualContainer?.classList.contains('input-container--error')).toBe(true);
     expect(durationContainer?.classList.contains('input-container--error')).toBe(true);
+  });
+});
+
+describe('CreateStreamModal i18n catalog copy', () => {
+  it('renders step-2 helper copy from the typed catalog', () => {
+    const t = createT();
+    const { container } = renderModal();
+    advanceToStep2(container);
+
+    expect(
+      within(container).getByText(t('createStream.step2.rateHelper')),
+    ).toBeInTheDocument();
+    expect(
+      within(container).getByText(t('createStream.step2.durationHelper')),
+    ).toBeInTheDocument();
   });
 });
 

--- a/src/i18n/I18nProvider.tsx
+++ b/src/i18n/I18nProvider.tsx
@@ -1,0 +1,60 @@
+import {
+  createContext,
+  useContext,
+  useMemo,
+  type ReactNode,
+} from "react";
+import {
+  createT,
+  getCatalog,
+  type Locale,
+  type PluralFunction,
+  type TFunction,
+} from "./core";
+
+type I18nContextValue = {
+  locale: Locale;
+  t: TFunction;
+  plural: PluralFunction;
+};
+
+function createI18nValue(locale: Locale): I18nContextValue {
+  const catalog = getCatalog(locale);
+  const t = createT(catalog);
+
+  return {
+    locale,
+    t,
+    plural(count, forms) {
+      return t(count === 1 ? forms.one : forms.other);
+    },
+  };
+}
+
+const defaultI18nValue = createI18nValue("en");
+const I18nContext = createContext<I18nContextValue>(defaultI18nValue);
+
+/**
+ * Provides the typed message catalog for UI copy.
+ *
+ * New locales should keep the same key shape as the English catalog so calls to
+ * t("namespace.key") remain compile-time checked.
+ */
+export function I18nProvider({
+  children,
+  locale = "en",
+}: {
+  children: ReactNode;
+  locale?: Locale;
+}) {
+  const value = useMemo(() => createI18nValue(locale), [locale]);
+
+  return <I18nContext.Provider value={value}>{children}</I18nContext.Provider>;
+}
+
+/**
+ * Returns the typed translator and plural helper for the active locale.
+ */
+export function useI18n() {
+  return useContext(I18nContext);
+}

--- a/src/i18n/README.md
+++ b/src/i18n/README.md
@@ -1,0 +1,25 @@
+# Internationalization
+
+Fluxora uses a small typed in-house catalog instead of a runtime i18n dependency.
+The English catalog lives in `src/i18n/en.ts`, and UI code reads strings through
+`useI18n().t("namespace.key")`.
+
+## Adding Copy
+
+1. Add the string under the closest namespace in `en.ts`.
+2. Use descriptive dotted keys, for example `createStream.validation.walletRequired`.
+3. Render it with `t("createStream.validation.walletRequired")`.
+4. For interpolated values, use named placeholders: `Hello {name}`.
+
+The key argument is typed from the English catalog, so missing or misspelled keys
+fail during TypeScript checks.
+
+## Adding A Locale
+
+1. Create a new catalog with the same shape as `en`.
+2. Register it in `src/i18n/index.tsx`.
+3. Pass the locale to `I18nProvider`.
+
+Catalog lookups are not driven by user input. Interpolated values are escaped by
+the translator before substitution, and components render translated copy as
+plain React text instead of `dangerouslySetInnerHTML`.

--- a/src/i18n/__tests__/i18n.test.tsx
+++ b/src/i18n/__tests__/i18n.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import {
+  I18nProvider,
+  createT,
+  interpolateMessage,
+  useI18n,
+  type MessageKey,
+} from "../index";
+
+function Probe() {
+  const { plural, t } = useI18n();
+
+  return (
+    <div>
+      <span>{t("createStream.title")}</span>
+      <span>{plural(2, {
+        one: "createStream.units.month.one",
+        other: "createStream.units.month.other",
+      })}</span>
+    </div>
+  );
+}
+
+describe("i18n catalog", () => {
+  it("resolves typed message keys through the provider", () => {
+    render(
+      <I18nProvider>
+        <Probe />
+      </I18nProvider>,
+    );
+
+    expect(screen.getByText("Create stream")).toBeInTheDocument();
+    expect(screen.getByText("months")).toBeInTheDocument();
+  });
+
+  it("interpolates and escapes provided values", () => {
+    expect(
+      interpolateMessage("Recipient {name}", {
+        name: '<img src=x onerror="alert(1)">',
+      }),
+    ).toBe("Recipient &lt;img src=x onerror=&quot;alert(1)&quot;&gt;");
+  });
+
+  it("falls back to the key when a runtime lookup is missing", () => {
+    const t = createT();
+
+    expect(t("missing.key" as MessageKey)).toBe("missing.key");
+  });
+});

--- a/src/i18n/core.ts
+++ b/src/i18n/core.ts
@@ -1,0 +1,67 @@
+import { en, type EnglishCatalog } from "./en";
+
+const catalogs = {
+  en,
+} as const;
+
+type Primitive = string | number | boolean | null | undefined;
+export type MessageParams = Record<string, Primitive>;
+type StringLeafPaths<T, Prefix extends string = ""> = {
+  [Key in keyof T & string]: T[Key] extends string
+    ? `${Prefix}${Key}`
+    : T[Key] extends Record<string, unknown>
+      ? StringLeafPaths<T[Key], `${Prefix}${Key}.`>
+      : never;
+}[keyof T & string];
+
+export type Locale = keyof typeof catalogs;
+export type MessageKey = StringLeafPaths<EnglishCatalog>;
+export type TFunction = <Key extends MessageKey>(
+  key: Key,
+  params?: MessageParams,
+) => string;
+export type PluralFunction = (
+  count: number,
+  forms: { one: MessageKey; other: MessageKey },
+) => string;
+
+export function getCatalog(locale: Locale): EnglishCatalog {
+  return catalogs[locale];
+}
+
+function getCatalogValue(catalog: EnglishCatalog, key: MessageKey): string {
+  const value = key.split(".").reduce<unknown>((current, segment) => {
+    if (current && typeof current === "object" && segment in current) {
+      return (current as Record<string, unknown>)[segment];
+    }
+
+    return undefined;
+  }, catalog);
+
+  return typeof value === "string" ? value : key;
+}
+
+export function escapeInterpolationValue(value: Primitive): string {
+  return String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+export function interpolateMessage(
+  template: string,
+  params: MessageParams = {},
+): string {
+  return template.replace(/\{([A-Za-z0-9_]+)\}/g, (match, name: string) => {
+    if (!(name in params)) return match;
+    return escapeInterpolationValue(params[name]);
+  });
+}
+
+export function createT(catalog: EnglishCatalog = en): TFunction {
+  return ((key: MessageKey, params?: MessageParams) => {
+    return interpolateMessage(getCatalogValue(catalog, key), params);
+  }) as TFunction;
+}

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -1,0 +1,222 @@
+export const en = {
+  common: {
+    back: "Back",
+    cancel: "Cancel",
+    edit: "Edit",
+    next: "Next",
+    notSet: "Not set",
+  },
+  createStream: {
+    title: "Create stream",
+    description:
+      "Set the recipient, funding, and schedule details for a new Stellar stream.",
+    closeAria: "Close create stream modal",
+    steps: {
+      recipientAmount: "Recipient & amount",
+      rateSchedule: "Rate & schedule",
+      reviewCreate: "Review & create",
+    },
+    buttons: {
+      create: "Create stream",
+      confirming: "Confirming...",
+      retryCreate: "Retry create stream",
+      submitting: "Submitting...",
+    },
+    validation: {
+      cliffAfterStart: "Cliff date must be on or after the start date.",
+      cliffDateRequired: "Cliff date is required.",
+      cliffPast: "Cliff date must not be in the past.",
+      customStartRequired: "Custom start date is required.",
+      depositPositive: "Deposit amount must be a positive number.",
+      durationMax: "Duration must be {maxDays} days or less.",
+      durationPositive: "Duration must be a positive number.",
+      invalidRecipient:
+        "Please enter a valid Stellar address (starts with G, 56 characters).",
+      missingTransactionHash: "Missing transaction hash from Stellar RPC.",
+      recipientRequired: "Recipient is required.",
+      startPast: "Start date must be in the future.",
+      streamCreationFallback: "Stream creation failed. Please try again.",
+      transactionConfirmationFailed:
+        "Transaction confirmation failed. Please retry.",
+      walletRequired: "Please connect your wallet first.",
+      rateMax: "Stream rate must be {maxRate} USDC/day or less.",
+      ratePositive: "Stream rate must be a positive number.",
+      wrongNetwork:
+        "Wrong Stellar network. Expected {expectedNetwork}, but wallet is connected to {walletNetwork}. Please switch network in Freighter.",
+    },
+    toast: {
+      createFailed: "Failed to create stream: {message}",
+      created: "Stream created successfully on-chain!",
+    },
+    step1: {
+      depositHelper: "Enter the total USDC amount to deposit into the stream",
+      depositLabel: "Deposit amount",
+      depositPlaceholder: "$ 0.00 USDC",
+      heading: "Recipient & amount",
+      infoTitle: "Smart contract lock:",
+      infoText:
+        "Your USDC will be locked in a Soroban smart contract. The recipient can withdraw their accrued portion at any time.",
+      recipientHelper:
+        "Enter a valid Stellar address (starts with G, 56 characters)",
+      recipientLabel: "Recipient",
+      recipientPlaceholder: "Paste Stellar address (G...)",
+      summary: "Set who receives the stream and how much USDC to lock.",
+    },
+    step2: {
+      cliffCommonUseLabel: "Common use case:",
+      cliffCommonUseText:
+        'Employee compensation where vesting "cliff" prevents withdrawal for the first 3-6 months, ensuring commitment before funds are accessible.',
+      cliffDateHelper:
+        "The recipient cannot withdraw until this date, even though USDC accrues",
+      cliffDateLabel: "Cliff date",
+      cliffExample:
+        "Example: 1-year stream with 3-month cliff = No withdrawals for 3 months, then all accrued USDC becomes available.",
+      cliffIntro: "A cliff is a vesting lockup period. During the cliff:",
+      cliffItemAccrues: "USDC continues to accrue normally",
+      cliffItemLocked: "The recipient CANNOT withdraw any funds",
+      cliffItemUnlocks:
+        "After the cliff date, all accrued funds become withdrawable",
+      cliffLabel: "Cliff period",
+      cliffOptional: "(optional)",
+      cliffToggle: "Enable cliff (vesting lockup until specific date)",
+      cliffTooltipAria: "Learn more about cliff periods",
+      cliffTooltipTitle: "What is a cliff?",
+      customDate: "Custom date",
+      customStartHelper: "When the stream begins accruing USDC",
+      customStartLabel: "Custom start date",
+      durationExample:
+        "Example: A 7-day stream transfers funds continuously over one week. The recipient can withdraw at any time during this period.",
+      durationHelper: "How many days the stream will run before ending",
+      durationLabel: "Stream duration",
+      durationTooltipAria: "Learn more about stream duration",
+      durationTooltipText:
+        "The duration defines the total length of the stream in days. After this period ends, the full deposit amount will have been streamed to the recipient.",
+      durationTooltipTitle: "Understanding stream duration",
+      heading: "Rate & schedule",
+      localTimezone: "Start and cliff times use your local timezone.",
+      rateFormula: "Formula: Total Deposit / Duration = Stream Rate",
+      rateHelper: "How much USDC the recipient earns per day",
+      rateLabel: "Stream rate",
+      rateTooltipAria: "Learn more about stream rate calculation",
+      rateTooltipText:
+        "The stream rate is the amount of USDC that accrues to the recipient per day. For example, a rate of 38.62 USDC/day means the recipient can withdraw approximately 270 USDC after 7 days.",
+      rateTooltipTitle: "How is stream rate calculated?",
+      requiredDeposit: "Required deposit",
+      startNow: "Start now",
+      startTime: "Start time",
+      summary: "Configure how fast USDC streams and when it starts.",
+      yourDeposit: "Your deposit",
+    },
+    review: {
+      address: "Address",
+      cliff: "Cliff",
+      deposit: "Deposit",
+      duration: "Duration",
+      editDepositAria: "Edit deposit",
+      editRateScheduleAria: "Edit rate and schedule",
+      editRecipientAria: "Edit recipient",
+      failedTitle: "Stream creation failed.",
+      rate: "Rate",
+      rateSchedule: "Rate & schedule",
+      rateValue: "{rate} USDC per day",
+      recipient: "Recipient",
+      start: "Start",
+      startImmediately: "Immediately",
+      submitStatus:
+        "Submitting transaction to Stellar. Keep this window open.",
+      waitingForConfirmation:
+        "Waiting for Stellar confirmation before opening the success receipt.",
+      confirmationCheck: "Confirmation check {attempts}",
+      confirmationTx: "tx {txHash}",
+      tryAgain: "Try again",
+      warningPrefix: "By creating this stream:",
+      warningBody:
+        "{amount} USDC will be locked in a Soroban smart contract. The recipient can withdraw their accrued amount at any time during the stream.",
+    },
+    units: {
+      day: {
+        one: "day",
+        other: "days",
+      },
+      days: "days",
+      month: {
+        one: "month",
+        other: "months",
+      },
+    },
+  },
+  streams: {
+    actions: {
+      create: "Create stream",
+      openFeatured: "Open featured deep dive",
+    },
+    announcements: {
+      collapsed: "collapsed",
+      expanded: "expanded",
+      showing: "Showing {count} {streamWord}.",
+      streamPlural: "streams",
+      streamSingular: "stream",
+      toggle: "{streamName} deep dive {state}.",
+    },
+    empty: {
+      description:
+        "Create and manage USDC streams. Set rate, duration, and cliff from the treasury.",
+    },
+    hero: {
+      eyebrow: "Treasury streaming",
+      subtitle:
+        "Review every stream from a single operational surface, then open a deeper layout when treasury context, recipient balance, or audit notes need closer attention.",
+      title: "Streams",
+    },
+    list: {
+      cardsAria: "Stream cards",
+      emptySearch: "No streams match your search or filter.",
+      filterAria: "Filter and search streams",
+      heading: "Deep-dive ready list",
+      searchAria: "Search streams by name, ID or recipient",
+      searchPlaceholder: "Search streams...",
+      sortAria: "Sort streams",
+      sortHighestRate: "Highest rate",
+      sortMostRecent: "Most recent",
+      sortName: "Name (A-Z)",
+      subtitle:
+        "Expand a row for the operational summary or open the full stream detail route for the complete layout.",
+    },
+    streamCard: {
+      nextUnlock: "Next unlock {relativeTime}",
+      nextUnlockLabel: "Next unlock",
+      withdrawableNow: "Withdrawable now",
+    },
+    statusFilters: {
+      active: "Active",
+      all: "All",
+      completed: "Completed",
+      paused: "Paused",
+    },
+    summary: {
+      activeDescription: "Currently accruing from treasury capital.",
+      activeLabel: "Active streams",
+      ariaLabel: "Stream summary",
+      monthlyDescription:
+        "Projected accrual across active streams each month.",
+      monthlyLabel: "Monthly outflow",
+      nextUnlockDescription:
+        "Earliest upcoming release window across active streams.",
+      nextUnlockLabel: "Next unlock",
+      withdrawableDescription:
+        "Available to recipients right now without a refill.",
+      withdrawableLabel: "Withdrawable now",
+    },
+    toast: {
+      clipboardUnavailable:
+        "Clipboard access is unavailable in this browser. Copy the address manually instead.",
+      recipientCopied:
+        "Recipient for {streamName} copied to your clipboard.",
+    },
+    zeroAccrual: {
+      action: "Check cliff date",
+    },
+  },
+} as const;
+
+export type EnglishCatalog = typeof en;

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,0 +1,11 @@
+export { I18nProvider, useI18n } from "./I18nProvider";
+export { en } from "./en";
+export {
+  createT,
+  escapeInterpolationValue,
+  interpolateMessage,
+  type Locale,
+  type MessageKey,
+  type PluralFunction,
+  type TFunction,
+} from "./core";

--- a/src/pages/Streams.test.tsx
+++ b/src/pages/Streams.test.tsx
@@ -6,6 +6,7 @@ import { MemoryRouter, Route, Routes } from "react-router-dom";
 import Streams from "./Streams";
 import { streamRecords } from "../data/streamRecords";
 import { ToastProvider } from "../components/toast/ToastProvider";
+import { I18nProvider, createT } from "../i18n";
 
 type MatchMediaChangeHandler = (event: MediaQueryListEvent) => void;
 type ClipboardMock = {
@@ -45,13 +46,15 @@ function mockMatchMedia(matches: boolean) {
 
 function renderStreams() {
   return render(
-    <ToastProvider>
-      <MemoryRouter initialEntries={["/app/streams"]}>
-        <Routes>
-          <Route path="/app/streams" element={<Streams />} />
-        </Routes>
-      </MemoryRouter>
-    </ToastProvider>,
+    <I18nProvider>
+      <ToastProvider>
+        <MemoryRouter initialEntries={["/app/streams"]}>
+          <Routes>
+            <Route path="/app/streams" element={<Streams />} />
+          </Routes>
+        </MemoryRouter>
+      </ToastProvider>
+    </I18nProvider>,
   );
 }
 
@@ -138,6 +141,26 @@ describe("Streams disclosure motion", () => {
     expect(list).toHaveAttribute("data-virtualized", "false");
     expect(screen.getByText(streamRecords[0]!.name)).toBeInTheDocument();
     expect(screen.getByText(streamRecords[streamRecords.length - 1]!.name)).toBeInTheDocument();
+  });
+
+  it("renders hero, search, and empty-search copy from the catalog", async () => {
+    const t = createT();
+    mockMatchMedia(false);
+    renderStreams();
+    await finishLoading();
+
+    expect(screen.getByText(t("streams.hero.eyebrow"))).toBeInTheDocument();
+    expect(screen.getByText(t("streams.list.heading"))).toBeInTheDocument();
+    expect(screen.getByLabelText(t("streams.list.searchAria"))).toHaveAttribute(
+      "placeholder",
+      t("streams.list.searchPlaceholder"),
+    );
+
+    fireEvent.change(screen.getByLabelText(t("streams.list.searchAria")), {
+      target: { value: "no-stream-here" },
+    });
+
+    expect(screen.getByText(t("streams.list.emptySearch"))).toBeInTheDocument();
   });
 
   it("keeps the stream list in sync after filtering and sorting", async () => {

--- a/src/pages/Streams.tsx
+++ b/src/pages/Streams.tsx
@@ -36,6 +36,7 @@ import {
 } from "../lib/timePresentation";
 import { useLiveAnnouncer } from "../hooks/useLiveAnnouncer";
 import { usePrefersReducedMotion } from "../hooks/usePrefersReducedMotion";
+import { useI18n, type MessageKey, type TFunction } from "../i18n";
 import "./Streams.css";
 import TruncatedAddress from "../components/common/TruncatedAddress";
 
@@ -43,6 +44,12 @@ import TruncatedAddress from "../components/common/TruncatedAddress";
 type StatusFilter = "All" | StreamStatus;
 
 const STATUS_FILTERS: StatusFilter[] = ["All", "Active", "Paused", "Completed"];
+const STATUS_FILTER_KEYS: Record<StatusFilter, MessageKey> = {
+  Active: "streams.statusFilters.active",
+  All: "streams.statusFilters.all",
+  Completed: "streams.statusFilters.completed",
+  Paused: "streams.statusFilters.paused",
+};
 const DISCLOSURE_DURATION_MS = 200;
 const FILTER_ANNOUNCEMENT_DELAY_MS = 300;
 const STREAMS_VIRTUALIZATION_THRESHOLD = 20;
@@ -199,6 +206,7 @@ type StreamCardProps = {
   onAnnounceToggle: (streamName: string, expanded: boolean) => void;
   onCopyRecipient: (stream: StreamRecord) => void;
   onCopyRecipientError: (stream: StreamRecord) => void;
+  t: TFunction;
 };
 
 // Memoized so unrelated page state updates do not repaint every stream card.
@@ -212,6 +220,7 @@ const StreamCard = memo(function StreamCard({
   onAnnounceToggle,
   onCopyRecipient,
   onCopyRecipientError,
+  t,
 }: StreamCardProps) {
   const urgency = getUrgencyLevel(stream.cliffDate, stream.endDate);
   const cliffStatus = getCliffStatusText(stream.cliffDate);
@@ -334,11 +343,13 @@ const StreamCard = memo(function StreamCard({
           </div>
         </div>
         <div className="stream-meta-block">
-          <span>Withdrawable now</span>
+          <span>{t("streams.streamCard.withdrawableNow")}</span>
           <strong>{formatUsdc(stream.withdrawableAmount)}</strong>
           <div className="stream-card__meta-label">
             {stream.nextUnlockDate
-              ? `Next unlock ${getRelativeTime(stream.nextUnlockDate)}`
+              ? t("streams.streamCard.nextUnlock", {
+                  relativeTime: getRelativeTime(stream.nextUnlockDate),
+                })
               : "No upcoming unlock"}
           </div>
         </div>
@@ -477,11 +488,13 @@ function StreamDetail({
   onBack,
   onCreateSimilar,
   onCopyAddress,
+  t,
 }: {
   stream: StreamRecord;
   onBack: () => void;
   onCreateSimilar: () => void;
   onCopyAddress: () => void;
+  t: TFunction;
 }) {
   return (
     <>
@@ -635,7 +648,9 @@ function StreamDetail({
                 </div>
               </div>
               <div className="stream-panel__row">
-                <span className="stream-panel__row-label">Next unlock</span>
+                <span className="stream-panel__row-label">
+                  {t("streams.streamCard.nextUnlockLabel")}
+                </span>
                 <div className="stream-panel__row-value">
                   {formatDate(stream.nextUnlockDate)}
                 </div>
@@ -713,6 +728,8 @@ function StreamNotFound({
   onBack: () => void;
   onCreateStream: () => void;
 }) {
+  const { t } = useI18n();
+
   return (
     <section className="stream-empty-state">
       <p className="streams-eyebrow">Stream detail</p>
@@ -730,7 +747,7 @@ function StreamNotFound({
           className="streams-primary-button"
           onClick={onCreateStream}
         >
-          Create stream
+          {t("streams.actions.create")}
         </button>
       </div>
     </section>
@@ -742,6 +759,7 @@ export default function Streams() {
   const { streamId } = useParams();
   const { announcement, announce } = useLiveAnnouncer();
   const { addToast } = useToast();
+  const { t } = useI18n();
   const hasMountedFilterAnnouncer = useRef(false);
 
   const [loading, setLoading] = useState(true);
@@ -811,15 +829,21 @@ export default function Streams() {
     }
 
     const timer = window.setTimeout(() => {
+      const streamWord = t(
+        visibleStreams.length === 1
+          ? "streams.announcements.streamSingular"
+          : "streams.announcements.streamPlural",
+      );
       announce(
-        `Showing ${visibleStreams.length} ${
-          visibleStreams.length === 1 ? "stream" : "streams"
-        }.`,
+        t("streams.announcements.showing", {
+          count: visibleStreams.length,
+          streamWord,
+        }),
       );
     }, FILTER_ANNOUNCEMENT_DELAY_MS);
 
     return () => window.clearTimeout(timer);
-  }, [announce, searchQuery, sortBy, statusFilter, visibleStreams.length]);
+  }, [announce, searchQuery, sortBy, statusFilter, t, visibleStreams.length]);
   const selectedStream = streamId ? getStreamRecord(streamId) : undefined;
   const hasStreams = streamRecords.length > 0;
   const showEmptyState = !selectedStream && (!walletConnected || !hasStreams);
@@ -854,30 +878,30 @@ export default function Streams() {
     try {
       await navigator.clipboard.writeText(stream.recipientAddress);
       addToast(
-        `Recipient for ${stream.name} copied to your clipboard.`,
+        t("streams.toast.recipientCopied", { streamName: stream.name }),
         "success",
       );
     } catch {
       addToast(
-        "Clipboard access is unavailable in this browser. Copy the address manually instead.",
+        t("streams.toast.clipboardUnavailable"),
         "error",
       );
     }
-  }, [addToast]);
+  }, [addToast, t]);
 
   const handleRecipientCopied = useCallback((stream: StreamRecord) => {
     addToast(
-      `Recipient for ${stream.name} copied to your clipboard.`,
+      t("streams.toast.recipientCopied", { streamName: stream.name }),
       "success",
     );
-  }, [addToast]);
+  }, [addToast, t]);
 
-  const handleRecipientCopyError = useCallback((_stream: StreamRecord) => {
+  const handleRecipientCopyError = useCallback(() => {
     addToast(
-      "Clipboard access is unavailable in this browser. Copy the address manually instead.",
+      t("streams.toast.clipboardUnavailable"),
       "error",
     );
-  }, [addToast]);
+  }, [addToast, t]);
 
   const handleToggleStreamCard = useCallback((streamId: string) => {
     setExpandedStreamId((current) => (current === streamId ? "" : streamId));
@@ -894,10 +918,17 @@ export default function Streams() {
   const handleAnnounceStreamToggle = useCallback(
     (streamName: string, nextExpanded: boolean) => {
       announce(
-        `${streamName} deep dive ${nextExpanded ? "expanded" : "collapsed"}.`,
+        t("streams.announcements.toggle", {
+          streamName,
+          state: t(
+            nextExpanded
+              ? "streams.announcements.expanded"
+              : "streams.announcements.collapsed",
+          ),
+        }),
       );
     },
-    [announce],
+    [announce, t],
   );
 
   if (loading) return <StreamsLoading />;
@@ -942,13 +973,13 @@ export default function Streams() {
           onBack={() => navigate("/app/streams")}
           onCreateSimilar={handleCreateStream}
           onCopyAddress={() => void handleCopyRecipient(selectedStream)}
+          t={t}
         />
       ) : showEmptyState ? (
         <section>
-          <h1 style={{ marginTop: 0 }}>Streams</h1>
+          <h1 style={{ marginTop: 0 }}>{t("streams.hero.title")}</h1>
           <p style={{ color: "var(--muted)" }}>
-            Create and manage USDC streams. Set rate, duration, and cliff from
-            the treasury.
+            {t("streams.empty.description")}
           </p>
           <EmptyState
             variant="streams"
@@ -964,12 +995,10 @@ export default function Streams() {
         <>
           <section className="streams-hero">
             <div className="streams-hero__copy">
-              <p className="streams-eyebrow">Treasury streaming</p>
-              <h1>Streams</h1>
+              <p className="streams-eyebrow">{t("streams.hero.eyebrow")}</p>
+              <h1>{t("streams.hero.title")}</h1>
               <p className="streams-subtitle">
-                Review every stream from a single operational surface, then open
-                a deeper layout when treasury context, recipient balance, or
-                audit notes need closer attention.
+                {t("streams.hero.subtitle")}
               </p>
             </div>
             <div className="streams-hero__actions">
@@ -978,14 +1007,14 @@ export default function Streams() {
                 className="streams-primary-button"
                 onClick={handleCreateStream}
               >
-                Create stream
+                {t("streams.actions.create")}
               </button>
               <button
                 type="button"
                 className="streams-secondary-button"
                 onClick={() => navigate(`/app/streams/${streamRecords[0]?.id}`)}
               >
-                Open featured deep dive
+                {t("streams.actions.openFeatured")}
               </button>
             </div>
           </section>
@@ -1002,49 +1031,48 @@ export default function Streams() {
                   );
                   if (first) navigate(`/app/streams/${first.id}`);
                 }}
-                actionLabel="Check cliff date"
+                actionLabel={t("streams.zeroAccrual.action")}
               />
             </div>
           )}
 
-          <section className="streams-summary-grid" aria-label="Stream summary">
+          <section className="streams-summary-grid" aria-label={t("streams.summary.ariaLabel")}>
             <div className="streams-summary-card">
-              <span>Active streams</span>
+              <span>{t("streams.summary.activeLabel")}</span>
               <strong>{activeStreams.length}</strong>
-              <p>Currently accruing from treasury capital.</p>
+              <p>{t("streams.summary.activeDescription")}</p>
             </div>
             <div className="streams-summary-card">
-              <span>Monthly outflow</span>
+              <span>{t("streams.summary.monthlyLabel")}</span>
               <strong>{formatUsdc(monthlyOutflow)}</strong>
-              <p>Projected accrual across active streams each month.</p>
+              <p>{t("streams.summary.monthlyDescription")}</p>
             </div>
             <div className="streams-summary-card">
-              <span>Withdrawable now</span>
+              <span>{t("streams.summary.withdrawableLabel")}</span>
               <strong>{formatUsdc(withdrawableNow)}</strong>
-              <p>Available to recipients right now without a refill.</p>
+              <p>{t("streams.summary.withdrawableDescription")}</p>
             </div>
             <div className="streams-summary-card">
-              <span>Next unlock</span>
+              <span>{t("streams.summary.nextUnlockLabel")}</span>
               <strong>{formatDate(nextUnlock)}</strong>
-              <p>Earliest upcoming release window across active streams.</p>
+              <p>{t("streams.summary.nextUnlockDescription")}</p>
             </div>
           </section>
 
           <section className="streams-list-shell">
             <div className="streams-list-head">
               <div>
-                <h2>Deep-dive ready list</h2>
+                <h2>{t("streams.list.heading")}</h2>
                 <p className="streams-subtitle">
-                  Expand a row for the operational summary or open the full
-                  stream detail route for the complete layout.
+                  {t("streams.list.subtitle")}
                 </p>
               </div>
-              <div className="flex flex-wrap items-center gap-3 w-full mt-4" aria-label="Filter and search streams">
+              <div className="flex flex-wrap items-center gap-3 w-full mt-4" aria-label={t("streams.list.filterAria")}>
                 <div className="flex-1 min-w-[200px]">
                   <Input
                     id="streams-search"
-                    aria-label="Search streams by name, ID or recipient"
-                    placeholder="Search streams..."
+                    aria-label={t("streams.list.searchAria")}
+                    placeholder={t("streams.list.searchPlaceholder")}
                     value={searchQuery}
                     onChange={(e) => setSearchQuery(e.target.value)}
                   />
@@ -1060,21 +1088,21 @@ export default function Streams() {
                       onClick={() => setStatusFilter(filter)}
                       aria-pressed={statusFilter === filter}
                     >
-                      {filter}
+                      {t(STATUS_FILTER_KEYS[filter])}
                     </button>
                   ))}
                 </div>
                 <div className="min-w-[160px]">
                   <Input
                     id="streams-sort"
-                    aria-label="Sort streams"
+                    aria-label={t("streams.list.sortAria")}
                     type="select"
                     value={sortBy}
                     onChange={(e) => setSortBy(e.target.value)}
                     options={[
-                      { value: "recent", label: "Most recent" },
-                      { value: "name", label: "Name (A-Z)" },
-                      { value: "rate", label: "Highest rate" },
+                      { value: "recent", label: t("streams.list.sortMostRecent") },
+                      { value: "name", label: t("streams.list.sortName") },
+                      { value: "rate", label: t("streams.list.sortHighestRate") },
                     ]}
                   />
                 </div>
@@ -1082,11 +1110,11 @@ export default function Streams() {
             </div>
 
             <VirtualList
-              ariaLabel="Stream cards"
+              ariaLabel={t("streams.list.cardsAria")}
               className="streams-list"
               emptyState={
                 <div className="streams-empty-search">
-                  <p>No streams match your search or filter.</p>
+                  <p>{t("streams.list.emptySearch")}</p>
                 </div>
               }
               estimateSize={STREAM_CARD_ESTIMATED_HEIGHT}
@@ -1103,6 +1131,7 @@ export default function Streams() {
                   onOpenDetail={handleOpenStreamDetail}
                   onCopyRecipient={handleRecipientCopied}
                   onCopyRecipientError={handleRecipientCopyError}
+                  t={t}
                 />
               )}
               threshold={STREAMS_VIRTUALIZATION_THRESHOLD}


### PR DESCRIPTION
## Summary
- adds a lightweight typed i18n provider and English message catalog under src/i18n
- wraps the app in I18nProvider and migrates CreateStreamModal copy to catalog keys
- migrates Streams hero, summary, filter/search/sort, empty-search, and related stream copy to catalog keys
- documents locale/key conventions and interpolation safety

## Tests
- 
pm run test -- src/i18n/__tests__/i18n.test.tsx src/components/__tests__/CreateStreamModal.step2.test.tsx src/pages/Streams.test.tsx
- 
ode .\node_modules\typescript\bin\tsc --noEmit --pretty false 2>&1 | Select-String -Pattern 'src/i18n|src/components/CreateStreamModal|src/pages/Streams|src/App|eslint.config'
- 
ode .\node_modules\eslint\bin\eslint.js --no-warn-ignored src/i18n/I18nProvider.tsx src/i18n/index.ts src/i18n/core.ts src/i18n/en.ts src/App.tsx src/components/CreateStreamModal.tsx src/pages/Streams.tsx eslint.config.js
- git diff --check

## Security notes
- catalog keys are statically selected in code, not derived from user input
- interpolation escapes values before substitution
- translated strings render as React text, with no dangerouslySetInnerHTML

Closes #264