### PR TITLE
Memoize breadcrumb labels and address checks

### DIFF
--- a/src/components/navigation/AppNavbar.tsx
+++ b/src/components/navigation/AppNavbar.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { Menu, X, Moon, Sun } from "lucide-react";
 import { useWallet } from "../wallet-connect/Walletcontext";
@@ -28,6 +28,12 @@ const APP_SECONDARY_LINKS: { to: string; label: string }[] = [
   // Settings and Help go here when added
   // { to: "/app/settings", label: "Settings" },
 ];
+
+const BREADCRUMB_LABELS: Record<string, string> = {
+  streams: "Streams",
+  recipient: "Recipient",
+  treasury: "Treasury",
+};
 
 function FluxoraLogo({ connected }: { connected: boolean }) {
   return (
@@ -92,17 +98,11 @@ function ConnectingSkeleton() {
  * Build breadcrumb items from the current pathname.
  * e.g. /app/streams/STR-001 → [Streams, STR-001]
  */
-function useBreadcrumbs(pathname: string): BreadcrumbItem[] {
+function buildBreadcrumbs(pathname: string): BreadcrumbItem[] {
   if (!pathname.startsWith("/app")) return [];
 
   const segments = pathname.replace("/app", "").split("/").filter(Boolean);
   if (segments.length === 0) return [];
-
-  const labelMap: Record<string, string> = {
-    streams: "Streams",
-    recipient: "Recipient",
-    treasury: "Treasury",
-  };
 
   const items: BreadcrumbItem[] = [];
   let accumulatedPath = "/app";
@@ -111,7 +111,7 @@ function useBreadcrumbs(pathname: string): BreadcrumbItem[] {
     accumulatedPath += `/${segment}`;
     const isLast = index === segments.length - 1;
     items.push({
-      label: labelMap[segment] ?? segment,
+      label: BREADCRUMB_LABELS[segment] ?? segment,
       to: isLast ? undefined : accumulatedPath,
     });
   });
@@ -142,9 +142,12 @@ export default function AppNavbar({
     return () => clearTimeout(t);
   }, []);
 
-const location = useLocation();
+  const location = useLocation();
   const isAppView = connected && location.pathname.startsWith("/app");
-  const breadcrumbs = useBreadcrumbs(location.pathname);
+  const breadcrumbs = useMemo(
+    () => buildBreadcrumbs(location.pathname),
+    [location.pathname],
+  );
   const showBreadcrumb = isAppView && breadcrumbs.length > 1;
   const links = connected ? APP_PRIMARY_LINKS : ANON_LINKS;
 

--- a/src/components/navigation/Breadcrumb.tsx
+++ b/src/components/navigation/Breadcrumb.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { Link } from "react-router-dom";
 import { isValidStellarAddress, maskAddress } from "../../lib/stellar";
 
@@ -8,6 +9,17 @@ export interface BreadcrumbItem {
 
 interface BreadcrumbProps {
   items: BreadcrumbItem[];
+}
+
+const stellarAddressValidationCache = new Map<string, boolean>();
+
+function isCachedStellarAddress(label: string): boolean {
+  const cached = stellarAddressValidationCache.get(label);
+  if (cached !== undefined) return cached;
+
+  const isAddress = isValidStellarAddress(label);
+  stellarAddressValidationCache.set(label, isAddress);
+  return isAddress;
 }
 
 /**
@@ -26,6 +38,19 @@ interface BreadcrumbProps {
  * WCAG 2.1 AA: 4.5:1 text contrast, 3:1 focus ring contrast
  */
 export default function Breadcrumb({ items }: BreadcrumbProps) {
+  const displayItems = useMemo(
+    () =>
+      items.map((item) => {
+        const isStellarAddress = isCachedStellarAddress(item.label);
+        return {
+          ...item,
+          displayLabel: isStellarAddress ? maskAddress(item.label) : item.label,
+          isStellarAddress,
+        };
+      }),
+    [items],
+  );
+
   if (items.length === 0) return null;
 
   return (
@@ -42,12 +67,8 @@ export default function Breadcrumb({ items }: BreadcrumbProps) {
           flexWrap: "wrap",
         }}
       >
-        {items.map((item, index) => {
-          const isLast = index === items.length - 1;
-          const isStellarAddress = isValidStellarAddress(item.label);
-          const displayLabel = isStellarAddress
-            ? maskAddress(item.label)
-            : item.label;
+        {displayItems.map((item, index) => {
+          const isLast = index === displayItems.length - 1;
 
           return (
             <li
@@ -56,9 +77,9 @@ export default function Breadcrumb({ items }: BreadcrumbProps) {
             >
               {isLast || !item.to ? (
                 <span
-                  aria-label={isStellarAddress ? item.label : undefined}
+                  aria-label={item.isStellarAddress ? item.label : undefined}
                   aria-current={isLast ? "page" : undefined}
-                  title={isStellarAddress ? item.label : undefined}
+                  title={item.isStellarAddress ? item.label : undefined}
                   style={{
                     color: isLast
                       ? "var(--breadcrumb-color-current)"
@@ -70,16 +91,16 @@ export default function Breadcrumb({ items }: BreadcrumbProps) {
                     whiteSpace: "nowrap",
                   }}
                 >
-                  {displayLabel}
+                  {item.displayLabel}
                 </span>
               ) : (
                 <Link
                   to={item.to}
-                  aria-label={isStellarAddress ? item.label : undefined}
-                  title={isStellarAddress ? item.label : undefined}
+                  aria-label={item.isStellarAddress ? item.label : undefined}
+                  title={item.isStellarAddress ? item.label : undefined}
                   className="breadcrumb-link"
                 >
-                  {displayLabel}
+                  {item.displayLabel}
                 </Link>
               )}
 

--- a/src/components/navigation/__tests__/AppNavbar.breadcrumbs.test.tsx
+++ b/src/components/navigation/__tests__/AppNavbar.breadcrumbs.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+import AppNavbar from "../AppNavbar";
+
+const VALID_STELLAR =
+  "GATDOSCZNJ5YZHNOX7IOD4QDCQSTMR2YNF5IXHFNX3H6B4ICCMSDLOWN";
+
+vi.mock("../../wallet-connect/Walletcontext", () => ({
+  useWallet: () => ({
+    connected: true,
+    address: VALID_STELLAR,
+    network: "TESTNET",
+    expectedNetwork: "TESTNET",
+    isNetworkMismatch: false,
+    disconnect: vi.fn(),
+  }),
+}));
+
+vi.mock("../../../theme/ThemeProvider", () => ({
+  useTheme: () => ({
+    theme: "light",
+    toggleTheme: vi.fn(),
+  }),
+}));
+
+describe("AppNavbar breadcrumbs", () => {
+  it("preserves route labels and Stellar address masking on deep app routes", () => {
+    render(
+      <MemoryRouter initialEntries={[`/app/streams/${VALID_STELLAR}`]}>
+        <AppNavbar />
+      </MemoryRouter>,
+    );
+
+    const breadcrumb = screen.getByRole("navigation", { name: "Breadcrumb" });
+    expect(within(breadcrumb).getByRole("link", { name: "Streams" })).toHaveAttribute(
+      "href",
+      "/app/streams",
+    );
+
+    const currentPage = within(breadcrumb).getByLabelText(VALID_STELLAR);
+    expect(currentPage).toHaveTextContent(
+      `${VALID_STELLAR.slice(0, 8)}...${VALID_STELLAR.slice(-4)}`,
+    );
+    expect(currentPage).toHaveAttribute("aria-current", "page");
+    expect(currentPage).toHaveAttribute("title", VALID_STELLAR);
+  });
+});


### PR DESCRIPTION
## Summary
- Hoists the breadcrumb route label map out of the breadcrumb builder so it is not recreated per call.
- Memoizes breadcrumb generation by pathname in `AppNavbar`.
- Memoizes/caches per-label Stellar address validation in `Breadcrumb` while preserving address masking and full-label assistive context.
- Adds a focused navbar breadcrumb regression test for the `Streams / masked Stellar address` route.

Fixes #374.

## Validation
- `node node_modules/vitest/vitest.mjs run src/components/navigation/__tests__/Breadcrumb.test.tsx src/components/navigation/__tests__/Breadcrumb.stellar.test.tsx src/components/navigation/__tests__/AppNavbar.breadcrumbs.test.tsx` - 7 tests passed; jsdom emitted the existing canvas getContext warning
- `node node_modules/typescript/bin/tsc -b` - passed
- `node node_modules/vite/bin/vite.js build` - passed; existing circular chunk warning only
- `git diff --check` - passed

## Payout
GrantFox / crypto payout address: `0xE4D2C448c32f982B03eb5f3947b77f58BE2965Ef`