### PR TITLE
Validate stream contract config ID

### DIFF
--- a/src/lib/__tests__/config.test.ts
+++ b/src/lib/__tests__/config.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, it } from "vitest";
 import {
+  ConfigError,
   createConfig,
   getNetworkLabel,
   getNetworkPassphrase,
   parseBooleanFlag,
 } from "../config";
+
+const VALID_STREAM_CONTRACT_ID =
+  "CBQQXQSQB4GBB5XDPBFWEXTURY5HDG37TIE7YZ3WHP3DXVZQ2E4UHY4Z";
 
 function env(overrides: Partial<ImportMetaEnv> = {}): ImportMetaEnv {
   return overrides as ImportMetaEnv;
@@ -25,7 +29,7 @@ describe("config", () => {
         VITE_API_URL: "https://api.example.test",
         VITE_NETWORK: "PUBLIC",
         VITE_RPC_URL: " ",
-        VITE_STREAM_CONTRACT_ID: "CCONTRACT",
+        VITE_STREAM_CONTRACT_ID: VALID_STREAM_CONTRACT_ID,
         VITE_USE_MOCKS: "true",
       }),
     );
@@ -34,8 +38,46 @@ describe("config", () => {
     expect(config.network).toBe("PUBLIC");
     expect(config.networkLabel).toBe("Public Network (Mainnet)");
     expect(config.rpcUrl).toBeNull();
-    expect(config.streamContractId).toBe("CCONTRACT");
+    expect(config.streamContractId).toBe(VALID_STREAM_CONTRACT_ID);
     expect(config.useMocks).toBe(true);
+  });
+
+  it("preserves optional unset stream contract IDs", () => {
+    expect(createConfig(env()).streamContractId).toBeNull();
+    expect(createConfig(env({ VITE_STREAM_CONTRACT_ID: " " })).streamContractId).toBeNull();
+  });
+
+  it("rejects malformed stream contract IDs with typed config errors", () => {
+    const invalidValues = [
+      "GBQQXQSQB4GBB5XDPBFWEXTURY5HDG37TIE7YZ3WHP3DXVZQ2E4UHY4Z",
+      "CBQQXQSQB4GBB5XDPBFWEXTURY5HDG37TIE7YZ3WHP3DXVZQ2E4UHY4",
+      VALID_STREAM_CONTRACT_ID.toLowerCase(),
+      `${VALID_STREAM_CONTRACT_ID.slice(0, -1)}A`,
+    ];
+
+    for (const value of invalidValues) {
+      expect(() =>
+        createConfig(env({ VITE_STREAM_CONTRACT_ID: value })),
+      ).toThrow(ConfigError);
+
+      try {
+        createConfig(env({ VITE_STREAM_CONTRACT_ID: value }));
+      } catch (error) {
+        expect(error).toBeInstanceOf(ConfigError);
+        expect((error as ConfigError).envName).toBe("VITE_STREAM_CONTRACT_ID");
+        expect((error as Error).message).toContain("VITE_STREAM_CONTRACT_ID");
+      }
+    }
+  });
+
+  it("rejects whitespace-padded stream contract IDs", () => {
+    expect(() =>
+      createConfig(env({ VITE_STREAM_CONTRACT_ID: ` ${VALID_STREAM_CONTRACT_ID}` })),
+    ).toThrow("VITE_STREAM_CONTRACT_ID: must not include leading or trailing whitespace.");
+
+    expect(() =>
+      createConfig(env({ VITE_STREAM_CONTRACT_ID: `${VALID_STREAM_CONTRACT_ID} ` })),
+    ).toThrow("VITE_STREAM_CONTRACT_ID: must not include leading or trailing whitespace.");
   });
 
   it("fails closed to TESTNET for unsupported networks", () => {

--- a/src/lib/__tests__/stellar.test.ts
+++ b/src/lib/__tests__/stellar.test.ts
@@ -1,8 +1,14 @@
 import { describe, expect, it } from "vitest";
-import { isValidStellarAddress, maskAddress, stellarExplorerUrl } from "../stellar";
+import {
+  isValidStellarAddress,
+  isValidStellarContractId,
+  maskAddress,
+  stellarExplorerUrl,
+} from "../stellar";
 
 const BASE32_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
 const ED25519_PUBLIC_KEY_VERSION_BYTE = 6 << 3;
+const CONTRACT_ID_VERSION_BYTE = 2 << 3;
 
 function crc16XModem(bytes: Uint8Array): number {
   let crc = 0x0000;
@@ -42,9 +48,9 @@ function encodeBase32(bytes: Uint8Array): string {
   return encoded;
 }
 
-function createValidAddress(seed: number): string {
+function createValidStrKey(versionByte: number, seed: number): string {
   const payload = new Uint8Array(33);
-  payload[0] = ED25519_PUBLIC_KEY_VERSION_BYTE;
+  payload[0] = versionByte;
 
   for (let i = 1; i < payload.length; i += 1) {
     payload[i] = (seed + i * 17) & 0xff;
@@ -59,9 +65,13 @@ function createValidAddress(seed: number): string {
   return encodeBase32(bytes);
 }
 
-const VALID_STELLAR_ADDRESS = createValidAddress(277);
+const VALID_STELLAR_ADDRESS = createValidStrKey(ED25519_PUBLIC_KEY_VERSION_BYTE, 277);
 const checksumInvalidAddress = `${VALID_STELLAR_ADDRESS.slice(0, -1)}${
   VALID_STELLAR_ADDRESS[VALID_STELLAR_ADDRESS.length - 1] === "A" ? "B" : "A"
+}`;
+const VALID_STELLAR_CONTRACT_ID = createValidStrKey(CONTRACT_ID_VERSION_BYTE, 311);
+const checksumInvalidContractId = `${VALID_STELLAR_CONTRACT_ID.slice(0, -1)}${
+  VALID_STELLAR_CONTRACT_ID[VALID_STELLAR_CONTRACT_ID.length - 1] === "A" ? "B" : "A"
 }`;
 
 describe("Stellar address helpers", () => {
@@ -89,6 +99,26 @@ describe("Stellar address helpers", () => {
     );
     expect(maskAddress("  GSHORT  ")).toBe("GSHORT");
     expect(maskAddress("")).toBe("-");
+  });
+});
+
+describe("Stellar contract ID helpers", () => {
+  it("accepts a checksum-valid C contract ID", () => {
+    expect(VALID_STELLAR_CONTRACT_ID).toHaveLength(56);
+    expect(VALID_STELLAR_CONTRACT_ID.startsWith("C")).toBe(true);
+    expect(isValidStellarContractId(VALID_STELLAR_CONTRACT_ID)).toBe(true);
+  });
+
+  it("rejects non-contract StrKeys and checksum-invalid contract IDs", () => {
+    expect(isValidStellarContractId(VALID_STELLAR_ADDRESS)).toBe(false);
+    expect(checksumInvalidContractId).toMatch(/^C[ABCDEFGHIJKLMNOPQRSTUVWXYZ234567]{55}$/);
+    expect(isValidStellarContractId(checksumInvalidContractId)).toBe(false);
+  });
+
+  it("rejects wrong length, lowercase, and ambiguous contract characters", () => {
+    expect(isValidStellarContractId(VALID_STELLAR_CONTRACT_ID.slice(0, -1))).toBe(false);
+    expect(isValidStellarContractId(VALID_STELLAR_CONTRACT_ID.toLowerCase())).toBe(false);
+    expect(isValidStellarContractId(`C${"0".repeat(55)}`)).toBe(false);
   });
 });
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -2,6 +2,7 @@ import {
   getExpectedStellarNetwork,
   type StellarNetwork,
 } from "./stellarNetwork";
+import { isValidStellarContractId } from "./stellar";
 
 const NETWORK_LABELS: Record<StellarNetwork, string> = {
   PUBLIC: "Public Network (Mainnet)",
@@ -23,9 +24,42 @@ export interface AppConfig {
   useMocks: boolean;
 }
 
+export class ConfigError extends Error {
+  constructor(
+    public readonly envName: string,
+    message: string,
+  ) {
+    super(`${envName}: ${message}`);
+    this.name = "ConfigError";
+  }
+}
+
 function optionalString(value: string | undefined): string | null {
   const trimmed = value?.trim();
   return trimmed ? trimmed : null;
+}
+
+function optionalStreamContractId(value: string | undefined): string | null {
+  const trimmed = optionalString(value);
+  if (!trimmed) {
+    return null;
+  }
+
+  if (trimmed !== value) {
+    throw new ConfigError(
+      "VITE_STREAM_CONTRACT_ID",
+      "must not include leading or trailing whitespace.",
+    );
+  }
+
+  if (!isValidStellarContractId(trimmed)) {
+    throw new ConfigError(
+      "VITE_STREAM_CONTRACT_ID",
+      "must be a valid 56-character Stellar contract ID StrKey starting with C.",
+    );
+  }
+
+  return trimmed;
 }
 
 export function parseBooleanFlag(value: string | undefined): boolean {
@@ -49,7 +83,7 @@ export function createConfig(env: ImportMetaEnv): AppConfig {
     networkLabel: getNetworkLabel(network),
     networkPassphrase: getNetworkPassphrase(network),
     rpcUrl: optionalString(env.VITE_RPC_URL),
-    streamContractId: optionalString(env.VITE_STREAM_CONTRACT_ID),
+    streamContractId: optionalStreamContractId(env.VITE_STREAM_CONTRACT_ID),
     useMocks: parseBooleanFlag(env.VITE_USE_MOCKS),
   };
 }

--- a/src/lib/stellar.ts
+++ b/src/lib/stellar.ts
@@ -1,7 +1,9 @@
 const STELLAR_ADDRESS_REGEX = /^G[ABCDEFGHIJKLMNOPQRSTUVWXYZ234567]{55}$/;
+const STELLAR_CONTRACT_ID_REGEX = /^C[ABCDEFGHIJKLMNOPQRSTUVWXYZ234567]{55}$/;
 const STRKEY_BASE32_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
 const ED25519_PUBLIC_KEY_VERSION_BYTE = 6 << 3;
-const ED25519_PUBLIC_KEY_BYTE_LENGTH = 35;
+const CONTRACT_ID_VERSION_BYTE = 2 << 3;
+const STRKEY_BYTE_LENGTH = 35;
 
 function decodeBase32(value: string): Uint8Array | null {
   let bits = 0;
@@ -52,11 +54,35 @@ export function isValidStellarAddress(value: string): boolean {
   if (!STELLAR_ADDRESS_REGEX.test(trimmed)) return false;
 
   const decoded = decodeBase32(trimmed);
-  if (!decoded || decoded.length !== ED25519_PUBLIC_KEY_BYTE_LENGTH) {
+  if (!decoded || decoded.length !== STRKEY_BYTE_LENGTH) {
     return false;
   }
 
   if (decoded[0] !== ED25519_PUBLIC_KEY_VERSION_BYTE) return false;
+
+  const payload = decoded.slice(0, decoded.length - 2);
+  const checksum = decoded[decoded.length - 2] | (decoded[decoded.length - 1] << 8);
+
+  return crc16XModem(payload) === checksum;
+}
+
+/**
+ * Validates a Stellar StrKey contract ID.
+ *
+ * Contract IDs are 56-character uppercase base32 StrKeys that start with C,
+ * decode to version byte 0x10 plus a 32-byte contract hash, and end with a
+ * little-endian CRC16-XModem checksum over the version byte and payload.
+ */
+export function isValidStellarContractId(value: string): boolean {
+  const trimmed = value.trim();
+  if (!STELLAR_CONTRACT_ID_REGEX.test(trimmed)) return false;
+
+  const decoded = decodeBase32(trimmed);
+  if (!decoded || decoded.length !== STRKEY_BYTE_LENGTH) {
+    return false;
+  }
+
+  if (decoded[0] !== CONTRACT_ID_VERSION_BYTE) return false;
 
   const payload = decoded.slice(0, decoded.length - 2);
   const checksum = decoded[decoded.length - 2] | (decoded[decoded.length - 1] << 8);


### PR DESCRIPTION
## Summary
- add a reusable Stellar contract ID StrKey validator with checksum verification
- validate `VITE_STREAM_CONTRACT_ID` at config load time with a typed `ConfigError`
- preserve optional missing/blank contract IDs while rejecting whitespace-padded and malformed values
- add config and Stellar helper regression tests for valid, missing, wrong-prefix, wrong-length, lowercase, whitespace, and checksum-invalid inputs

## Validation
- `node node_modules/vitest/vitest.mjs run src/lib/__tests__/config.test.ts src/lib/__tests__/stellar.test.ts` (19 tests passed)
- `node node_modules/typescript/bin/tsc -b`
- `node node_modules/vite/bin/vite.js build`

## Security notes
Malformed contract IDs now fail at configuration load time instead of surfacing later during transaction simulation.

Closes #360