### PR TITLE
Disable unavailable wallet provider options

### DIFF
--- a/src/components/ConnectWalletModal.module.css
+++ b/src/components/ConnectWalletModal.module.css
@@ -185,6 +185,22 @@
   box-shadow: none;
 }
 
+.walletOptionUnavailable {
+  cursor: not-allowed;
+  opacity: 0.72;
+}
+
+.walletOptionUnavailable:hover {
+  background: var(--surface-neutral);
+  border-color: var(--border-neutral);
+  box-shadow: none;
+  transform: none;
+}
+
+.walletOptionUnavailable .chevron {
+  display: none;
+}
+
 /* ═══════════════════════════════════════════════════════════
    WALLET OPTION INTERNALS
    ═══════════════════════════════════════════════════════════ */
@@ -216,6 +232,18 @@
   font: var(--font-body-sm);
   color: var(--color-text-tertiary);
   line-height: 1.4;
+}
+
+.walletUnavailableBadge {
+  display: inline-flex;
+  width: fit-content;
+  margin-top: var(--space-xs);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-full);
+  padding: 2px var(--space-sm);
+  color: var(--color-text-tertiary);
+  background: var(--color-bg-secondary);
+  font: var(--font-label-sm);
 }
 
 .chevron {

--- a/src/components/ConnectWalletModal.tsx
+++ b/src/components/ConnectWalletModal.tsx
@@ -29,7 +29,8 @@ interface WalletOption {
   name: string;
   description: string;
   icon: string;
-  action: () => void;
+  action?: () => void;
+  unavailableLabel?: string;
 }
 
 export default function ConnectWalletModal({
@@ -211,14 +212,16 @@ export default function ConnectWalletModal({
       name: "Albedo",
       description: "Open in-browser wallet for quick secure approvals.",
       icon: "⭐",
-      action: onConnectAlbedo ?? (() => {}),
+      action: onConnectAlbedo,
+      unavailableLabel: "Coming soon",
     },
     {
       id: "walletconnect",
       name: "WalletConnect",
       description: "Pair with compatible mobile wallets via QR.",
       icon: "🔗",
-      action: onConnectWalletConnect ?? (() => {}),
+      action: onConnectWalletConnect,
+      unavailableLabel: "Coming soon",
     },
   ];
 
@@ -277,15 +280,23 @@ export default function ConnectWalletModal({
 
             <div className={styles.walletList} role="list" aria-label="Wallet providers">
               {walletOptions.map((wallet) => {
+                const isUnavailable = !wallet.action;
                 const isActive =
-                  hoveredOptionId === wallet.id || focusedOptionId === wallet.id;
+                  !isUnavailable &&
+                  (hoveredOptionId === wallet.id || focusedOptionId === wallet.id);
+                const ariaLabel = isUnavailable
+                  ? `${wallet.name} unavailable. ${wallet.unavailableLabel}`
+                  : `Connect with ${wallet.name}`;
 
                 return (
                   <button
                     key={wallet.id}
                     type="button"
                     role="listitem"
-                    className={styles.walletOption}
+                    className={`${styles.walletOption} ${
+                      isUnavailable ? styles.walletOptionUnavailable : ""
+                    }`}
+                    disabled={isUnavailable}
                     style={{
                       background: isActive ? "var(--surface-elevated)" : "var(--surface-neutral)",
                       borderColor: isActive ? "var(--border-interactive)" : "var(--border-neutral)",
@@ -298,7 +309,7 @@ export default function ConnectWalletModal({
                     onMouseLeave={() => setHoveredOptionId(null)}
                     onFocus={() => setFocusedOptionId(wallet.id)}
                     onBlur={() => setFocusedOptionId(null)}
-                    aria-label={`Connect with ${wallet.name}`}
+                    aria-label={ariaLabel}
                   >
                     <div className={styles.walletIcon} aria-hidden="true">
                       {wallet.icon}
@@ -306,6 +317,11 @@ export default function ConnectWalletModal({
                     <div className={styles.walletInfo}>
                       <div className={styles.walletName}>{wallet.name}</div>
                       <div className={styles.walletDescription}>{wallet.description}</div>
+                      {isUnavailable && wallet.unavailableLabel && (
+                        <span className={styles.walletUnavailableBadge}>
+                          {wallet.unavailableLabel}
+                        </span>
+                      )}
                     </div>
                     <svg
                       className={styles.chevron}

--- a/src/components/__tests__/ConnectWalletModal.test.tsx
+++ b/src/components/__tests__/ConnectWalletModal.test.tsx
@@ -38,6 +38,41 @@ describe("ConnectWalletModal", () => {
     expect(screen.getByText(/By continuing, you agree to Fluxora's/)).toBeInTheDocument();
   });
 
+  it("disables unavailable wallet options instead of wiring no-op handlers", () => {
+    render(<ConnectWalletModal isOpen={true} onClose={onClose} />);
+
+    expect(screen.getByLabelText("Connect with Freighter")).toBeEnabled();
+    expect(screen.getByLabelText("Albedo unavailable. Coming soon")).toBeDisabled();
+    expect(screen.getByLabelText("WalletConnect unavailable. Coming soon")).toBeDisabled();
+    expect(screen.getAllByText("Coming soon")).toHaveLength(2);
+  });
+
+  it("enables optional wallet providers when handlers are supplied", async () => {
+    const onConnectAlbedo = vi.fn();
+    const onConnectWalletConnect = vi.fn();
+
+    render(
+      <ConnectWalletModal
+        isOpen={true}
+        onClose={onClose}
+        onConnectAlbedo={onConnectAlbedo}
+        onConnectWalletConnect={onConnectWalletConnect}
+      />,
+    );
+
+    const albedo = screen.getByLabelText("Connect with Albedo");
+    const walletConnect = screen.getByLabelText("Connect with WalletConnect");
+
+    expect(albedo).toBeEnabled();
+    expect(walletConnect).toBeEnabled();
+
+    await userEvent.click(albedo);
+    await userEvent.click(walletConnect);
+
+    expect(onConnectAlbedo).toHaveBeenCalledTimes(1);
+    expect(onConnectWalletConnect).toHaveBeenCalledTimes(1);
+  });
+
   it("calls onClose when close button is clicked", async () => {
     render(<ConnectWalletModal isOpen={true} onClose={onClose} />);
     const closeBtn = screen.getByLabelText("Close wallet connection dialog");


### PR DESCRIPTION
## Summary
- mark Albedo and WalletConnect unavailable when no connection handler is supplied
- remove no-op wallet actions and use disabled buttons with explicit accessible labels
- add a visible "Coming soon" badge and disabled styling for unavailable options
- keep optional provider handlers enabled when they are supplied

## Validation
- `node node_modules/vitest/vitest.mjs run src/components/__tests__/ConnectWalletModal.test.tsx` (11 tests passed)
- `node node_modules/typescript/bin/tsc -b`
- `node node_modules/vite/bin/vite.js build`

## Security notes
No wallet signing or external provider calls were added. Unavailable providers no longer trigger silent no-op clicks.

Closes #376