### PR TITLE
Normalize pagination totals and page inputs

### DIFF
--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -26,6 +26,14 @@ function clampPage(page: number, totalPages: number): number {
   return Math.min(Math.max(Math.trunc(page), 1), totalPages);
 }
 
+/**
+ * Normalizes untrusted upstream item counts before page math or display.
+ */
+function normalizeTotalItems(totalItems: number): number {
+  if (!Number.isFinite(totalItems)) return 0;
+  return Math.max(0, Math.floor(totalItems));
+}
+
 function getPageTokens(currentPage: number, totalPages: number): PageToken[] {
   if (totalPages <= 1) return [1];
 
@@ -58,16 +66,18 @@ export const Pagination: React.FC<PaginationProps> = ({
   onPageChange,
   onItemsPerPageChange,
 }) => {
-  if (totalItems === 0) return null;
+  const safeTotalItems = normalizeTotalItems(totalItems);
+
+  if (safeTotalItems === 0) return null;
 
   const safeItemsPerPage =
     Number.isFinite(itemsPerPage) && itemsPerPage > 0
       ? Math.trunc(itemsPerPage)
       : PAGE_SIZE_OPTIONS[0];
-  const totalPages = Math.max(1, Math.ceil(totalItems / safeItemsPerPage));
+  const totalPages = Math.max(1, Math.ceil(safeTotalItems / safeItemsPerPage));
   const safeCurrentPage = clampPage(currentPage, totalPages);
   const startItem = (safeCurrentPage - 1) * safeItemsPerPage + 1;
-  const endItem = Math.min(safeCurrentPage * safeItemsPerPage, totalItems);
+  const endItem = Math.min(safeCurrentPage * safeItemsPerPage, safeTotalItems);
   const pageTokens = getPageTokens(safeCurrentPage, totalPages);
 
   const requestPageChange = (page: number) => {
@@ -86,7 +96,7 @@ export const Pagination: React.FC<PaginationProps> = ({
       <div className="pagination-info" aria-live="polite" aria-atomic="true">
         Showing <span className="highlight">{startItem}</span> -{" "}
         <span className="highlight">{endItem}</span> of{" "}
-        <span className="highlight">{totalItems}</span> streams
+        <span className="highlight">{safeTotalItems}</span> streams
       </div>
 
       <div className="pagination-controls">

--- a/src/components/__tests__/Pagination.test.tsx
+++ b/src/components/__tests__/Pagination.test.tsx
@@ -107,9 +107,41 @@ describe("Pagination", () => {
     expect(pageButtonNames()).toEqual(["1", "2", "3", "4"]);
   });
 
-  it("does not render when there are no items", () => {
+  it("does not render when there are no items or the total is negative", () => {
     const { container } = renderPagination({ totalItems: 0 });
 
     expect(container).toBeEmptyDOMElement();
+
+    const negative = renderPagination({ totalItems: -12 });
+    expect(negative.container).toBeEmptyDOMElement();
+  });
+
+  it("floors fractional totals before computing and displaying the page range", () => {
+    renderPagination({ currentPage: 2, totalItems: 25.9, itemsPerPage: 10 });
+
+    const info = document.querySelector(".pagination-info");
+    expect(info).toHaveTextContent("Showing 11 - 20 of 25 streams");
+    expect(info).not.toHaveTextContent("25.9");
+    expect(screen.getByRole("button", { name: "Page 2" })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+    expect(pageButtonNames()).toEqual(["1", "2", "3"]);
+  });
+
+  it("floors fractional page inputs and keeps navigation callbacks in range", () => {
+    const { onPageChange } = renderPagination({
+      currentPage: 2.9,
+      totalItems: 50,
+      itemsPerPage: 10,
+    });
+
+    expect(screen.getByRole("button", { name: "Page 2" })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Previous page" }));
+    expect(onPageChange).toHaveBeenCalledWith(1);
   });
 });


### PR DESCRIPTION
## Summary
- normalize untrusted `totalItems` before pagination math and display
- clamp negative/non-finite totals to an empty state and floor fractional totals
- add coverage for negative totals, fractional totals, and fractional current page inputs

## Validation
- `node node_modules/vitest/vitest.mjs run src/components/__tests__/Pagination.test.tsx` (11 tests passed)
- `node node_modules/typescript/bin/tsc -b`
- `node node_modules/vite/bin/vite.js build`

## Security notes
No new external inputs or logging were added; the change only normalizes numeric props before rendering.

Closes #369