### PR TITLE
Validate cliff date before stream end

### DIFF
--- a/src/components/CreateStreamModal.tsx
+++ b/src/components/CreateStreamModal.tsx
@@ -11,8 +11,11 @@ import { createStream, getTransactionStatus } from '../lib/stellar/tx';
 import { isValidStellarAddress, maskAddress } from '../lib/stellar';
 import {
   formatLocalDateTime,
+  getStreamEndDate,
+  isAfterStreamEndDateTime,
   isBeforeLocalDateTime,
   isDateTimeInPast,
+  parseLocalDateTime,
 } from '../lib/createStreamDates';
 
 const USDC_DECIMAL_PLACES = 7;
@@ -195,6 +198,12 @@ export default function CreateStreamModal({
     setHasCompletedConfirmation(false);
   };
 
+  const getScheduleStartDate = (): Date | null => {
+    return startTimeOption === "now"
+      ? new Date()
+      : parseLocalDateTime(customStartDate);
+  };
+
   const validateStep1 = (): boolean => {
     if (!recipient.trim()) {
       setError("Recipient is required.");
@@ -267,6 +276,13 @@ export default function CreateStreamModal({
           return false;
         }
       }
+      const scheduleStartDate = getScheduleStartDate();
+      if (
+        scheduleStartDate &&
+        isAfterStreamEndDateTime(cliffDate, scheduleStartDate, durationValue)
+      ) {
+        return false;
+      }
     }
     return true;
   };
@@ -313,13 +329,18 @@ export default function CreateStreamModal({
       const parsedAmount = parseFloat(depositAmount.replace(/,/g, "")) || 0;
       const amountStr = Math.floor(parsedAmount * 10_000_000).toString();
 
-      const start = startTimeOption === "now"
-        ? Math.floor(Date.now() / 1000)
-        : Math.floor(new Date(customStartDate).getTime() / 1000);
-
+      const streamStartDate = getScheduleStartDate();
       const durationDays = parseFloat(duration) || 0;
-      const durationSeconds = Math.floor(durationDays * 24 * 60 * 60);
-      const end = start + durationSeconds;
+      const streamEndDate = streamStartDate
+        ? getStreamEndDate(streamStartDate, durationDays)
+        : null;
+      if (!streamStartDate || !streamEndDate) {
+        setError("Please enter a valid stream schedule.");
+        return;
+      }
+
+      const start = Math.floor(streamStartDate.getTime() / 1000);
+      const end = Math.floor(streamEndDate.getTime() / 1000);
 
       try {
         const response = await createStream(
@@ -565,6 +586,9 @@ export default function CreateStreamModal({
             : undefined;
           const customStartDateSuccess = startTimeOption === 'custom' && touched.customStartDate && !customStartDateError && Boolean(customStartDate);
 
+          const scheduleStartDate = startTimeOption === 'custom'
+            ? parseLocalDateTime(customStartDate)
+            : new Date();
           const cliffDateError = (cliffEnabled && touched.cliffDate)
             ? (!cliffDate
                 ? 'Cliff date is required.'
@@ -572,6 +596,8 @@ export default function CreateStreamModal({
                 ? 'Cliff date must not be in the past.'
                 : (startTimeOption === 'custom' && customStartDate && isBeforeLocalDateTime(cliffDate, customStartDate))
                 ? 'Cliff date must be on or after the start date.'
+                : (scheduleStartDate && isAfterStreamEndDateTime(cliffDate, scheduleStartDate, durationValue))
+                ? 'Cliff date must be on or before the stream end date.'
                 : undefined)
             : undefined;
           const cliffDateSuccess = cliffEnabled && touched.cliffDate && !cliffDateError && Boolean(cliffDate);

--- a/src/components/__tests__/CreateStreamModal.dates.test.tsx
+++ b/src/components/__tests__/CreateStreamModal.dates.test.tsx
@@ -84,4 +84,52 @@ describe("CreateStreamModal date consistency", () => {
       screen.getByText("Cliff date must be on or after the start date."),
     ).toBeInTheDocument();
   });
+
+  it("rejects a cliff datetime after the computed stream end", () => {
+    const { container } = renderStep2();
+
+    fireEvent.click(screen.getByRole("button", { name: /custom date/i }));
+    fireEvent.change(
+      container.querySelector("#create-stream-custom-start-date") as HTMLInputElement,
+      { target: { value: "2026-06-20T14:00" } },
+    );
+    fireEvent.change(
+      container.querySelector("#create-stream-duration") as HTMLInputElement,
+      { target: { value: "1" } },
+    );
+    fireEvent.click(screen.getByText(/enable cliff/i));
+    fireEvent.change(
+      container.querySelector("#create-stream-cliff-date") as HTMLInputElement,
+      { target: { value: "2026-06-21T14:01" } },
+    );
+    goToReview(container);
+
+    expect(
+      screen.getByText("Cliff date must be on or before the stream end date."),
+    ).toBeInTheDocument();
+  });
+
+  it("allows a cliff datetime exactly at the computed stream end", () => {
+    const { container } = renderStep2();
+
+    fireEvent.click(screen.getByRole("button", { name: /custom date/i }));
+    fireEvent.change(
+      container.querySelector("#create-stream-custom-start-date") as HTMLInputElement,
+      { target: { value: "2026-06-20T14:00" } },
+    );
+    fireEvent.change(
+      container.querySelector("#create-stream-duration") as HTMLInputElement,
+      { target: { value: "1" } },
+    );
+    fireEvent.click(screen.getByText(/enable cliff/i));
+    fireEvent.change(
+      container.querySelector("#create-stream-cliff-date") as HTMLInputElement,
+      { target: { value: "2026-06-21T14:00" } },
+    );
+    goToReview(container);
+
+    expect(
+      within(container).getByRole("button", { name: /^create stream$/i }),
+    ).toBeInTheDocument();
+  });
 });

--- a/src/lib/createStreamDates.ts
+++ b/src/lib/createStreamDates.ts
@@ -4,6 +4,8 @@
  * This keeps start and cliff inputs in one representation and avoids mixing
  * date-only strings, which JavaScript parses as UTC in some environments.
  */
+const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000;
+
 export function parseLocalDateTime(value: string): Date | null {
   if (!value.trim()) return null;
 
@@ -27,6 +29,42 @@ export function isBeforeLocalDateTime(
   const anchorDate = parseLocalDateTime(anchor);
   if (!candidateDate || !anchorDate) return true;
   return candidateDate.getTime() < anchorDate.getTime();
+}
+
+/**
+ * Computes the stream end from a validated local start datetime and duration.
+ * Invalid starts or non-positive durations return null so callers fail closed.
+ */
+export function getStreamEndDate(
+  startDate: Date,
+  durationDays: number,
+): Date | null {
+  const startTime = startDate.getTime();
+  if (
+    !Number.isFinite(startTime) ||
+    !Number.isFinite(durationDays) ||
+    durationDays <= 0
+  ) {
+    return null;
+  }
+
+  return new Date(startTime + durationDays * MILLISECONDS_PER_DAY);
+}
+
+/**
+ * Returns true when a cliff falls after the computed stream end date.
+ * Equality is allowed because funds can be claimed once the stream completes.
+ */
+export function isAfterStreamEndDateTime(
+  cliffValue: string,
+  startDate: Date,
+  durationDays: number,
+): boolean {
+  const cliffDate = parseLocalDateTime(cliffValue);
+  const endDate = getStreamEndDate(startDate, durationDays);
+  if (!cliffDate || !endDate) return true;
+
+  return cliffDate.getTime() > endDate.getTime();
 }
 
 /** Formats a local datetime string for the review step without changing zones. */


### PR DESCRIPTION
## Summary
- Adds a shared stream end-date helper in `createStreamDates.ts` so validation and submit-time timestamps use the same schedule math.
- Rejects enabled cliff dates that fall after the computed stream end while allowing `cliff === end`.
- Adds focused modal date tests for the invalid after-end case and the valid exact-end boundary.

Fixes #354.

## Validation
- `node node_modules/vitest/vitest.mjs run src/components/__tests__/CreateStreamModal.dates.test.tsx` - 5 tests passed
- `node node_modules/typescript/bin/tsc -b` - passed
- `node node_modules/vite/bin/vite.js build` - passed; existing circular chunk warning only
- `git diff --check` - passed

## Payout
GrantFox / crypto payout address: `0xE4D2C448c32f982B03eb5f3947b77f58BE2965Ef`