### PR TITLE
Generate collision-resistant toast IDs

### DIFF
--- a/src/components/toast/ToastProvider.tsx
+++ b/src/components/toast/ToastProvider.tsx
@@ -31,6 +31,14 @@ const MAX_VISIBLE = 3;
 const DEFAULT_TIMEOUT = 4000;
 
 /**
+ * Builds toast IDs from a provider-local monotonic sequence so same-tick
+ * additions cannot collide even when clocks or random sources repeat.
+ */
+function createToastId(sequence: number): string {
+  return `toast-${sequence}`;
+}
+
+/**
  * ToastProvider — wraps the app and manages a stacked toast queue.
  *
  * @example
@@ -43,6 +51,7 @@ const DEFAULT_TIMEOUT = 4000;
 export function ToastProvider({ children }: { children: ReactNode }) {
   const [toasts, setToasts] = useState<Toast[]>([]);
   const timers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+  const nextToastId = useRef(0);
 
   const dismiss = useCallback((id: string) => {
     clearTimeout(timers.current.get(id));
@@ -52,7 +61,8 @@ export function ToastProvider({ children }: { children: ReactNode }) {
 
   const addToast = useCallback(
     (message: string, variant: ToastVariant, timeout = DEFAULT_TIMEOUT): string => {
-      const id = `toast-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+      const id = createToastId(nextToastId.current);
+      nextToastId.current += 1;
       setToasts((prev) => [...prev, { id, message, variant, timeout }]);
       const timer = setTimeout(() => dismiss(id), timeout);
       timers.current.set(id, timer);

--- a/src/components/toast/__tests__/ToastProvider.test.tsx
+++ b/src/components/toast/__tests__/ToastProvider.test.tsx
@@ -112,6 +112,69 @@ describe("ToastProvider / useToast", () => {
     expect(screen.queryByText("B")).not.toBeInTheDocument();
   });
 
+  it("returns unique IDs for same-tick additions and dismisses only the targeted toast", () => {
+    const returnedIds: string[] = [];
+
+    function SameTickAdder() {
+      const { addToast, dismiss } = useToast();
+      return (
+        <button
+          onClick={() => {
+            const firstId = addToast("Same tick A", "info", 99999);
+            const secondId = addToast("Same tick B", "info", 99999);
+            const thirdId = addToast("Same tick C", "info", 99999);
+            returnedIds.push(firstId, secondId, thirdId);
+            dismiss(secondId);
+          }}
+        >
+          same tick
+        </button>
+      );
+    }
+
+    renderWithProvider(<SameTickAdder />);
+    fireEvent.click(screen.getByRole("button", { name: /same tick/i }));
+
+    expect(new Set(returnedIds).size).toBe(3);
+    expect(screen.getByText("Same tick A")).toBeInTheDocument();
+    expect(screen.queryByText("Same tick B")).not.toBeInTheDocument();
+    expect(screen.getByText("Same tick C")).toBeInTheDocument();
+  });
+
+  it("allows dismiss to be invoked repeatedly for the same ID", () => {
+    let toastId = "";
+
+    function DoubleDismissButton() {
+      const { addToast, dismiss } = useToast();
+      return (
+        <>
+          <button
+            onClick={() => {
+              toastId = addToast("Dismiss me once", "success", 99999);
+            }}
+          >
+            add once
+          </button>
+          <button
+            onClick={() => {
+              dismiss(toastId);
+              dismiss(toastId);
+            }}
+          >
+            dismiss twice
+          </button>
+        </>
+      );
+    }
+
+    renderWithProvider(<DoubleDismissButton />);
+    fireEvent.click(screen.getByRole("button", { name: /add once/i }));
+    expect(screen.getByText("Dismiss me once")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /dismiss twice/i }));
+    expect(screen.queryByText("Dismiss me once")).not.toBeInTheDocument();
+  });
+
   it("caps visible toasts at 3 and shows overflow count", () => {
     function ManyAdder() {
       const { addToast } = useToast();


### PR DESCRIPTION
## Summary
- replace Date.now/random toast IDs with a provider-local monotonic ID sequence
- keep queue and MAX_VISIBLE behavior intact
- add coverage for same-tick additions, targeted dismiss, and repeated dismiss calls

## Validation
- `node node_modules/vitest/vitest.mjs run src/components/toast/__tests__/ToastProvider.test.tsx` (15 tests passed)
- `node node_modules/typescript/bin/tsc -b`
- `node node_modules/vite/bin/vite.js build`

## Security notes
No external randomness, logging, or user data exposure was added. IDs are local UI identifiers only.

Closes #377