### PR TITLE
Map toast variants to explicit aria semantics

### DIFF
--- a/src/components/ToastNotification.tsx
+++ b/src/components/ToastNotification.tsx
@@ -4,7 +4,7 @@ export type ToastVariant = "success" | "error" | "info" | "warning";
 
 interface ToastNotificationProps {
   message: string;
-  variant: ToastVariant;
+  variant: ToastVariant | (string & {});
   onClose: () => void;
 }
 
@@ -15,21 +15,73 @@ const TOAST_COPY: Record<ToastVariant, { label: string; icon: string }> = {
   warning: { label: "Warning", icon: "⚠" },
 };
 
+type ToastSemantics = {
+  role: "alert" | "status";
+  "aria-live": "assertive" | "polite";
+};
+
+/**
+ * Known variants map to explicit announcement semantics; unknown variants
+ * fail safe as assertive warnings so error-like messages are not missed.
+ */
+const TOAST_PRESENTATION: Record<
+  ToastVariant,
+  { copy: { label: string; icon: string }; semantics: ToastSemantics; classVariant: ToastVariant }
+> = {
+  success: {
+    copy: TOAST_COPY.success,
+    semantics: { role: "status", "aria-live": "polite" },
+    classVariant: "success",
+  },
+  info: {
+    copy: TOAST_COPY.info,
+    semantics: { role: "status", "aria-live": "polite" },
+    classVariant: "info",
+  },
+  warning: {
+    copy: TOAST_COPY.warning,
+    semantics: { role: "alert", "aria-live": "assertive" },
+    classVariant: "warning",
+  },
+  error: {
+    copy: TOAST_COPY.error,
+    semantics: { role: "alert", "aria-live": "assertive" },
+    classVariant: "error",
+  },
+};
+
+const UNKNOWN_TOAST_PRESENTATION = {
+  copy: { label: "Notification", icon: "!" },
+  semantics: { role: "alert", "aria-live": "assertive" },
+  classVariant: "warning",
+} satisfies {
+  copy: { label: string; icon: string };
+  semantics: ToastSemantics;
+  classVariant: ToastVariant;
+};
+
+function getToastPresentation(variant: ToastVariant | (string & {})) {
+  return TOAST_PRESENTATION[variant as ToastVariant] ?? UNKNOWN_TOAST_PRESENTATION;
+}
+
 export default function ToastNotification({
   message,
   variant,
   onClose,
 }: ToastNotificationProps) {
-  const semantics =
-    variant === "error" || variant === "warning"
-      ? { role: "alert" as const, "aria-live": "assertive" as const }
-      : { role: "status" as const, "aria-live": "polite" as const };
-
-  const { label, icon } = TOAST_COPY[variant];
+  const {
+    copy: { label, icon },
+    semantics,
+    classVariant,
+  } = getToastPresentation(variant);
+  const dismissLabel =
+    label === "Notification"
+      ? "Dismiss notification"
+      : `Dismiss ${label.toLowerCase()} notification`;
 
   return (
     <div
-      className={`toast-notification toast-notification--${variant}`}
+      className={`toast-notification toast-notification--${classVariant}`}
       aria-atomic="true"
       {...semantics}
     >
@@ -44,7 +96,7 @@ export default function ToastNotification({
         type="button"
         className="toast-notification__close"
         onClick={onClose}
-        aria-label={`Dismiss ${label.toLowerCase()} notification`}
+        aria-label={dismissLabel}
       >
         <span aria-hidden="true">×</span>
       </button>

--- a/src/components/__tests__/ToastNotification.test.tsx
+++ b/src/components/__tests__/ToastNotification.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import ToastNotification, { type ToastVariant } from "../ToastNotification";
+
+function renderToast(variant: ToastVariant | (string & {})) {
+  const onClose = vi.fn();
+  render(<ToastNotification message={`${variant} message`} variant={variant} onClose={onClose} />);
+  return { onClose };
+}
+
+describe("ToastNotification", () => {
+  it.each([
+    ["success", "Success"],
+    ["info", "Info"],
+  ] as const)("%s uses polite status semantics", (variant, label) => {
+    renderToast(variant);
+
+    const toast = screen.getByRole("status");
+    expect(toast).toHaveAttribute("aria-live", "polite");
+    expect(toast).toHaveAttribute("aria-atomic", "true");
+    expect(screen.getByText(label)).toBeInTheDocument();
+  });
+
+  it.each([
+    ["warning", "Warning"],
+    ["error", "Error"],
+  ] as const)("%s uses assertive alert semantics", (variant, label) => {
+    renderToast(variant);
+
+    const toast = screen.getByRole("alert");
+    expect(toast).toHaveAttribute("aria-live", "assertive");
+    expect(toast).toHaveAttribute("aria-atomic", "true");
+    expect(screen.getByText(label)).toBeInTheDocument();
+  });
+
+  it("fails safe to assertive alert semantics for unknown variants", () => {
+    renderToast("urgent");
+
+    const toast = screen.getByRole("alert");
+    expect(toast).toHaveAttribute("aria-live", "assertive");
+    expect(toast).toHaveClass("toast-notification--warning");
+    expect(screen.getByText("Notification")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Dismiss notification" })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- replace the toast variant ternary with an explicit presentation/ARIA mapping
- keep success/info as polite status notifications and warning/error as assertive alerts
- fail safe for unknown runtime variants by using assertive alert semantics with warning styling
- add focused ToastNotification coverage for all known variants plus an unknown variant

## Validation
- `node node_modules/vitest/vitest.mjs run src/components/__tests__/ToastNotification.test.tsx src/components/toast/__tests__/ToastProvider.test.tsx` (18 tests passed)
- `node node_modules/typescript/bin/tsc -b`
- `node node_modules/vite/bin/vite.js build`

## Security notes
No message HTML parsing, logging, or external side effects were added; unknown variants are normalized before CSS class selection.

Closes #378