### PR TITLE
Validate API and RPC config URLs

### DIFF
--- a/src/lib/__tests__/config.test.ts
+++ b/src/lib/__tests__/config.test.ts
@@ -22,9 +22,9 @@ describe("config", () => {
   it("reads public env values without coercing empty strings into values", () => {
     const config = createConfig(
       env({
-        VITE_API_URL: "https://api.example.test",
+        VITE_API_URL: " https://api.example.test ",
         VITE_NETWORK: "PUBLIC",
-        VITE_RPC_URL: " ",
+        VITE_RPC_URL: "http://localhost:8000",
         VITE_STREAM_CONTRACT_ID: "CCONTRACT",
         VITE_USE_MOCKS: "true",
       }),
@@ -33,9 +33,41 @@ describe("config", () => {
     expect(config.apiUrl).toBe("https://api.example.test");
     expect(config.network).toBe("PUBLIC");
     expect(config.networkLabel).toBe("Public Network (Mainnet)");
-    expect(config.rpcUrl).toBeNull();
+    expect(config.rpcUrl).toBe("http://localhost:8000");
     expect(config.streamContractId).toBe("CCONTRACT");
     expect(config.useMocks).toBe(true);
+  });
+
+  it("preserves optional unset API and RPC URLs", () => {
+    const config = createConfig(
+      env({
+        VITE_API_URL: " ",
+        VITE_RPC_URL: undefined,
+      }),
+    );
+
+    expect(config.apiUrl).toBeNull();
+    expect(config.rpcUrl).toBeNull();
+  });
+
+  it("rejects malformed API and RPC URLs with field-specific errors", () => {
+    expect(() =>
+      createConfig(env({ VITE_API_URL: "not a url" })),
+    ).toThrow("VITE_API_URL must be a well-formed http(s) URL.");
+
+    expect(() =>
+      createConfig(env({ VITE_RPC_URL: "http://[invalid" })),
+    ).toThrow("VITE_RPC_URL must be a well-formed http(s) URL.");
+  });
+
+  it("rejects unsupported API and RPC URL protocols", () => {
+    expect(() =>
+      createConfig(env({ VITE_API_URL: "ftp://api.example.test" })),
+    ).toThrow("VITE_API_URL must use the http or https protocol.");
+
+    expect(() =>
+      createConfig(env({ VITE_RPC_URL: "javascript:alert(1)" })),
+    ).toThrow("VITE_RPC_URL must use the http or https protocol.");
   });
 
   it("fails closed to TESTNET for unsupported networks", () => {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -28,6 +28,29 @@ function optionalString(value: string | undefined): string | null {
   return trimmed ? trimmed : null;
 }
 
+function optionalHttpUrl(
+  value: string | undefined,
+  envName: "VITE_API_URL" | "VITE_RPC_URL",
+): string | null {
+  const trimmed = optionalString(value);
+  if (!trimmed) {
+    return null;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    throw new Error(`${envName} must be a well-formed http(s) URL.`);
+  }
+
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error(`${envName} must use the http or https protocol.`);
+  }
+
+  return trimmed;
+}
+
 export function parseBooleanFlag(value: string | undefined): boolean {
   return value === "true" || value === "1";
 }
@@ -44,11 +67,11 @@ export function createConfig(env: ImportMetaEnv): AppConfig {
   const network = getExpectedStellarNetwork(env.VITE_NETWORK);
 
   return {
-    apiUrl: optionalString(env.VITE_API_URL),
+    apiUrl: optionalHttpUrl(env.VITE_API_URL, "VITE_API_URL"),
     network,
     networkLabel: getNetworkLabel(network),
     networkPassphrase: getNetworkPassphrase(network),
-    rpcUrl: optionalString(env.VITE_RPC_URL),
+    rpcUrl: optionalHttpUrl(env.VITE_RPC_URL, "VITE_RPC_URL"),
     streamContractId: optionalString(env.VITE_STREAM_CONTRACT_ID),
     useMocks: parseBooleanFlag(env.VITE_USE_MOCKS),
   };


### PR DESCRIPTION
## Summary
- validate optional `VITE_API_URL` and `VITE_RPC_URL` values with the platform `URL` parser
- allow only `http:` and `https:` protocols while preserving unset/blank values as `null`
- add field-specific regression tests for valid URLs, blank values, malformed strings, and unsupported protocols

## Validation
- `node node_modules/vitest/vitest.mjs run src/lib/__tests__/config.test.ts` (7 tests passed)
- `node node_modules/typescript/bin/tsc -b`
- `node node_modules/vite/bin/vite.js build`

Closes #361