### PR TITLE
Surface wallet address copy failures

### DIFF
--- a/src/components/navigation/WalletStatus.tsx
+++ b/src/components/navigation/WalletStatus.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from "react";
-import { ChevronDown, Copy, ExternalLink, LogOut, Check } from "lucide-react";
+import { AlertCircle, ChevronDown, Copy, ExternalLink, LogOut, Check } from "lucide-react";
 import {
   isStellarNetworkMismatch,
   normalizeStellarNetwork,
@@ -14,6 +14,7 @@ interface WalletStatusProps {
   onDisconnect?: () => void;
 }
 
+type CopyState = "idle" | "copied" | "error";
 
 export default function WalletStatus({
   address,
@@ -23,7 +24,7 @@ export default function WalletStatus({
   onDisconnect,
 }: WalletStatusProps) {
   const [open, setOpen] = useState(false);
-  const [copied, setCopied] = useState(false);
+  const [copyState, setCopyState] = useState<CopyState>("idle");
   const [confirmingDisconnect, setConfirmingDisconnect] = useState(false);
   const [announcement, setAnnouncement] = useState("");
   const ref = useRef<HTMLDivElement>(null);
@@ -34,6 +35,36 @@ export default function WalletStatus({
   const networkUpper = normalizeStellarNetwork(network);
   const isWrongNetwork = isNetworkMismatch;
   const isTestnet = networkUpper === "TESTNET";
+
+  const fallbackCopyAddress = () => {
+    const textarea = document.createElement("textarea");
+    textarea.value = address;
+    textarea.setAttribute("readonly", "");
+    textarea.style.position = "fixed";
+    textarea.style.left = "-9999px";
+    textarea.style.opacity = "0";
+    document.body.appendChild(textarea);
+    textarea.select();
+
+    try {
+      return document.execCommand("copy");
+    } finally {
+      document.body.removeChild(textarea);
+    }
+  };
+
+  const copyAddress = async () => {
+    if (navigator.clipboard?.writeText) {
+      try {
+        await navigator.clipboard.writeText(address);
+        return true;
+      } catch {
+        return fallbackCopyAddress();
+      }
+    }
+
+    return fallbackCopyAddress();
+  };
 
   useEffect(() => {
     const close = (e: MouseEvent) => {
@@ -69,10 +100,19 @@ export default function WalletStatus({
 
   const handleCopy = async () => {
     try {
-      await navigator.clipboard.writeText(address);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1500);
-    } catch {}
+      const didCopy = await copyAddress();
+      if (!didCopy) {
+        throw new Error("Fallback copy command failed");
+      }
+
+      setCopyState("copied");
+      setAnnouncement("Wallet address copied.");
+      setTimeout(() => setCopyState("idle"), 1500);
+    } catch {
+      setCopyState("error");
+      setAnnouncement("Wallet address could not be copied.");
+      setTimeout(() => setCopyState("idle"), 3000);
+    }
   };
 
   const closeMenu = () => {
@@ -175,12 +215,18 @@ export default function WalletStatus({
                   onClick={handleCopy}
                   className={`flex items-center gap-2.5 w-full px-3 py-2 text-sm text-[var(--text)] rounded-lg hover:bg-[var(--surface)] transition-colors ${focusRingClassName}`}
                 >
-                  {copied ? (
+                  {copyState === "copied" ? (
                     <Check size={16} className="text-emerald-400" />
+                  ) : copyState === "error" ? (
+                    <AlertCircle size={16} className="text-red-400" />
                   ) : (
                     <Copy size={16} />
                   )}
-                  {copied ? "Copied!" : "Copy address"}
+                  {copyState === "copied"
+                    ? "Copied!"
+                    : copyState === "error"
+                      ? "Copy failed"
+                      : "Copy address"}
                 </button>
 
                 <button

--- a/src/components/navigation/__tests__/WalletStatus.test.tsx
+++ b/src/components/navigation/__tests__/WalletStatus.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import WalletStatus from "../WalletStatus";
+
+const ADDRESS = "GDU4D7EXAMPLEADDRESS0L50DR222222222222222222222222222222";
+
+function renderWalletStatus() {
+  render(<WalletStatus address={ADDRESS} network="TESTNET" />);
+}
+
+async function openWalletMenu() {
+  await userEvent.click(
+    screen.getByRole("button", {
+      name: /open wallet options/i,
+    }),
+  );
+}
+
+function mockClipboard(writeText?: ReturnType<typeof vi.fn>) {
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: writeText ? { writeText } : undefined,
+  });
+}
+
+function mockExecCommand(result: boolean) {
+  const execCommand = vi.fn().mockReturnValue(result);
+  Object.defineProperty(document, "execCommand", {
+    configurable: true,
+    value: execCommand,
+  });
+  return execCommand;
+}
+
+describe("WalletStatus", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: undefined,
+    });
+  });
+
+  it("shows copied feedback when the async clipboard succeeds", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    mockClipboard(writeText);
+
+    renderWalletStatus();
+    await openWalletMenu();
+    await userEvent.click(screen.getByRole("menuitem", { name: "Copy address" }));
+
+    expect(writeText).toHaveBeenCalledWith(ADDRESS);
+    expect(screen.getByRole("menuitem", { name: "Copied!" })).toBeInTheDocument();
+    expect(screen.getByText("Wallet address copied.")).toBeInTheDocument();
+  });
+
+  it("uses the textarea fallback when the async clipboard is unavailable", async () => {
+    mockClipboard();
+    const execCommand = mockExecCommand(true);
+
+    renderWalletStatus();
+    await openWalletMenu();
+    await userEvent.click(screen.getByRole("menuitem", { name: "Copy address" }));
+
+    expect(execCommand).toHaveBeenCalledWith("copy");
+    expect(screen.getByRole("menuitem", { name: "Copied!" })).toBeInTheDocument();
+  });
+
+  it("surfaces failure feedback when both copy paths fail", async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error("denied"));
+    mockClipboard(writeText);
+    mockExecCommand(false);
+
+    renderWalletStatus();
+    await openWalletMenu();
+    await userEvent.click(screen.getByRole("menuitem", { name: "Copy address" }));
+
+    expect(screen.getByRole("menuitem", { name: "Copy failed" })).toBeInTheDocument();
+    expect(screen.getByText("Wallet address could not be copied.")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add explicit copied/error copy state in WalletStatus instead of swallowing clipboard failures
- fall back to a temporary textarea + execCommand path when the Clipboard API is unavailable or denied
- announce copy success/failure through the existing live region without logging the address
- add focused tests for async clipboard success, fallback success, and full copy failure

## Validation
- `node node_modules/vitest/vitest.mjs run src/components/navigation/__tests__/WalletStatus.test.tsx` (3 tests passed)
- `node node_modules/typescript/bin/tsc -b`
- `node node_modules/vite/bin/vite.js build`

## Security notes
The full wallet address is never logged. The fallback textarea is temporary, readonly, visually hidden, and removed immediately after the copy attempt.

Closes #373