### PR TITLE
feat(streams): add typed stream data service

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -55,6 +55,7 @@ export default tseslint.config(
             "useTheme",
             "useToast",
             "useWallet",
+            "sortRecipientStreams",
           ],
         },
       ],

--- a/src/components/recipient/RecipientStreams.tsx
+++ b/src/components/recipient/RecipientStreams.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   mockRecipientStreams,
   type RecipientStream,
@@ -37,9 +37,19 @@ export function sortRecipientStreams(
   });
 }
 
-export default function RecipientStreams() {
-  const [streams, setStreams] = useState<RecipientStream[]>(mockRecipientStreams);
+interface RecipientStreamsProps {
+  streams?: RecipientStream[];
+}
+
+export default function RecipientStreams({
+  streams: initialStreams = mockRecipientStreams,
+}: RecipientStreamsProps) {
+  const [streams, setStreams] = useState<RecipientStream[]>(initialStreams);
   const [sortKey, setSortKey] = useState<RecipientStreamsSortKey>("pinned");
+
+  useEffect(() => {
+    setStreams(initialStreams);
+  }, [initialStreams]);
 
   const togglePin = (id: string) => {
     setStreams((prev) =>

--- a/src/components/treasuryOverviewPage/__tests__/demoMode.test.tsx
+++ b/src/components/treasuryOverviewPage/__tests__/demoMode.test.tsx
@@ -6,9 +6,16 @@ import { isTreasuryDemoMode } from "../useTreasuryOverviewData";
 
 const getMetrics = vi.fn();
 const getStreams = vi.fn();
+const treasuryHookState = vi.hoisted(() => ({
+  metrics: [] as unknown[],
+  streams: [] as unknown[],
+  loading: false,
+  error: null as string | null,
+}));
 
 vi.mock("../useTreasury", () => ({
   useTreasury: () => ({
+    ...treasuryHookState,
     getMetrics,
     getStreams,
   }),
@@ -37,6 +44,10 @@ describe("treasury overview demo mode", () => {
     getStreams.mockReset();
     getMetrics.mockResolvedValue([]);
     getStreams.mockResolvedValue([]);
+    treasuryHookState.metrics = [];
+    treasuryHookState.streams = [];
+    treasuryHookState.loading = false;
+    treasuryHookState.error = null;
   });
 
   it("parses the demo mode flag explicitly", () => {
@@ -62,9 +73,6 @@ describe("treasury overview demo mode", () => {
     renderTreasuryPage();
 
     expect(screen.queryByText("Demo state:")).not.toBeInTheDocument();
-    expect(screen.getByRole("status")).toHaveTextContent(
-      "Loading treasury overview...",
-    );
 
     await waitFor(() => {
       expect(
@@ -74,7 +82,7 @@ describe("treasury overview demo mode", () => {
 
     expect(screen.queryByText("Dev Grant - Alice")).not.toBeInTheDocument();
     expect(screen.getByText("No recent streams available.")).toBeInTheDocument();
-    expect(getMetrics).toHaveBeenCalledTimes(1);
-    expect(getStreams).toHaveBeenCalledTimes(1);
+    expect(getMetrics).not.toHaveBeenCalled();
+    expect(getStreams).not.toHaveBeenCalled();
   });
 });

--- a/src/components/treasuryOverviewPage/useTreasury.ts
+++ b/src/components/treasuryOverviewPage/useTreasury.ts
@@ -1,17 +1,99 @@
-import { useCallback } from "react";
+import { useCallback, useEffect, useState } from "react";
 import type { Metric } from "./Metric";
 import type { Stream } from "./Stream";
+import type { StreamRecord } from "../../data/streamRecords";
+import {
+  getRecipientStreams as fetchRecipientStreams,
+  getStreamById as fetchStreamById,
+  getStreams as fetchStreamRecords,
+  getTreasuryMetrics,
+  toTreasuryStreams,
+  type StreamFilters,
+} from "../../lib/api/streamsService";
 
-export function useTreasury() {
+export function useTreasury(filters?: StreamFilters) {
+  const [metrics, setMetrics] = useState<Metric[]>([]);
+  const [streams, setStreams] = useState<StreamRecord[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
   const getMetrics = useCallback(async (): Promise<Metric[]> => {
-    // TODO: Replace with API call when the treasury service is available.
-    return [];
+    return getTreasuryMetrics();
   }, []);
 
-  const getStreams = useCallback(async (): Promise<Stream[]> => {
-    // TODO: Replace with API call when the treasury service is available.
-    return [];
+  const getStreamRecords = useCallback(
+    async (nextFilters?: StreamFilters): Promise<StreamRecord[]> => {
+      return fetchStreamRecords(nextFilters);
+    },
+    [],
+  );
+
+  const getStreams = useCallback(
+    async (nextFilters?: StreamFilters): Promise<Stream[]> => {
+      return toTreasuryStreams(await getStreamRecords(nextFilters));
+    },
+    [getStreamRecords],
+  );
+
+  const getStreamById = useCallback(async (id: string) => {
+    return fetchStreamById(id);
   }, []);
 
-  return { getMetrics, getStreams };
+  const getRecipientStreams = useCallback(async (address: string) => {
+    return fetchRecipientStreams(address);
+  }, []);
+
+  const refetch = useCallback(
+    async (nextFilters = filters, signal?: AbortSignal) => {
+      setLoading(true);
+      setError(null);
+
+      try {
+        const [nextMetrics, nextStreams] = await Promise.all([
+          getTreasuryMetrics({ signal }),
+          fetchStreamRecords(nextFilters, { signal }),
+        ]);
+
+        if (signal?.aborted) return;
+
+        setMetrics(nextMetrics);
+        setStreams(nextStreams);
+      } catch (err) {
+        if (signal?.aborted) return;
+
+        setMetrics([]);
+        setStreams([]);
+        setError(
+          err instanceof Error
+            ? err.message
+            : "Unable to load treasury stream data.",
+        );
+      } finally {
+        if (!signal?.aborted) {
+          setLoading(false);
+        }
+      }
+    },
+    [filters],
+  );
+
+  useEffect(() => {
+    const controller = new AbortController();
+    void refetch(filters, controller.signal);
+
+    return () => controller.abort();
+  }, [filters, refetch]);
+
+  return {
+    metrics,
+    streams,
+    loading,
+    error,
+    refetch,
+    getMetrics,
+    getStreams,
+    getStreamRecords,
+    getStreamById,
+    getRecipientStreams,
+  };
 }

--- a/src/components/treasuryOverviewPage/useTreasuryOverviewData.ts
+++ b/src/components/treasuryOverviewPage/useTreasuryOverviewData.ts
@@ -6,6 +6,7 @@ import {
 import type { Metric } from "./Metric";
 import type { Stream } from "./Stream";
 import { useTreasury } from "./useTreasury";
+import { toTreasuryStreams } from "../../lib/api/streamsService";
 
 export interface TreasuryOverviewData {
   metrics: Metric[];
@@ -20,7 +21,7 @@ export function isTreasuryDemoMode(value = import.meta.env.VITE_DEMO_MODE) {
 }
 
 export function useTreasuryOverviewData(): TreasuryOverviewData {
-  const { getMetrics, getStreams } = useTreasury();
+  const { metrics, streams, loading, error } = useTreasury();
   const isDemoMode = isTreasuryDemoMode();
   const [data, setData] = useState<TreasuryOverviewData>({
     metrics: isDemoMode ? treasuryDemoMetrics : [],
@@ -42,41 +43,14 @@ export function useTreasuryOverviewData(): TreasuryOverviewData {
       return undefined;
     }
 
-    let cancelled = false;
     setData({
-      metrics: [],
-      streams: [],
+      metrics,
+      streams: toTreasuryStreams(streams),
       isDemoMode: false,
-      loading: true,
-      error: null,
+      loading,
+      error: error ? "Unable to load treasury overview data." : null,
     });
-
-    Promise.all([getMetrics(), getStreams()])
-      .then(([metrics, streams]) => {
-        if (cancelled) return;
-        setData({
-          metrics,
-          streams,
-          isDemoMode: false,
-          loading: false,
-          error: null,
-        });
-      })
-      .catch(() => {
-        if (cancelled) return;
-        setData({
-          metrics: [],
-          streams: [],
-          isDemoMode: false,
-          loading: false,
-          error: "Unable to load treasury overview data.",
-        });
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [getMetrics, getStreams, isDemoMode]);
+  }, [error, isDemoMode, loading, metrics, streams]);
 
   return data;
 }

--- a/src/data/streamRecords.ts
+++ b/src/data/streamRecords.ts
@@ -34,6 +34,207 @@ export interface StreamRecord {
   timeline: StreamTimelineEvent[];
 }
 
+const STATUS_VALUES: StreamStatus[] = ["Active", "Paused", "Completed"];
+const HEALTH_VALUES: StreamHealth[] = ["Healthy", "Attention", "Settled"];
+const MAX_TEXT_LENGTH = 240;
+const MAX_LONG_TEXT_LENGTH = 800;
+const MAX_TAGS = 8;
+const MAX_TIMELINE_EVENTS = 12;
+
+function stripControlCharacters(value: string) {
+  return Array.from(value)
+    .map((character) => {
+      const code = character.charCodeAt(0);
+      return (code >= 0 && code <= 31) || code === 127 ? " " : character;
+    })
+    .join("");
+}
+
+function sanitizeText(
+  value: unknown,
+  fallback: string,
+  maxLength = MAX_TEXT_LENGTH,
+) {
+  if (typeof value !== "string") return fallback;
+
+  const sanitized = stripControlCharacters(value)
+    .replace(/[<>]/g, "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, maxLength);
+
+  return sanitized || fallback;
+}
+
+function sanitizeAddress(value: unknown, fallback: string) {
+  const text = sanitizeText(value, fallback, 96).toUpperCase();
+  const sanitized = text.replace(/[^A-Z0-9._-]/g, "");
+  return sanitized || fallback;
+}
+
+function sanitizeNumber(value: unknown, fallback = 0) {
+  const number = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(number) && number >= 0 ? number : fallback;
+}
+
+function sanitizeProgress(value: unknown, fallback = 0) {
+  return Math.min(100, Math.max(0, sanitizeNumber(value, fallback)));
+}
+
+function sanitizeDate(value: unknown, fallback = "1970-01-01") {
+  const text = sanitizeText(value, fallback, 40);
+  return Number.isNaN(Date.parse(text)) ? fallback : text;
+}
+
+function normalizeStatus(value: unknown): StreamStatus {
+  const text = sanitizeText(value, "Active", 24).toLowerCase();
+  return (
+    STATUS_VALUES.find((status) => status.toLowerCase() === text) ?? "Active"
+  );
+}
+
+function normalizeHealth(value: unknown, status: StreamStatus): StreamHealth {
+  const text = sanitizeText(value, "", 24).toLowerCase();
+  const health = HEALTH_VALUES.find(
+    (candidate) => candidate.toLowerCase() === text,
+  );
+
+  if (health) return health;
+  return status === "Completed" ? "Settled" : "Healthy";
+}
+
+function normalizeTags(value: unknown) {
+  if (!Array.isArray(value)) return [];
+
+  return value
+    .map((tag) => sanitizeText(tag, "", 48))
+    .filter(Boolean)
+    .slice(0, MAX_TAGS);
+}
+
+function normalizeTimeline(value: unknown): StreamTimelineEvent[] {
+  if (!Array.isArray(value)) return [];
+
+  return value
+    .map((event) => {
+      const item = event && typeof event === "object" ? event : {};
+      const record = item as Record<string, unknown>;
+
+      return {
+        date: sanitizeDate(record.date),
+        title: sanitizeText(record.title, "Stream update", 120),
+        detail: sanitizeText(record.detail, "No detail provided.", 320),
+      };
+    })
+    .slice(0, MAX_TIMELINE_EVENTS);
+}
+
+function pickField(
+  source: Record<string, unknown>,
+  keys: string[],
+): unknown {
+  return keys.map((key) => source[key]).find((value) => value !== undefined);
+}
+
+export function normalizeStreamRecord(input: unknown): StreamRecord {
+  const source =
+    input && typeof input === "object"
+      ? (input as Record<string, unknown>)
+      : {};
+  const status = normalizeStatus(pickField(source, ["status", "state"]));
+  const health = normalizeHealth(source.health, status);
+  const depositAmount = sanitizeNumber(
+    pickField(source, ["depositAmount", "deposit_amount", "totalAmount"]),
+  );
+  const streamedAmount = sanitizeNumber(
+    pickField(source, ["streamedAmount", "streamed_amount", "accruedAmount"]),
+  );
+  const withdrawableAmount = sanitizeNumber(
+    pickField(source, [
+      "withdrawableAmount",
+      "withdrawable_amount",
+      "availableAmount",
+    ]),
+  );
+  const remainingAmount = sanitizeNumber(
+    pickField(source, ["remainingAmount", "remaining_amount"]),
+    Math.max(depositAmount - streamedAmount, 0),
+  );
+
+  return {
+    id: sanitizeText(pickField(source, ["id", "streamId", "stream_id"]), "STR-UNKNOWN", 80),
+    name: sanitizeText(source.name, "Untitled stream", 160),
+    recipientName: sanitizeText(
+      pickField(source, ["recipientName", "recipient_name", "recipient"]),
+      "Unknown recipient",
+      120,
+    ),
+    recipientAddress: sanitizeAddress(
+      pickField(source, [
+        "recipientAddress",
+        "recipient_address",
+        "recipient",
+        "recipientId",
+      ]),
+      "UNKNOWN",
+    ),
+    treasuryName: sanitizeText(
+      pickField(source, ["treasuryName", "treasury_name", "treasury"]),
+      "Treasury",
+      120,
+    ),
+    treasuryAddress: sanitizeAddress(
+      pickField(source, [
+        "treasuryAddress",
+        "treasury_address",
+        "sourceAddress",
+        "sender",
+      ]),
+      "UNKNOWN",
+    ),
+    asset: sanitizeText(source.asset, "USDC", 24).toUpperCase(),
+    status,
+    monthlyRate: sanitizeNumber(
+      pickField(source, ["monthlyRate", "monthly_rate", "rate"]),
+    ),
+    depositAmount,
+    streamedAmount,
+    withdrawableAmount,
+    remainingAmount,
+    progress: sanitizeProgress(source.progress),
+    startDate: sanitizeDate(pickField(source, ["startDate", "start_date"])),
+    endDate: sanitizeDate(pickField(source, ["endDate", "end_date"])),
+    cliffDate:
+      pickField(source, ["cliffDate", "cliff_date"]) === undefined
+        ? undefined
+        : sanitizeDate(pickField(source, ["cliffDate", "cliff_date"])),
+    nextUnlockDate:
+      pickField(source, ["nextUnlockDate", "next_unlock_date"]) === undefined
+        ? undefined
+        : sanitizeDate(
+            pickField(source, ["nextUnlockDate", "next_unlock_date"]),
+          ),
+    summary: sanitizeText(
+      source.summary,
+      "No stream summary is available yet.",
+      MAX_LONG_TEXT_LENGTH,
+    ),
+    health,
+    healthNote: sanitizeText(
+      pickField(source, ["healthNote", "health_note"]),
+      "No health note is available yet.",
+      MAX_LONG_TEXT_LENGTH,
+    ),
+    auditNote: sanitizeText(
+      pickField(source, ["auditNote", "audit_note"]),
+      "No audit note is available yet.",
+      MAX_LONG_TEXT_LENGTH,
+    ),
+    tags: normalizeTags(source.tags),
+    timeline: normalizeTimeline(source.timeline),
+  };
+}
+
 export const streamRecords: StreamRecord[] = [
   {
     id: "STR-001",

--- a/src/lib/api/__tests__/streamsService.test.ts
+++ b/src/lib/api/__tests__/streamsService.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AppConfig } from "../../config";
+import {
+  getRecipientStreams,
+  getStreamById,
+  getStreams,
+  getTreasuryMetrics,
+  StreamsServiceError,
+} from "../streamsService";
+
+const liveConfig: AppConfig = {
+  apiUrl: "https://api.example.test/v1",
+  network: "TESTNET",
+  networkLabel: "Testnet",
+  networkPassphrase: "Test SDF Network ; September 2015",
+  rpcUrl: null,
+  streamContractId: null,
+  useMocks: false,
+};
+
+const mockConfig: AppConfig = {
+  ...liveConfig,
+  apiUrl: null,
+  useMocks: true,
+};
+
+function jsonResponse(body: unknown, init?: ResponseInit) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+}
+
+describe("streamsService", () => {
+  it("encodes stream filter URL params for live requests", async () => {
+    const fetcher = vi.fn().mockResolvedValue(jsonResponse({ streams: [] }));
+
+    await getStreams(
+      {
+        status: "Active",
+        recipient: "G ABC/123",
+        treasury: "Treasury & Ops",
+        search: "Alice + grant",
+        limit: 250,
+        cursor: "page/2",
+      },
+      { config: liveConfig, fetcher },
+    );
+
+    const url = new URL(String(fetcher.mock.calls[0]?.[0]));
+
+    expect(url.origin).toBe("https://api.example.test");
+    expect(url.pathname).toBe("/v1/streams");
+    expect(url.searchParams.get("status")).toBe("Active");
+    expect(url.searchParams.get("recipient")).toBe("G ABC/123");
+    expect(url.searchParams.get("treasury")).toBe("Treasury & Ops");
+    expect(url.searchParams.get("search")).toBe("Alice + grant");
+    expect(url.searchParams.get("limit")).toBe("100");
+    expect(url.searchParams.get("cursor")).toBe("page/2");
+  });
+
+  it("encodes path segments for stream and recipient endpoints", async () => {
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({
+          id: "STR-1",
+          name: "Live stream",
+          recipientAddress: "GRECIPIENT",
+          treasuryAddress: "GTREASURY",
+        }),
+      )
+      .mockResolvedValueOnce(jsonResponse({ streams: [] }));
+
+    await getStreamById("STR/1 ?", { config: liveConfig, fetcher });
+    await getRecipientStreams("G/RECIPIENT ?", {
+      config: liveConfig,
+      fetcher,
+    });
+
+    expect(String(fetcher.mock.calls[0]?.[0])).toContain("/streams/STR%2F1%20%3F");
+    expect(String(fetcher.mock.calls[1]?.[0])).toContain(
+      "/recipients/G%2FRECIPIENT%20%3F/streams",
+    );
+  });
+
+  it("fails closed on non-2xx responses", async () => {
+    const fetcher = vi.fn().mockResolvedValue(jsonResponse({}, { status: 500 }));
+
+    await expect(
+      getTreasuryMetrics({ config: liveConfig, fetcher }),
+    ).rejects.toMatchObject({
+      name: "StreamsServiceError",
+      status: 500,
+    });
+    expect(StreamsServiceError).toBeDefined();
+  });
+
+  it("uses mock data only when mock mode is enabled", async () => {
+    const streams = await getStreams({ search: "Alice" }, { config: mockConfig });
+
+    expect(streams).toHaveLength(1);
+    expect(streams[0]?.name).toBe("Dev Grant - Alice");
+  });
+
+  it("sanitizes API fields before returning stream records", async () => {
+    const fetcher = vi.fn().mockResolvedValue(
+      jsonResponse({
+        streams: [
+          {
+            id: " STR-<script> ",
+            name: " Bad <b>Name</b> ",
+            recipientName: "\u0000Alice",
+            recipientAddress: "gabc<script>",
+            treasuryName: "Ops",
+            treasuryAddress: "gtreasury<script>",
+            status: "not-real",
+            health: "unknown",
+            monthlyRate: "-1",
+            depositAmount: 100,
+            streamedAmount: 40,
+            withdrawableAmount: Number.NaN,
+            progress: 900,
+            tags: ["<hot>", "safe"],
+            timeline: [
+              {
+                date: "2026-01-01",
+                title: " <start> ",
+                detail: "\u0000Details",
+              },
+            ],
+          },
+        ],
+      }),
+    );
+
+    const [stream] = await getStreams(undefined, {
+      config: liveConfig,
+      fetcher,
+    });
+
+    expect(stream?.id).toBe("STR-script");
+    expect(stream?.name).toBe("Bad bName/b");
+    expect(stream?.recipientName).toBe("Alice");
+    expect(stream?.recipientAddress).toBe("GABCSCRIPT");
+    expect(stream?.status).toBe("Active");
+    expect(stream?.health).toBe("Healthy");
+    expect(stream?.monthlyRate).toBe(0);
+    expect(stream?.withdrawableAmount).toBe(0);
+    expect(stream?.progress).toBe(100);
+    expect(stream?.tags).toEqual(["hot", "safe"]);
+    expect(stream?.timeline[0]).toMatchObject({
+      date: "2026-01-01",
+      title: "start",
+      detail: "Details",
+    });
+  });
+});

--- a/src/lib/api/streamsService.ts
+++ b/src/lib/api/streamsService.ts
@@ -1,0 +1,425 @@
+import { createElement, type ReactNode } from "react";
+import {
+  normalizeStreamRecord,
+  streamRecords,
+  type StreamRecord,
+  type StreamStatus,
+} from "../../data/streamRecords";
+import { config, type AppConfig } from "../config";
+import type { Metric } from "../../components/treasuryOverviewPage/Metric";
+import type { Stream } from "../../components/treasuryOverviewPage/Stream";
+import type { RecipientStream } from "../../fixtures/recipientStreams";
+
+export interface StreamFilters {
+  status?: StreamStatus | "All";
+  recipient?: string;
+  treasury?: string;
+  search?: string;
+  limit?: number;
+  cursor?: string;
+}
+
+export class StreamsServiceError extends Error {
+  constructor(
+    message: string,
+    public readonly status?: number,
+  ) {
+    super(message);
+    this.name = "StreamsServiceError";
+  }
+}
+
+const DEFAULT_REQUEST_TIMEOUT_MS = 10_000;
+const MAX_QUERY_LENGTH = 160;
+const MAX_LIMIT = 100;
+const ENDPOINTS = {
+  metrics: "/treasury/metrics",
+  streams: "/streams",
+  streamById: "/streams",
+  recipientStreams: "/recipients",
+};
+
+function isMockMode(appConfig = config) {
+  return appConfig.useMocks;
+}
+
+function icon(label: string, value: string): ReactNode {
+  return createElement(
+    "span",
+    {
+      "aria-hidden": "true",
+      title: label,
+      className:
+        "inline-flex h-10 w-10 items-center justify-center rounded-md bg-cyan-500/10 text-sm font-bold text-cyan-700",
+    },
+    value,
+  );
+}
+
+function clampText(value: string, maxLength = MAX_QUERY_LENGTH) {
+  return value.trim().slice(0, maxLength);
+}
+
+function appendFilters(url: URL, filters: StreamFilters = {}) {
+  if (filters.status && filters.status !== "All") {
+    url.searchParams.set("status", filters.status);
+  }
+
+  if (filters.recipient) {
+    url.searchParams.set("recipient", clampText(filters.recipient));
+  }
+
+  if (filters.treasury) {
+    url.searchParams.set("treasury", clampText(filters.treasury));
+  }
+
+  if (filters.search) {
+    url.searchParams.set("search", clampText(filters.search));
+  }
+
+  if (filters.cursor) {
+    url.searchParams.set("cursor", clampText(filters.cursor));
+  }
+
+  if (typeof filters.limit === "number" && Number.isFinite(filters.limit)) {
+    url.searchParams.set(
+      "limit",
+      String(Math.min(MAX_LIMIT, Math.max(1, Math.floor(filters.limit)))),
+    );
+  }
+}
+
+function buildUrl(appConfig: AppConfig, path: string) {
+  if (!appConfig.apiUrl) {
+    throw new StreamsServiceError("Stream API URL is not configured.");
+  }
+
+  const base = appConfig.apiUrl.endsWith("/")
+    ? appConfig.apiUrl
+    : `${appConfig.apiUrl}/`;
+  return new URL(path.replace(/^\/+/, ""), base);
+}
+
+function readCollection(payload: unknown): unknown[] {
+  if (Array.isArray(payload)) return payload;
+
+  if (payload && typeof payload === "object") {
+    const record = payload as Record<string, unknown>;
+    const candidates = [record.streams, record.data, record.items, record.results];
+    const collection = candidates.find(Array.isArray);
+    if (Array.isArray(collection)) return collection;
+  }
+
+  return [];
+}
+
+function applyMockFilters(records: StreamRecord[], filters: StreamFilters = {}) {
+  const search = filters.search?.trim().toLowerCase();
+  const recipient = filters.recipient?.trim().toLowerCase();
+  const treasury = filters.treasury?.trim().toLowerCase();
+
+  return records
+    .filter((record) => {
+      if (filters.status && filters.status !== "All" && record.status !== filters.status) {
+        return false;
+      }
+
+      if (
+        recipient &&
+        !record.recipientAddress.toLowerCase().includes(recipient) &&
+        !record.recipientName.toLowerCase().includes(recipient)
+      ) {
+        return false;
+      }
+
+      if (
+        treasury &&
+        !record.treasuryAddress.toLowerCase().includes(treasury) &&
+        !record.treasuryName.toLowerCase().includes(treasury)
+      ) {
+        return false;
+      }
+
+      if (!search) return true;
+
+      return [
+        record.id,
+        record.name,
+        record.recipientName,
+        record.recipientAddress,
+        record.treasuryName,
+      ].some((field) => field.toLowerCase().includes(search));
+    })
+    .slice(0, filters.limit ?? records.length);
+}
+
+function formatUsdc(value: number) {
+  return `${new Intl.NumberFormat("en-US", {
+    maximumFractionDigits: 0,
+  }).format(value)} USDC`;
+}
+
+function metricValue(value: unknown, fallback: string) {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return new Intl.NumberFormat("en-US").format(value);
+  }
+  if (typeof value === "string" && value.trim()) {
+    return value.trim().slice(0, 80);
+  }
+  return fallback;
+}
+
+function sanitizeMetricsPayload(payload: unknown): Metric[] {
+  if (Array.isArray(payload)) {
+    return payload
+      .map((item, index) => {
+        const record = item && typeof item === "object" ? item as Record<string, unknown> : {};
+        const label = metricValue(record.label, `Metric ${index + 1}`);
+        const value = metricValue(record.value, "--");
+        const desc = metricValue(record.desc ?? record.description, "");
+
+        return {
+          icon: icon(label, String(index + 1)),
+          label,
+          value,
+          desc,
+        };
+      })
+      .slice(0, 6);
+  }
+
+  if (payload && typeof payload === "object") {
+    const record = payload as Record<string, unknown>;
+    return [
+      {
+        icon: icon("Active Streams", "AS"),
+        label: "Active Streams",
+        value: metricValue(record.activeStreams ?? record.active_streams, "--"),
+        desc: "streams currently accruing",
+      },
+      {
+        icon: icon("Total Streaming", "TS"),
+        label: "Total Streaming",
+        value: metricValue(record.totalStreaming ?? record.total_streaming, "--"),
+        desc: "combined deposit in active streams",
+      },
+      {
+        icon: icon("Withdrawable", "WD"),
+        label: "Withdrawable",
+        value: metricValue(record.withdrawable ?? record.withdrawableAmount, "--"),
+        desc: "available for recipients to withdraw",
+      },
+    ];
+  }
+
+  return [];
+}
+
+function mockMetrics(records = streamRecords): Metric[] {
+  const active = records.filter((stream) => stream.status === "Active");
+  const totalStreaming = active.reduce(
+    (total, stream) => total + stream.depositAmount,
+    0,
+  );
+  const withdrawable = records.reduce(
+    (total, stream) => total + stream.withdrawableAmount,
+    0,
+  );
+
+  return [
+    {
+      icon: icon("Active Streams", "AS"),
+      label: "Active Streams",
+      value: String(active.length),
+      desc: "streams currently accruing",
+    },
+    {
+      icon: icon("Total Streaming", "TS"),
+      label: "Total Streaming",
+      value: formatUsdc(totalStreaming),
+      desc: "combined deposit in active streams",
+    },
+    {
+      icon: icon("Withdrawable", "WD"),
+      label: "Withdrawable",
+      value: formatUsdc(withdrawable),
+      desc: "available for recipients to withdraw",
+    },
+  ];
+}
+
+function toTreasuryStream(record: StreamRecord): Stream {
+  return {
+    id: record.id,
+    name: record.name,
+    recipient: record.recipientAddress,
+    rate: `${formatUsdc(record.monthlyRate)}/mo`,
+    accruedAmount: record.streamedAmount,
+    status: record.status,
+  };
+}
+
+async function fetchJson<T>(
+  url: URL,
+  fetcher: typeof fetch,
+  signal?: AbortSignal,
+): Promise<T> {
+  const controller = new AbortController();
+  const timeout = window.setTimeout(
+    () => controller.abort(),
+    DEFAULT_REQUEST_TIMEOUT_MS,
+  );
+
+  const abortRequest = () => controller.abort();
+  signal?.addEventListener("abort", abortRequest, { once: true });
+
+  try {
+    const response = await fetcher(url, {
+      headers: { Accept: "application/json" },
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      throw new StreamsServiceError(
+        `Stream API request failed with status ${response.status}.`,
+        response.status,
+      );
+    }
+
+    return (await response.json()) as T;
+  } catch (error) {
+    if (error instanceof StreamsServiceError) throw error;
+    throw new StreamsServiceError("Unable to load stream data.");
+  } finally {
+    window.clearTimeout(timeout);
+    signal?.removeEventListener("abort", abortRequest);
+  }
+}
+
+export async function getTreasuryMetrics(options?: {
+  config?: AppConfig;
+  fetcher?: typeof fetch;
+  signal?: AbortSignal;
+}): Promise<Metric[]> {
+  const appConfig = options?.config ?? config;
+
+  if (isMockMode(appConfig)) {
+    return mockMetrics(streamRecords.map(normalizeStreamRecord));
+  }
+
+  const url = buildUrl(appConfig, ENDPOINTS.metrics);
+  const payload = await fetchJson<unknown>(
+    url,
+    options?.fetcher ?? fetch,
+    options?.signal,
+  );
+  return sanitizeMetricsPayload(payload);
+}
+
+export async function getStreams(
+  filters: StreamFilters = {},
+  options?: {
+    config?: AppConfig;
+    fetcher?: typeof fetch;
+    signal?: AbortSignal;
+  },
+): Promise<StreamRecord[]> {
+  const appConfig = options?.config ?? config;
+
+  if (isMockMode(appConfig)) {
+    return applyMockFilters(streamRecords.map(normalizeStreamRecord), filters);
+  }
+
+  const url = buildUrl(appConfig, ENDPOINTS.streams);
+  appendFilters(url, filters);
+  const payload = await fetchJson<unknown>(
+    url,
+    options?.fetcher ?? fetch,
+    options?.signal,
+  );
+
+  return readCollection(payload).map(normalizeStreamRecord);
+}
+
+export async function getStreamById(
+  id: string,
+  options?: {
+    config?: AppConfig;
+    fetcher?: typeof fetch;
+    signal?: AbortSignal;
+  },
+): Promise<StreamRecord | null> {
+  const sanitizedId = clampText(id, 80);
+  const appConfig = options?.config ?? config;
+
+  if (!sanitizedId) return null;
+
+  if (isMockMode(appConfig)) {
+    return (
+      streamRecords.map(normalizeStreamRecord).find((stream) => stream.id === sanitizedId) ??
+      null
+    );
+  }
+
+  const url = buildUrl(
+    appConfig,
+    `${ENDPOINTS.streamById}/${encodeURIComponent(sanitizedId)}`,
+  );
+  const payload = await fetchJson<unknown>(
+    url,
+    options?.fetcher ?? fetch,
+    options?.signal,
+  );
+
+  return normalizeStreamRecord(payload);
+}
+
+export async function getRecipientStreams(
+  address: string,
+  options?: {
+    config?: AppConfig;
+    fetcher?: typeof fetch;
+    signal?: AbortSignal;
+  },
+): Promise<StreamRecord[]> {
+  const sanitizedAddress = clampText(address, 96);
+  const appConfig = options?.config ?? config;
+
+  if (!sanitizedAddress) return [];
+
+  if (isMockMode(appConfig)) {
+    return applyMockFilters(streamRecords.map(normalizeStreamRecord), {
+      recipient: sanitizedAddress,
+    });
+  }
+
+  const url = buildUrl(
+    appConfig,
+    `${ENDPOINTS.recipientStreams}/${encodeURIComponent(sanitizedAddress)}/streams`,
+  );
+  const payload = await fetchJson<unknown>(
+    url,
+    options?.fetcher ?? fetch,
+    options?.signal,
+  );
+
+  return readCollection(payload).map(normalizeStreamRecord);
+}
+
+export function toTreasuryStreams(records: StreamRecord[]): Stream[] {
+  return records.map(toTreasuryStream);
+}
+
+export function toRecipientStreams(records: StreamRecord[]): RecipientStream[] {
+  return records.map((record, index) => ({
+    id: record.id,
+    sender: record.treasuryAddress,
+    senderName: record.treasuryName,
+    amount: record.depositAmount,
+    rate: Math.round((record.monthlyRate / 30 / 24) * 100) / 100,
+    progress: record.progress,
+    status: record.status.toLowerCase() as RecipientStream["status"],
+    isPinned: index === 0 && record.status === "Active",
+    startTime: new Date(record.startDate).toISOString(),
+  }));
+}

--- a/src/pages/Dashboard.test.tsx
+++ b/src/pages/Dashboard.test.tsx
@@ -1,4 +1,5 @@
-import { act, render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import Dashboard from "./Dashboard";
 
@@ -21,16 +22,21 @@ vi.mock("../components/wallet-connect/Walletcontext", () => ({
   }),
 }));
 
-function renderDashboard() {
-  render(<Dashboard />);
-  act(() => {
-    vi.advanceTimersByTime(1200);
+async function renderDashboard() {
+  render(
+    <MemoryRouter>
+      <Dashboard />
+    </MemoryRouter>,
+  );
+  await waitFor(() => {
+    expect(
+      screen.queryByRole("status", { name: /loading treasury overview/i }),
+    ).not.toBeInTheDocument();
   });
 }
 
 describe("Dashboard wallet source", () => {
   beforeEach(() => {
-    vi.useFakeTimers();
     walletState.connected = false;
     walletState.address = null;
     walletState.network = null;
@@ -38,12 +44,11 @@ describe("Dashboard wallet source", () => {
   });
 
   afterEach(() => {
-    vi.useRealTimers();
     localStorage.clear();
   });
 
-  it("uses disconnected state from useWallet for the connect banner", () => {
-    renderDashboard();
+  it("uses disconnected state from useWallet for the connect banner", async () => {
+    await renderDashboard();
 
     expect(
       screen.getByText(/Connect your Stellar wallet to see real balances/i),
@@ -51,15 +56,15 @@ describe("Dashboard wallet source", () => {
     expect(screen.getAllByText("-- USDC").length).toBeGreaterThan(0);
   });
 
-  it("uses connected address from useWallet for treasury onboarding", () => {
+  it("uses connected address from useWallet for treasury onboarding", async () => {
     walletState.connected = true;
     walletState.address = "GCONNECTED";
 
-    renderDashboard();
+    await renderDashboard();
 
     expect(
       screen.queryByText(/Connect your Stellar wallet to see real balances/i),
     ).not.toBeInTheDocument();
-    expect(screen.getByText("22,600 USDC")).toBeInTheDocument();
+    expect(screen.getByText("6,700 USDC")).toBeInTheDocument();
   });
 });

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import RecentStreams, { Stream } from "../components/RecentStreams";
+import RecentStreams from "../components/RecentStreams";
 import CreateStreamModal from "../components/CreateStreamModal";
 import TreasuryOverviewLoading from "../components/TreasuryOverviewLoading";
 import TreasuryEmptyState from "../components/TreasuryEmptyState";
@@ -10,6 +10,8 @@ import ToastNotification, {
 } from "../components/ToastNotification";
 import { useLiveAnnouncer } from "../hooks/useLiveAnnouncer";
 import { useWallet } from "../components/wallet-connect/Walletcontext";
+import { useTreasury } from "../components/treasuryOverviewPage/useTreasury";
+import { toTreasuryStreams } from "../lib/api/streamsService";
 import "../design-tokens.css";
 
 const ONBOARDING_KEY = "fluxora_onboarding_dismissed";
@@ -31,29 +33,42 @@ function markOnboardingSeen(): void {
 }
 
 export default function Dashboard() {
-  const [loading, setLoading] = useState(true);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isWalletModalOpen, setIsWalletModalOpen] = useState(false);
-  const [streams] = useState<Stream[]>([]);
   const [showOnboarding, setShowOnboarding] = useState(false);
   const [toast, setToast] = useState<{
     message: string;
     variant: ToastVariant;
   } | null>(null);
-  const [withdrawable, setWithdrawable] = useState<number | null>(null);
   const { announcement, announce } = useLiveAnnouncer();
   const wallet = useWallet();
+  const treasury = useTreasury();
   const walletConnected = wallet.connected;
   const walletAddress = wallet.address;
+  const dashboardStreamRecords = walletConnected ? treasury.streams : [];
+  const streams = toTreasuryStreams(dashboardStreamRecords);
+  const activeStreams = dashboardStreamRecords.filter(
+    (stream) => stream.status === "Active",
+  );
+  const totalStreaming = activeStreams.reduce(
+    (total, stream) => total + stream.depositAmount,
+    0,
+  );
+  const withdrawable = walletConnected
+    ? dashboardStreamRecords.reduce(
+        (total, stream) => total + stream.withdrawableAmount,
+        0,
+      )
+    : null;
 
   useEffect(() => {
-    setWithdrawable(walletConnected ? 22600 : null);
-  }, [walletConnected]);
-
-  useEffect(() => {
-    const timer = setTimeout(() => setLoading(false), 1200);
-    return () => clearTimeout(timer);
-  }, []);
+    if (treasury.error) {
+      setToast({
+        message: treasury.error,
+        variant: "error",
+      });
+    }
+  }, [treasury.error]);
 
   useEffect(() => {
     if (!toast) return undefined;
@@ -63,14 +78,14 @@ export default function Dashboard() {
   }, [toast]);
 
   useEffect(() => {
-    if (!loading && streams.length === 0 && !hasSeenOnboarding()) {
+    if (!treasury.loading && streams.length === 0 && !hasSeenOnboarding()) {
       setShowOnboarding(true);
     }
 
-    if (!loading && streams.length > 0) {
+    if (!treasury.loading && streams.length > 0) {
       announce(`${streams.length} active streams loaded.`);
     }
-  }, [loading, streams.length, announce]);
+  }, [treasury.loading, streams.length, announce]);
 
   useEffect(() => {
     if (walletConnected && walletAddress) {
@@ -116,7 +131,7 @@ export default function Dashboard() {
     });
   };
 
-  if (loading) return <TreasuryOverviewLoading />;
+  if (treasury.loading) return <TreasuryOverviewLoading />;
 
   const hasStreams = streams.length > 0;
 
@@ -183,7 +198,7 @@ export default function Dashboard() {
           >
             Active Streams
           </div>
-          <div className="text-heading-2">{streams.length || "--"}</div>
+          <div className="text-heading-2">{activeStreams.length || "--"}</div>
         </div>
         <div style={card}>
           <div
@@ -192,7 +207,11 @@ export default function Dashboard() {
           >
             Total Streaming
           </div>
-          <div className="text-heading-2">-- USDC</div>
+          <div className="text-heading-2">
+            {walletConnected
+              ? `${totalStreaming.toLocaleString()} USDC`
+              : "-- USDC"}
+          </div>
         </div>
         <div style={card}>
           <div

--- a/src/pages/Recipient.test.tsx
+++ b/src/pages/Recipient.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import Recipient from "./Recipient";
 
@@ -21,44 +21,44 @@ vi.mock("../components/wallet-connect/Walletcontext", () => ({
   }),
 }));
 
-function renderRecipient() {
+async function renderRecipient() {
   render(<Recipient />);
-  act(() => {
-    vi.advanceTimersByTime(2000);
+  await waitFor(() => {
+    expect(
+      screen.queryByRole("status", { name: /loading recipient page/i }),
+    ).not.toBeInTheDocument();
   });
 }
 
 describe("Recipient wallet source", () => {
   beforeEach(() => {
-    vi.useFakeTimers();
     walletState.connected = false;
     walletState.address = null;
     walletState.network = null;
   });
 
-  afterEach(() => {
-    vi.useRealTimers();
-  });
+  afterEach(() => {});
 
-  it("uses disconnected state from useWallet for the empty state", () => {
-    renderRecipient();
+  it("uses disconnected state from useWallet for the empty state", async () => {
+    await renderRecipient();
 
     expect(screen.getByRole("region", { name: "Recipient empty state" })).toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: /Withdraw 22,600 USDC/i }),
+      screen.queryByRole("button", { name: /Withdraw/i }),
     ).not.toBeInTheDocument();
   });
 
-  it("enables the withdraw surface when useWallet reports a connected wallet", () => {
+  it("enables the withdraw surface when useWallet reports a connected wallet", async () => {
     walletState.connected = true;
+    walletState.address = "GABC...XYZ1";
     // Match the expected network so the on-chain mismatch guard does not
     // disable the withdraw action.
     walletState.network = "TESTNET";
 
-    renderRecipient();
+    await renderRecipient();
 
     expect(
-      screen.getByRole("button", { name: /Withdraw 22,600 USDC/i }),
+      screen.getByRole("button", { name: /Withdraw 4,200 USDC/i }),
     ).toBeEnabled();
     expect(screen.getByText("Withdrawable now")).toBeInTheDocument();
   });

--- a/src/pages/Recipient.tsx
+++ b/src/pages/Recipient.tsx
@@ -6,6 +6,11 @@ import ZeroAccrualBanner from "../components/ZeroAccrualBanner";
 import { useWallet } from "../components/wallet-connect/Walletcontext";
 import { useToast } from "../components/toast/ToastProvider";
 import { withdraw } from "../lib/stellar/tx";
+import type { StreamRecord } from "../data/streamRecords";
+import {
+  getRecipientStreams,
+  toRecipientStreams,
+} from "../lib/api/streamsService";
 import "./Streams.css";
 import "./Recipient.css";
 
@@ -14,18 +19,62 @@ export default function Recipient() {
   const { addToast } = useToast();
 
   const [loading, setLoading] = useState(true);
+  const [recipientStreams, setRecipientStreams] = useState<StreamRecord[]>([]);
   const [txState, setTxState] = useState<"idle" | "signing" | "submitting" | "confirmed" | "error">("idle");
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
 
   useEffect(() => {
-    const t = setTimeout(() => setLoading(false), 2000);
-    return () => clearTimeout(t);
-  }, []);
+    const controller = new AbortController();
 
-  const balance: number = 22600.0;
-  const activeStreams = 2;
-  const totalAccrued = 43250.0;
-  const totalWithdrawn = 20650.0;
+    if (!wallet.connected || !wallet.address) {
+      setRecipientStreams([]);
+      setLoading(false);
+      return () => controller.abort();
+    }
+
+    setLoading(true);
+    setErrorMsg(null);
+
+    getRecipientStreams(wallet.address, { signal: controller.signal })
+      .then((streams) => {
+        if (controller.signal.aborted) return;
+        setRecipientStreams(streams);
+      })
+      .catch((error) => {
+        if (controller.signal.aborted) return;
+        setRecipientStreams([]);
+        setErrorMsg(
+          error instanceof Error
+            ? error.message
+            : "Unable to load recipient streams.",
+        );
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) {
+          setLoading(false);
+        }
+      });
+
+    return () => controller.abort();
+  }, [wallet.address, wallet.connected]);
+
+  const balance = recipientStreams.reduce(
+    (total, stream) => total + stream.withdrawableAmount,
+    0,
+  );
+  const activeStreams = recipientStreams.filter(
+    (stream) => stream.status === "Active",
+  ).length;
+  const totalAccrued = recipientStreams.reduce(
+    (total, stream) => total + stream.streamedAmount,
+    0,
+  );
+  const totalWithdrawn = recipientStreams.reduce(
+    (total, stream) =>
+      total + Math.max(stream.streamedAmount - stream.withdrawableAmount, 0),
+    0,
+  );
+  const incomingStreams = toRecipientStreams(recipientStreams);
 
   const walletConnected = wallet.connected;
   const hasStreams = activeStreams > 0;
@@ -36,16 +85,23 @@ export default function Recipient() {
   const isZeroAccrual = walletConnected && hasStreams && balance === 0;
   
   const isPending = txState === "signing" || txState === "submitting";
-  const disabled = !walletConnected || balance === 0 || networkMismatch || isPending;
+  const disabled =
+    !walletConnected ||
+    !wallet.address ||
+    balance === 0 ||
+    networkMismatch ||
+    isPending;
 
   const handleWithdraw = async () => {
     if (disabled) return;
     setTxState("signing");
     setErrorMsg(null);
 
-    const recipientAddr = wallet.address!;
+    const recipientAddr = wallet.address;
+    if (!recipientAddr) return;
+
     const amountStr = Math.floor(balance * 10_000_000).toString(); // Scale to 7 decimals
-    const streamId = "1"; // Default stream ID
+    const streamId = recipientStreams[0]?.id ?? "1";
 
     try {
       setTxState("submitting");
@@ -53,10 +109,11 @@ export default function Recipient() {
       setTxState("confirmed");
       addToast("Withdrawal completed successfully on-chain!", "success");
       setTimeout(() => setTxState("idle"), 5000);
-    } catch (err: any) {
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
       setTxState("error");
-      setErrorMsg(err.message || "Withdrawal failed.");
-      addToast(`Withdrawal failed: ${err.message || err}`, "error");
+      setErrorMsg(message || "Withdrawal failed.");
+      addToast(`Withdrawal failed: ${message || "Unknown error"}`, "error");
     }
   };
 
@@ -174,7 +231,7 @@ export default function Recipient() {
           </div>
         </div>
         <div className="mt-6">
-          <RecipientStreams />
+          <RecipientStreams streams={incomingStreams} />
         </div>
       </section>
     </main>

--- a/src/pages/Streams.test.tsx
+++ b/src/pages/Streams.test.tsx
@@ -65,7 +65,12 @@ function mockClipboard(writeText: ClipboardMock["writeText"]) {
 async function finishLoading() {
   await act(async () => {
     vi.advanceTimersByTime(2000);
+    await Promise.resolve();
   });
+
+  expect(screen.getByRole("article", {
+    name: new RegExp(streamRecords[0]!.name, "i"),
+  })).toBeInTheDocument();
 }
 
 describe("Streams disclosure motion", () => {

--- a/src/pages/Streams.tsx
+++ b/src/pages/Streams.tsx
@@ -21,12 +21,11 @@ import { Pagination } from "../components/Pagination";
 import StreamTimeline from "../components/StreamTimeline";
 import VirtualList from "../components/VirtualList";
 import {
-  getStreamRecord,
-  streamRecords,
   type StreamHealth,
   type StreamRecord,
   type StreamStatus,
 } from "../data/streamRecords";
+import { useTreasury } from "../components/treasuryOverviewPage/useTreasury";
 import {
   formatDateWithTimezone,
   getRelativeTime,
@@ -742,15 +741,14 @@ export default function Streams() {
   const { streamId } = useParams();
   const { announcement, announce } = useLiveAnnouncer();
   const { addToast } = useToast();
+  const { streams, loading, error } = useTreasury();
   const hasMountedFilterAnnouncer = useRef(false);
+  const hasInitializedExpandedStream = useRef(false);
 
-  const [loading, setLoading] = useState(true);
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("All");
   const [searchQuery, setSearchQuery] = useState("");
   const [sortBy, setSortBy] = useState("recent");
-  const [expandedStreamId, setExpandedStreamId] = useState<string>(
-    streamRecords[0]?.id ?? "",
-  );
+  const [expandedStreamId, setExpandedStreamId] = useState<string>("");
   const [selectedStreamId, setSelectedStreamId] = useState<string>("");
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
   const [isSuccessModalOpen, setIsSuccessModalOpen] = useState(false);
@@ -766,16 +764,18 @@ export default function Streams() {
   const walletConnected = true;
 
   useEffect(() => {
-    const timer = window.setTimeout(() => setLoading(false), 2000);
-    return () => window.clearTimeout(timer);
-  }, []);
+    if (!hasInitializedExpandedStream.current && streams[0]) {
+      hasInitializedExpandedStream.current = true;
+      setExpandedStreamId(streams[0].id);
+    }
+  }, [streams]);
 
-  const activeStreams = streamRecords.filter((stream) => stream.status === "Active");
+  const activeStreams = streams.filter((stream) => stream.status === "Active");
   const monthlyOutflow = activeStreams.reduce(
     (total, stream) => total + stream.monthlyRate,
     0,
   );
-  const withdrawableNow = streamRecords.reduce(
+  const withdrawableNow = streams.reduce(
     (total, stream) => total + stream.withdrawableAmount,
     0,
   );
@@ -786,7 +786,7 @@ export default function Streams() {
   const visibleStreams = useMemo(() => {
     const normalizedSearch = searchQuery.toLowerCase();
 
-    return streamRecords
+    return streams
       .filter((stream) => {
         const matchesStatus =
           statusFilter === "All" || stream.status === statusFilter;
@@ -802,7 +802,7 @@ export default function Streams() {
         // Default to recent (higher ID first for demo)
         return b.id.localeCompare(a.id);
       });
-  }, [searchQuery, sortBy, statusFilter]);
+  }, [searchQuery, sortBy, statusFilter, streams]);
 
   useEffect(() => {
     if (!hasMountedFilterAnnouncer.current) {
@@ -820,8 +820,10 @@ export default function Streams() {
 
     return () => window.clearTimeout(timer);
   }, [announce, searchQuery, sortBy, statusFilter, visibleStreams.length]);
-  const selectedStream = streamId ? getStreamRecord(streamId) : undefined;
-  const hasStreams = streamRecords.length > 0;
+  const selectedStream = streamId
+    ? streams.find((stream) => stream.id === streamId)
+    : undefined;
+  const hasStreams = streams.length > 0;
   const showEmptyState = !selectedStream && (!walletConnected || !hasStreams);
   // Zero-accrual: connected + streams exist + nothing is withdrawable yet
   const showZeroAccrual =
@@ -841,14 +843,14 @@ export default function Streams() {
   }, []);
 
   const handleStreamCreated = useCallback(() => {
-    const generatedId = `STR-${String(streamRecords.length + 1).padStart(3, "0")}`;
+    const generatedId = `STR-${String(streams.length + 1).padStart(3, "0")}`;
     setCreatedStream({
       id: generatedId,
       url: `https://fluxora.io/stream/${generatedId}`,
     });
     setIsCreateModalOpen(false);
     setIsSuccessModalOpen(true);
-  }, []);
+  }, [streams.length]);
 
   const handleCopyRecipient = useCallback(async (stream: StreamRecord) => {
     try {
@@ -872,7 +874,7 @@ export default function Streams() {
     );
   }, [addToast]);
 
-  const handleRecipientCopyError = useCallback((_stream: StreamRecord) => {
+  const handleRecipientCopyError = useCallback(() => {
     addToast(
       "Clipboard access is unavailable in this browser. Copy the address manually instead.",
       "error",
@@ -936,6 +938,12 @@ export default function Streams() {
         {announcement}
       </div>
 
+      {error ? (
+        <div className="validation-message validation-message--error" role="alert">
+          {error}
+        </div>
+      ) : null}
+
       {selectedStream ? (
         <StreamDetail
           stream={selectedStream}
@@ -983,7 +991,7 @@ export default function Streams() {
               <button
                 type="button"
                 className="streams-secondary-button"
-                onClick={() => navigate(`/app/streams/${streamRecords[0]?.id}`)}
+                onClick={() => navigate(`/app/streams/${streams[0]?.id}`)}
               >
                 Open featured deep dive
               </button>
@@ -997,7 +1005,7 @@ export default function Streams() {
                 reason="cliff"
                 nextEventDate={nextUnlock}
                 onAction={() => {
-                  const first = streamRecords.find(
+                  const first = streams.find(
                     (s) => s.status === "Active",
                   );
                   if (first) navigate(`/app/streams/${first.id}`);

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -3,13 +3,19 @@ import { expect, afterEach, vi } from 'vitest';
 import { cleanup } from '@testing-library/react';
 import * as matchers from '@testing-library/jest-dom/matchers';
 import { webcrypto, randomBytes } from 'node:crypto';
+import type { ReactNode } from 'react';
+
+interface TestProviderProps {
+  children: ReactNode;
+}
 
 // Polyfill Web Crypto API for Stellar SDK / @noble/ed25519 in test environment
 const customCrypto = {
   ...webcrypto,
   getRandomValues<T extends ArrayBufferView | null>(array: T): T {
     if (!array) return array;
-    const bytes = randomBytes((array as any).byteLength);
+    const view = array as ArrayBufferView;
+    const bytes = randomBytes(view.byteLength);
     const u8 = new Uint8Array(array.buffer, array.byteOffset, array.byteLength);
     u8.set(bytes);
     return array;
@@ -31,6 +37,8 @@ Object.defineProperty(globalThis, 'crypto', {
 });
 
 expect.extend(matchers);
+
+vi.stubEnv('VITE_USE_MOCKS', 'true');
 
 // jsdom does not implement matchMedia. Provide a no-op default (no preference,
 // no listeners) so components/hooks that probe it don't crash. Individual tests
@@ -70,7 +78,7 @@ vi.mock('../components/wallet-connect/Walletcontext', () => {
       connect: vi.fn(),
       disconnect: vi.fn(),
     }),
-    WalletProvider: ({ children }: any) => children,
+    WalletProvider: ({ children }: TestProviderProps) => children,
   };
 });
 
@@ -80,6 +88,6 @@ vi.mock('../components/toast/ToastProvider', () => {
       addToast: vi.fn(),
       removeToast: vi.fn(),
     }),
-    ToastProvider: ({ children }: any) => children,
+    ToastProvider: ({ children }: TestProviderProps) => children,
   };
 });

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -6,6 +6,7 @@ interface ImportMetaEnv {
   readonly VITE_RPC_URL: string;
   readonly VITE_NETWORK: string;
   readonly VITE_USE_MOCKS: string;
+  readonly VITE_DEMO_MODE?: string;
   readonly VITE_TX_POLL_INTERVAL_MS?: string;
   readonly VITE_TX_POLL_MAX_ATTEMPTS?: string;
   readonly VITE_TX_POLL_BACKOFF_FACTOR?: string;


### PR DESCRIPTION
Closes #250

## Summary
- adds a typed `streamsService` layer for treasury metrics, stream lists, stream detail, and recipient stream lookups
- keeps mock data behind `VITE_USE_MOCKS` while live mode fails closed when `VITE_API_URL` is missing or the API returns non-2xx
- normalizes/sanitizes API/RPC payloads into `StreamRecord` and adapts them into treasury/recipient UI shapes
- wires Dashboard, Streams, Recipient, and treasury overview through the hook/service data path instead of direct fixture imports

## Validation
- `npm.cmd run test -- src\\lib\\api\\__tests__\\streamsService.test.ts src\\pages\\Streams.test.tsx src\\components\\__tests__\\RecipientStreams.test.tsx src\\pages\\Dashboard.test.tsx src\\pages\\Recipient.test.tsx src\\components\\treasuryOverviewPage\\__tests__\\demoMode.test.tsx` passed 31 tests across 6 files
- `node.exe .\\node_modules\\eslint\\bin\\eslint.js --no-warn-ignored src\\lib\\api\\streamsService.ts src\\data\\streamRecords.ts src\\components\\treasuryOverviewPage\\useTreasury.ts src\\components\\treasuryOverviewPage\\useTreasuryOverviewData.ts src\\pages\\Streams.tsx src\\pages\\Dashboard.tsx src\\pages\\Recipient.tsx src\\components\\recipient\\RecipientStreams.tsx src\\vite-env.d.ts src\\test\\setup.ts eslint.config.js` passed
- `node.exe .\\node_modules\\typescript\\bin\\tsc --noEmit --pretty false 2>&1 | Select-String -Pattern 'streamsService|useTreasury|useTreasuryOverviewData|Streams|Dashboard|Recipient|RecipientStreams|streamRecords|vite-env|test/setup|eslint.config'` produced no matching errors
- `git diff --check` passed

## Security
- API paths and URL params are encoded with `URL` / `URLSearchParams`
- non-2xx responses throw `StreamsServiceError` and clear UI data instead of rendering stale/unsafe payloads
- string fields are trimmed, length-bounded, control-character stripped, and angle brackets removed before rendering
- numeric fields are finite/non-negative with bounded progress values