### PR TITLE
Replace sidebar placeholder utility links

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -87,8 +87,18 @@ export default function Sidebar({
   ];
 
   const utilityItems = [
-    { href: "#", label: "Documentation", icon: FileText },
-    { href: "#", label: "Legal", icon: Scale },
+    {
+      href: "https://github.com/Fluxora-Org/Fluxora-Frontend#readme",
+      label: "Documentation",
+      icon: FileText,
+      external: true,
+    },
+    {
+      href: "https://github.com/Fluxora-Org/Fluxora-Frontend/blob/main/docs/security.md",
+      label: "Legal",
+      icon: Scale,
+      external: true,
+    },
   ];
 
   return (
@@ -212,6 +222,8 @@ export default function Sidebar({
               <a
                 key={item.label}
                 href={item.href}
+                target={item.external ? "_blank" : undefined}
+                rel={item.external ? "noopener noreferrer" : undefined}
                 className="flex items-center gap-3 px-3 py-2 rounded-lg text-[var(--muted)] hover:bg-[var(--surface-elevated)] hover:text-[var(--text)] transition-all group outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
               >
                 <item.icon size={20} className="flex-shrink-0 group-hover:text-[var(--text)]" />

--- a/src/components/__tests__/Sidebar.test.tsx
+++ b/src/components/__tests__/Sidebar.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+import Sidebar from "../Sidebar";
+
+function renderSidebar() {
+  render(
+    <MemoryRouter>
+      <Sidebar
+        collapsed={false}
+        onToggleCollapse={vi.fn()}
+        mobileOpen={false}
+        onMobileClose={vi.fn()}
+      />
+    </MemoryRouter>,
+  );
+}
+
+describe("Sidebar", () => {
+  it("uses real external destinations for utility links", () => {
+    renderSidebar();
+
+    const documentation = screen.getByRole("link", { name: "Documentation" });
+    const legal = screen.getByRole("link", { name: "Legal" });
+
+    expect(documentation).toHaveAttribute(
+      "href",
+      "https://github.com/Fluxora-Org/Fluxora-Frontend#readme",
+    );
+    expect(legal).toHaveAttribute(
+      "href",
+      "https://github.com/Fluxora-Org/Fluxora-Frontend/blob/main/docs/security.md",
+    );
+    expect(documentation).not.toHaveAttribute("href", "#");
+    expect(legal).not.toHaveAttribute("href", "#");
+  });
+
+  it("marks external utility links as safe new-tab links", () => {
+    renderSidebar();
+
+    for (const label of ["Documentation", "Legal"]) {
+      const link = screen.getByRole("link", { name: label });
+      expect(link).toHaveAttribute("target", "_blank");
+      expect(link).toHaveAttribute("rel", "noopener noreferrer");
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- replace Sidebar Documentation and Legal placeholder # links with real GitHub destinations
- mark both utility links as safe external links with target="_blank" and rel="noopener noreferrer"
- add Sidebar tests for resolved hrefs and external-link safety attributes

## Validation
- `node node_modules/vitest/vitest.mjs run src/components/__tests__/Sidebar.test.tsx` (2 tests passed)
- `node node_modules/typescript/bin/tsc -b`
- `node node_modules/vite/bin/vite.js build`

## Security notes
External links use `noopener noreferrer` to avoid reverse-tabnabbing.

Closes #368