### PR TITLE
Preserve fractional USDC precision in stream amounts

### DIFF
--- a/src/lib/usdc.test.ts
+++ b/src/lib/usdc.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { formatUsdc } from "./usdc";
+
+describe("formatUsdc", () => {
+  it("keeps fractional USDC amounts instead of rounding to whole units", () => {
+    expect(formatUsdc(1234.56)).toBe("1,234.56 USDC");
+  });
+
+  it("preserves micro-USDC precision", () => {
+    expect(formatUsdc(0.000001)).toBe("0.000001 USDC");
+  });
+
+  it("omits unnecessary trailing decimal places", () => {
+    expect(formatUsdc(10)).toBe("10 USDC");
+    expect(formatUsdc(1000000.5)).toBe("1,000,000.5 USDC");
+  });
+});

--- a/src/lib/usdc.ts
+++ b/src/lib/usdc.ts
@@ -1,0 +1,8 @@
+const USDC_FRACTION_DIGITS = 6;
+
+export function formatUsdc(value: number) {
+  return `${new Intl.NumberFormat("en-US", {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: USDC_FRACTION_DIGITS,
+  }).format(value)} USDC`;
+}

--- a/src/pages/Streams.tsx
+++ b/src/pages/Streams.tsx
@@ -34,6 +34,7 @@ import {
   formatDetailTime,
   getUrgencyLevel,
 } from "../lib/timePresentation";
+import { formatUsdc } from "../lib/usdc";
 import { useLiveAnnouncer } from "../hooks/useLiveAnnouncer";
 import { usePrefersReducedMotion } from "../hooks/usePrefersReducedMotion";
 import "./Streams.css";
@@ -47,12 +48,6 @@ const DISCLOSURE_DURATION_MS = 200;
 const FILTER_ANNOUNCEMENT_DELAY_MS = 300;
 const STREAMS_VIRTUALIZATION_THRESHOLD = 20;
 const STREAM_CARD_ESTIMATED_HEIGHT = 420;
-
-function formatUsdc(value: number) {
-  return `${new Intl.NumberFormat("en-US", {
-    maximumFractionDigits: 0,
-  }).format(value)} USDC`;
-}
 
 function formatMonthlyRate(value: number) {
   return `${formatUsdc(value)} / mo`;


### PR DESCRIPTION
## Summary
- Fixes `formatUsdc` so fractional USDC values render with up to 6 decimal places instead of rounding to whole units.
- Moves USDC formatting into `src/lib/usdc.ts` for focused regression coverage.
- Adds tests for whole, fractional, and micro-USDC values.

Fixes #362.

## Validation
- `node node_modules/vitest/vitest.mjs run src/lib/usdc.test.ts` - 3 tests passed
- `node node_modules/typescript/bin/tsc -b` - passed
- `node node_modules/vite/bin/vite.js build` - passed; existing circular chunk warning only
- `git diff --check` - passed

## Payout
GrantFox / crypto payout address: `0xE4D2C448c32f982B03eb5f3947b77f58BE2965Ef`