### PR TITLE
Use segment-aware active matching for nav links

### DIFF
--- a/src/components/navigation/NavLink.tsx
+++ b/src/components/navigation/NavLink.tsx
@@ -7,7 +7,27 @@ interface NavLinkProps {
   icon?: React.ReactNode;
   onClick?: () => void;
   disabled?: boolean;
-    variant?: "primary" | "secondary"; // added
+  variant?: "primary" | "secondary";
+  end?: boolean;
+}
+
+function normalizePath(path: string): string {
+  if (path === "/") return path;
+  return path.replace(/\/+$/, "") || "/";
+}
+
+/**
+ * Matches navigation links on complete path segments instead of raw prefixes.
+ */
+function isPathActive(pathname: string, to: string, end = false): boolean {
+  const currentPath = normalizePath(pathname);
+  const targetPath = normalizePath(to);
+
+  if (targetPath === "/" || end) {
+    return currentPath === targetPath;
+  }
+
+  return currentPath === targetPath || currentPath.startsWith(`${targetPath}/`);
 }
 
 /**
@@ -29,10 +49,11 @@ export default function NavLink({
   icon,
   onClick,
   disabled = false,
-  variant = "primary", //added
+  variant = "primary",
+  end = false,
 }: NavLinkProps) {
   const { pathname } = useLocation();
-  const isActive = pathname === to || (to !== "/" && pathname.startsWith(to));
+  const isActive = isPathActive(pathname, to, end);
 
   return (
     <Link

--- a/src/components/navigation/__tests__/NavLink.test.tsx
+++ b/src/components/navigation/__tests__/NavLink.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import NavLink from "../NavLink";
+
+function renderNavLink(pathname: string, props: Partial<Parameters<typeof NavLink>[0]> = {}) {
+  render(
+    <MemoryRouter initialEntries={[pathname]}>
+      <NavLink to="/app/streams" label="Streams" {...props} />
+    </MemoryRouter>,
+  );
+
+  return screen.getByRole("link", { name: props.label ?? "Streams" });
+}
+
+describe("NavLink", () => {
+  it("marks exact route matches as current", () => {
+    const link = renderNavLink("/app/streams");
+
+    expect(link).toHaveAttribute("aria-current", "page");
+  });
+
+  it("keeps nested detail routes active by path segment", () => {
+    const link = renderNavLink("/app/streams/123");
+
+    expect(link).toHaveAttribute("aria-current", "page");
+  });
+
+  it("does not activate sibling routes that only share a prefix", () => {
+    const link = renderNavLink("/app/stream");
+
+    expect(link).not.toHaveAttribute("aria-current");
+  });
+
+  it("normalizes trailing slashes before matching", () => {
+    const link = renderNavLink("/app/streams/", { to: "/app/streams/" });
+
+    expect(link).toHaveAttribute("aria-current", "page");
+  });
+
+  it("supports exact matching for index-style links", () => {
+    const link = renderNavLink("/app/streams/123", { end: true });
+
+    expect(link).not.toHaveAttribute("aria-current");
+  });
+});


### PR DESCRIPTION
## Summary
- replace raw `startsWith` active matching with segment-aware path matching
- add an `end` option for exact/index-style navigation links
- add focused tests for exact routes, nested detail routes, sibling prefix collisions, trailing slashes, and exact mode

## Validation
- `node node_modules/vitest/vitest.mjs run src/components/navigation/__tests__/NavLink.test.tsx` (5 tests passed)
- `node node_modules/typescript/bin/tsc -b`
- `node node_modules/vite/bin/vite.js build`

## Security notes
No new external inputs or side effects were added; this only changes local pathname matching.

Closes #365