### PR TITLE
Add typed streams service layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,24 @@ Stellar metadata:
 Only expose public client metadata through `VITE_` variables. Do not put API
 secrets, signing keys, or wallet credentials in frontend env files.
 
+### Streams data service
+
+Treasury and stream screens load through `src/lib/api/streamsService.ts`.
+The service reads `VITE_API_URL`, normalizes API/RPC payloads into the existing
+`StreamRecord` and treasury `Metric` shapes, and encodes all URL path/query
+values before requesting data.
+
+Expected initial API paths:
+
+- `GET /treasury/metrics`
+- `GET /streams`
+- `GET /streams/:id`
+- `GET /recipients/:address/streams`
+
+Set `VITE_USE_MOCKS=true` to keep using the seeded local stream fixtures without
+network calls. This is intended for demos, local review, and tests while the
+backend and Soroban RPC readers are still being wired in.
+
 ## Transaction Signing Layer (Stellar / Soroban)
 
 Fluxora integrates with the Stellar ecosystem for on-chain stream management:

--- a/src/components/__tests__/RecipientStreams.test.tsx
+++ b/src/components/__tests__/RecipientStreams.test.tsx
@@ -9,39 +9,49 @@ import {
   type RecipientStream,
 } from "../../fixtures/recipientStreams";
 
+function renderRecipientStreams() {
+  return render(<RecipientStreams streams={mockRecipientStreams} />);
+}
+
 function streamNames() {
   return screen
     .getAllByRole("article")
     .map((article) =>
-      article.getAttribute("aria-label")?.replace("Stream from ", "")
+      article.getAttribute("aria-label")?.replace("Stream from ", ""),
     );
 }
 
 describe("RecipientStreams structure", () => {
   it("renders the streams list heading and labelled list", () => {
-    render(<RecipientStreams />);
+    renderRecipientStreams();
 
     expect(
-      screen.getByRole("heading", { level: 2, name: /your incoming streams/i })
+      screen.getByRole("heading", { level: 2, name: /your incoming streams/i }),
     ).toBeInTheDocument();
-    expect(screen.getByRole("list", { name: /your incoming streams/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("list", { name: /your incoming streams/i }),
+    ).toBeInTheDocument();
   });
 
   it("renders reusable fixture streams with ISO-8601 start times", () => {
-    render(<RecipientStreams />);
+    renderRecipientStreams();
 
-    expect(screen.getAllByRole("listitem")).toHaveLength(mockRecipientStreams.length);
+    expect(screen.getAllByRole("listitem")).toHaveLength(
+      mockRecipientStreams.length,
+    );
     mockRecipientStreams.forEach((stream) => {
       expect(stream.startTime).toMatch(/^\d{4}-\d{2}-\d{2}T.*Z$/);
       expect(Date.parse(stream.startTime)).not.toBeNaN();
       expect(
-        screen.getByRole("article", { name: `Stream from ${stream.senderName}` })
+        screen.getByRole("article", {
+          name: `Stream from ${stream.senderName}`,
+        }),
       ).toBeInTheDocument();
     });
   });
 
   it("renders From, Accrued, Rate, and Status column labels", () => {
-    render(<RecipientStreams />);
+    renderRecipientStreams();
 
     expect(screen.getByText(/^From$/i)).toBeInTheDocument();
     expect(screen.getByText(/^Accrued$/i)).toBeInTheDocument();
@@ -50,22 +60,26 @@ describe("RecipientStreams structure", () => {
   });
 
   it("renders progress bars, status badges, pin buttons, and detail buttons", () => {
-    render(<RecipientStreams />);
+    renderRecipientStreams();
 
-    expect(screen.getAllByRole("progressbar")).toHaveLength(mockRecipientStreams.length);
-    expect(screen.getAllByRole("status")).toHaveLength(mockRecipientStreams.length);
+    expect(screen.getAllByRole("progressbar")).toHaveLength(
+      mockRecipientStreams.length,
+    );
+    expect(screen.getAllByRole("status")).toHaveLength(
+      mockRecipientStreams.length,
+    );
     expect(
-      screen.getAllByRole("button", { name: /pin stream|unpin stream/i })
+      screen.getAllByRole("button", { name: /pin stream|unpin stream/i }),
     ).toHaveLength(mockRecipientStreams.length);
     expect(
-      screen.getAllByRole("button", { name: /view details for stream from/i })
+      screen.getAllByRole("button", { name: /view details for stream from/i }),
     ).toHaveLength(mockRecipientStreams.length);
   });
 });
 
 describe("RecipientStreams pin and sort behavior", () => {
   it("defaults to pinned-first order", () => {
-    render(<RecipientStreams />);
+    renderRecipientStreams();
 
     expect(streamNames()).toEqual([
       "Stellar Dev Foundation",
@@ -76,11 +90,11 @@ describe("RecipientStreams pin and sort behavior", () => {
 
   it("sorts unpinned streams by newest while keeping pinned streams first", async () => {
     const user = userEvent.setup();
-    render(<RecipientStreams />);
+    renderRecipientStreams();
 
     await user.selectOptions(
       screen.getByRole("combobox", { name: /sort by/i }),
-      "newest"
+      "newest",
     );
 
     expect(streamNames()).toEqual([
@@ -92,11 +106,11 @@ describe("RecipientStreams pin and sort behavior", () => {
 
   it("sorts unpinned streams by highest rate while keeping pinned streams first", async () => {
     const user = userEvent.setup();
-    render(<RecipientStreams />);
+    renderRecipientStreams();
 
     await user.selectOptions(
       screen.getByRole("combobox", { name: /sort by/i }),
-      "rate"
+      "rate",
     );
 
     expect(streamNames()).toEqual([
@@ -108,14 +122,16 @@ describe("RecipientStreams pin and sort behavior", () => {
 
   it("moves a newly pinned stream into the pinned group", async () => {
     const user = userEvent.setup();
-    render(<RecipientStreams />);
+    renderRecipientStreams();
 
     await user.selectOptions(
       screen.getByRole("combobox", { name: /sort by/i }),
-      "newest"
+      "newest",
     );
     await user.click(
-      screen.getByRole("button", { name: /pin stream from Ecosystem Grant #42/i })
+      screen.getByRole("button", {
+        name: /pin stream from Ecosystem Grant #42/i,
+      }),
     );
 
     expect(streamNames()).toEqual([
@@ -124,7 +140,9 @@ describe("RecipientStreams pin and sort behavior", () => {
       "Fluxora DAO",
     ]);
     expect(
-      screen.getByRole("button", { name: /unpin stream from Ecosystem Grant #42/i })
+      screen.getByRole("button", {
+        name: /unpin stream from Ecosystem Grant #42/i,
+      }),
     ).toHaveAttribute("aria-pressed", "true");
   });
 
@@ -154,26 +172,28 @@ describe("RecipientStreams pin and sort behavior", () => {
       },
     ];
 
-    expect(sortRecipientStreams(streams, "rate").map((stream) => stream.senderName)).toEqual([
-      "Pinned",
-      "Unpinned A",
-      "Unpinned B",
-    ]);
-    expect(sortRecipientStreams(streams, "newest").map((stream) => stream.senderName)).toEqual([
-      "Pinned",
-      "Unpinned A",
-      "Unpinned B",
-    ]);
+    expect(
+      sortRecipientStreams(streams, "rate").map((stream) => stream.senderName),
+    ).toEqual(["Pinned", "Unpinned A", "Unpinned B"]);
+    expect(
+      sortRecipientStreams(streams, "newest").map(
+        (stream) => stream.senderName,
+      ),
+    ).toEqual(["Pinned", "Unpinned A", "Unpinned B"]);
   });
 });
 
 describe("RecipientStreams accessibility details", () => {
   it("labels sort options and pin state", () => {
-    render(<RecipientStreams />);
+    renderRecipientStreams();
 
-    expect(screen.getByRole("option", { name: /priority/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("option", { name: /priority/i }),
+    ).toBeInTheDocument();
     expect(screen.getByRole("option", { name: /newest/i })).toBeInTheDocument();
-    expect(screen.getByRole("option", { name: /highest rate/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("option", { name: /highest rate/i }),
+    ).toBeInTheDocument();
 
     screen
       .getAllByRole("button", { name: /pin stream|unpin stream/i })
@@ -181,7 +201,9 @@ describe("RecipientStreams accessibility details", () => {
   });
 
   it("keeps each card's metric and SVG accessibility contracts", () => {
-    const { container } = render(<RecipientStreams />);
+    const { container } = render(
+      <RecipientStreams streams={mockRecipientStreams} />,
+    );
 
     screen.getAllByRole("article").forEach((article) => {
       expect(within(article).getByText(/USDC Total/i)).toBeInTheDocument();

--- a/src/components/recipient/RecipientStreams.tsx
+++ b/src/components/recipient/RecipientStreams.tsx
@@ -1,8 +1,17 @@
-import { useState } from "react";
-import {
-  mockRecipientStreams,
-  type RecipientStream,
-} from "../../fixtures/recipientStreams";
+import { useMemo, useState } from "react";
+
+export interface RecipientStream {
+  id: string;
+  sender: string;
+  senderName: string;
+  amount: number;
+  withdrawableAmount?: number;
+  rate: number;
+  progress: number;
+  status: "active" | "paused" | "completed";
+  isPinned: boolean;
+  startTime: string;
+}
 
 export type RecipientStreamsSortKey = "pinned" | "newest" | "rate";
 
@@ -20,7 +29,7 @@ const STATUS_CLASSES: Record<RecipientStream["status"], string> = {
 
 export function sortRecipientStreams(
   streams: RecipientStream[],
-  sortKey: RecipientStreamsSortKey
+  sortKey: RecipientStreamsSortKey,
 ) {
   return [...streams].sort((a, b) => {
     if (a.isPinned !== b.isPinned) {
@@ -37,17 +46,34 @@ export function sortRecipientStreams(
   });
 }
 
-export default function RecipientStreams() {
-  const [streams, setStreams] = useState<RecipientStream[]>(mockRecipientStreams);
+export default function RecipientStreams({
+  streams,
+}: {
+  streams: RecipientStream[];
+}) {
+  const [pinnedOverrides, setPinnedOverrides] = useState<
+    Record<string, boolean>
+  >({});
   const [sortKey, setSortKey] = useState<RecipientStreamsSortKey>("pinned");
 
   const togglePin = (id: string) => {
-    setStreams((prev) =>
-      prev.map((s) => (s.id === id ? { ...s, isPinned: !s.isPinned } : s))
-    );
+    setPinnedOverrides((current) => {
+      const stream = streams.find((item) => item.id === id);
+      if (!stream) return current;
+      const nextPinned = !(current[id] ?? stream.isPinned);
+      return { ...current, [id]: nextPinned };
+    });
   };
 
-  const sortedStreams = sortRecipientStreams(streams, sortKey);
+  const displayStreams = useMemo(
+    () =>
+      streams.map((stream) => ({
+        ...stream,
+        isPinned: pinnedOverrides[stream.id] ?? stream.isPinned,
+      })),
+    [pinnedOverrides, streams],
+  );
+  const sortedStreams = sortRecipientStreams(displayStreams, sortKey);
 
   return (
     <div className="flex flex-col gap-6 w-full">
@@ -70,7 +96,9 @@ export default function RecipientStreams() {
           <select
             id="streams-sort"
             value={sortKey}
-            onChange={(e) => setSortKey(e.target.value as RecipientStreamsSortKey)}
+            onChange={(e) =>
+              setSortKey(e.target.value as RecipientStreamsSortKey)
+            }
             className="bg-transparent border border-[var(--border)] text-xs font-bold rounded-lg px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-cyan-500"
             style={{ background: "var(--surface)", color: "var(--text)" }}
           >
@@ -93,195 +121,204 @@ export default function RecipientStreams() {
         aria-labelledby="streams-list-heading"
         role="list"
       >
-        {sortedStreams.map((stream) => (
-          <li
-            key={stream.id}
-            className={`stream-card group relative overflow-hidden rounded-2xl border transition-all duration-300 hover:scale-[1.01] ${
-              stream.isPinned ? "is-active" : ""
-            }`}
-            style={{
-              background: "var(--card-gradient)",
-              borderColor: "var(--border)",
-            }}
-          >
-            {stream.isPinned && (
-              <div
-                aria-hidden="true"
-                className="absolute top-0 left-0 w-1 h-full bg-cyan-500 shadow-[0_0_15px_rgba(6,182,212,0.5)]"
-              />
-            )}
-
-            <article
-              aria-label={`Stream from ${stream.senderName}`}
-              className="p-5 flex flex-col md:flex-row md:items-center gap-6"
+        {sortedStreams.length > 0 ? (
+          sortedStreams.map((stream) => (
+            <li
+              key={stream.id}
+              className={`stream-card group relative overflow-hidden rounded-2xl border transition-all duration-300 hover:scale-[1.01] ${
+                stream.isPinned ? "is-active" : ""
+              }`}
+              style={{
+                background: "var(--card-gradient)",
+                borderColor: "var(--border)",
+              }}
             >
-              <div className="flex items-center gap-4 min-w-[240px]">
+              {stream.isPinned && (
                 <div
                   aria-hidden="true"
-                  className={`flex h-12 w-12 items-center justify-center rounded-xl font-bold text-lg ${
-                    stream.isPinned
-                      ? "bg-cyan-500 text-white"
-                      : "bg-slate-800 text-slate-400"
-                  }`}
-                >
-                  {stream.senderName.charAt(0)}
-                </div>
-                <div className="flex flex-col">
-                  <span
-                    className="text-sm font-bold"
-                    style={{ color: "var(--text)" }}
-                  >
-                    {stream.senderName}
-                  </span>
-                  <span
-                    className="text-xs tabular-nums font-mono"
-                    style={{ color: "var(--muted)" }}
-                  >
-                    {stream.sender}
-                  </span>
-                </div>
-              </div>
+                  className="absolute top-0 left-0 w-1 h-full bg-cyan-500 shadow-[0_0_15px_rgba(6,182,212,0.5)]"
+                />
+              )}
 
-              <div className="flex-1 flex flex-col gap-2">
-                <div className="flex justify-between items-end">
-                  <div className="flex items-baseline gap-1">
-                    <span
-                      className="text-lg font-bold"
-                      style={{ color: "var(--text)" }}
-                    >
-                      {stream.amount.toLocaleString()}
-                    </span>
-                    <span
-                      className="text-xs font-medium"
-                      style={{ color: "var(--muted)" }}
-                    >
-                      USDC Total
-                    </span>
-                  </div>
-                  <span
-                    className={`text-xs font-bold ${
-                      stream.isPinned ? "text-cyan-400" : "text-slate-400"
-                    }`}
-                    aria-label={`${stream.progress}% streamed`}
-                  >
-                    {stream.progress}%
-                  </span>
-                </div>
-
-                <div
-                  role="progressbar"
-                  aria-valuenow={stream.progress}
-                  aria-valuemin={0}
-                  aria-valuemax={100}
-                  aria-label={`${stream.senderName} stream progress: ${stream.progress}%`}
-                  className="h-1.5 w-full bg-slate-800 rounded-full overflow-hidden"
-                >
+              <article
+                aria-label={`Stream from ${stream.senderName}`}
+                className="p-5 flex flex-col md:flex-row md:items-center gap-6"
+              >
+                <div className="flex items-center gap-4 min-w-[240px]">
                   <div
                     aria-hidden="true"
-                    className={`h-full rounded-full transition-all duration-1000 ${
+                    className={`flex h-12 w-12 items-center justify-center rounded-xl font-bold text-lg ${
                       stream.isPinned
-                        ? "bg-cyan-500 shadow-[0_0_10px_rgba(6,182,212,0.3)]"
-                        : "bg-slate-600"
+                        ? "bg-cyan-500 text-white"
+                        : "bg-slate-800 text-slate-400"
                     }`}
-                    style={{ width: `${stream.progress}%` }}
-                  />
-                </div>
-              </div>
-
-              <div className="flex items-center gap-8 min-w-[200px] justify-between">
-                <dl className="flex flex-col gap-2">
+                  >
+                    {stream.senderName.charAt(0)}
+                  </div>
                   <div className="flex flex-col">
-                    <dt className="text-xs font-bold text-slate-500 uppercase tracking-widest">
-                      Rate
-                    </dt>
-                    <dd
+                    <span
                       className="text-sm font-bold"
                       style={{ color: "var(--text)" }}
                     >
-                      {stream.rate} USDC/hr
-                    </dd>
-                  </div>
-                  <div className="flex flex-col">
-                    <dt className="sr-only">Status</dt>
-                    <dd>
-                      <span
-                        className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border text-[10px] font-bold uppercase tracking-widest ${STATUS_CLASSES[stream.status]}`}
-                        role="status"
-                        aria-label={`Stream status: ${STATUS_LABELS[stream.status]}`}
-                      >
-                        <span
-                          aria-hidden="true"
-                          className={`h-1.5 w-1.5 rounded-full ${
-                            stream.status === "active"
-                              ? "bg-emerald-400 animate-pulse"
-                              : stream.status === "paused"
-                                ? "bg-amber-400"
-                                : "bg-blue-400"
-                          }`}
-                        />
-                        {STATUS_LABELS[stream.status]}
-                      </span>
-                    </dd>
-                  </div>
-                </dl>
-
-                <div className="flex items-center gap-3">
-                  <button
-                    onClick={() => togglePin(stream.id)}
-                    aria-pressed={stream.isPinned}
-                    aria-label={
-                      stream.isPinned
-                        ? `Unpin stream from ${stream.senderName}`
-                        : `Pin stream from ${stream.senderName}`
-                    }
-                    className={`p-2 rounded-lg border transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-1 focus-visible:ring-offset-black ${
-                      stream.isPinned
-                        ? "bg-cyan-500/10 border-cyan-500/50 text-cyan-500 shadow-[0_0_15px_rgba(6,182,212,0.1)]"
-                        : "bg-slate-800 border-slate-700 text-slate-500 hover:text-slate-300 hover:border-slate-600"
-                    }`}
-                  >
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="18"
-                      height="18"
-                      viewBox="0 0 24 24"
-                      fill={stream.isPinned ? "currentColor" : "none"}
-                      stroke="currentColor"
-                      strokeWidth="2"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      aria-hidden="true"
-                      focusable="false"
+                      {stream.senderName}
+                    </span>
+                    <span
+                      className="text-xs tabular-nums font-mono"
+                      style={{ color: "var(--muted)" }}
                     >
-                      <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" />
-                    </svg>
-                  </button>
-
-                  <button
-                    aria-label={`View details for stream from ${stream.senderName}`}
-                    className="flex h-10 w-10 items-center justify-center rounded-lg bg-white/5 border border-white/10 text-white hover:bg-white/10 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-1 focus-visible:ring-offset-black"
-                  >
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="18"
-                      height="18"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeWidth="2"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      aria-hidden="true"
-                      focusable="false"
-                    >
-                      <path d="M5 12h14M12 5l7 7-7 7" />
-                    </svg>
-                  </button>
+                      {stream.sender}
+                    </span>
+                  </div>
                 </div>
-              </div>
-            </article>
+
+                <div className="flex-1 flex flex-col gap-2">
+                  <div className="flex justify-between items-end">
+                    <div className="flex items-baseline gap-1">
+                      <span
+                        className="text-lg font-bold"
+                        style={{ color: "var(--text)" }}
+                      >
+                        {stream.amount.toLocaleString()}
+                      </span>
+                      <span
+                        className="text-xs font-medium"
+                        style={{ color: "var(--muted)" }}
+                      >
+                        USDC Total
+                      </span>
+                    </div>
+                    <span
+                      className={`text-xs font-bold ${
+                        stream.isPinned ? "text-cyan-400" : "text-slate-400"
+                      }`}
+                      aria-label={`${stream.progress}% streamed`}
+                    >
+                      {stream.progress}%
+                    </span>
+                  </div>
+
+                  <div
+                    role="progressbar"
+                    aria-valuenow={stream.progress}
+                    aria-valuemin={0}
+                    aria-valuemax={100}
+                    aria-label={`${stream.senderName} stream progress: ${stream.progress}%`}
+                    className="h-1.5 w-full bg-slate-800 rounded-full overflow-hidden"
+                  >
+                    <div
+                      aria-hidden="true"
+                      className={`h-full rounded-full transition-all duration-1000 ${
+                        stream.isPinned
+                          ? "bg-cyan-500 shadow-[0_0_10px_rgba(6,182,212,0.3)]"
+                          : "bg-slate-600"
+                      }`}
+                      style={{ width: `${stream.progress}%` }}
+                    />
+                  </div>
+                </div>
+
+                <div className="flex items-center gap-8 min-w-[200px] justify-between">
+                  <dl className="flex flex-col gap-2">
+                    <div className="flex flex-col">
+                      <dt className="text-xs font-bold text-slate-500 uppercase tracking-widest">
+                        Rate
+                      </dt>
+                      <dd
+                        className="text-sm font-bold"
+                        style={{ color: "var(--text)" }}
+                      >
+                        {stream.rate} USDC/hr
+                      </dd>
+                    </div>
+                    <div className="flex flex-col">
+                      <dt className="sr-only">Status</dt>
+                      <dd>
+                        <span
+                          className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border text-[10px] font-bold uppercase tracking-widest ${STATUS_CLASSES[stream.status]}`}
+                          role="status"
+                          aria-label={`Stream status: ${STATUS_LABELS[stream.status]}`}
+                        >
+                          <span
+                            aria-hidden="true"
+                            className={`h-1.5 w-1.5 rounded-full ${
+                              stream.status === "active"
+                                ? "bg-emerald-400 animate-pulse"
+                                : stream.status === "paused"
+                                  ? "bg-amber-400"
+                                  : "bg-blue-400"
+                            }`}
+                          />
+                          {STATUS_LABELS[stream.status]}
+                        </span>
+                      </dd>
+                    </div>
+                  </dl>
+
+                  <div className="flex items-center gap-3">
+                    <button
+                      onClick={() => togglePin(stream.id)}
+                      aria-pressed={stream.isPinned}
+                      aria-label={
+                        stream.isPinned
+                          ? `Unpin stream from ${stream.senderName}`
+                          : `Pin stream from ${stream.senderName}`
+                      }
+                      className={`p-2 rounded-lg border transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-1 focus-visible:ring-offset-black ${
+                        stream.isPinned
+                          ? "bg-cyan-500/10 border-cyan-500/50 text-cyan-500 shadow-[0_0_15px_rgba(6,182,212,0.1)]"
+                          : "bg-slate-800 border-slate-700 text-slate-500 hover:text-slate-300 hover:border-slate-600"
+                      }`}
+                    >
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        width="18"
+                        height="18"
+                        viewBox="0 0 24 24"
+                        fill={stream.isPinned ? "currentColor" : "none"}
+                        stroke="currentColor"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        aria-hidden="true"
+                        focusable="false"
+                      >
+                        <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" />
+                      </svg>
+                    </button>
+
+                    <button
+                      aria-label={`View details for stream from ${stream.senderName}`}
+                      className="flex h-10 w-10 items-center justify-center rounded-lg bg-white/5 border border-white/10 text-white hover:bg-white/10 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-1 focus-visible:ring-offset-black"
+                    >
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        width="18"
+                        height="18"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        aria-hidden="true"
+                        focusable="false"
+                      >
+                        <path d="M5 12h14M12 5l7 7-7 7" />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              </article>
+            </li>
+          ))
+        ) : (
+          <li
+            className="stream-card rounded-2xl border p-5"
+            style={{ borderColor: "var(--border)" }}
+          >
+            No incoming streams available.
           </li>
-        ))}
+        )}
       </ul>
     </div>
   );

--- a/src/components/treasuryOverviewPage/__tests__/demoMode.test.tsx
+++ b/src/components/treasuryOverviewPage/__tests__/demoMode.test.tsx
@@ -8,10 +8,22 @@ const getMetrics = vi.fn();
 const getStreams = vi.fn();
 
 vi.mock("../useTreasury", () => ({
-  useTreasury: () => ({
-    getMetrics,
-    getStreams,
-  }),
+  useTreasury: (enabled = true) => {
+    if (enabled) {
+      void getMetrics();
+      void getStreams();
+    }
+
+    return {
+      metrics: [],
+      streams: [],
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+      getMetrics,
+      getStreams,
+    };
+  },
 }));
 
 vi.mock("../StreamRow", () => ({
@@ -62,9 +74,6 @@ describe("treasury overview demo mode", () => {
     renderTreasuryPage();
 
     expect(screen.queryByText("Demo state:")).not.toBeInTheDocument();
-    expect(screen.getByRole("status")).toHaveTextContent(
-      "Loading treasury overview...",
-    );
 
     await waitFor(() => {
       expect(
@@ -73,7 +82,9 @@ describe("treasury overview demo mode", () => {
     });
 
     expect(screen.queryByText("Dev Grant - Alice")).not.toBeInTheDocument();
-    expect(screen.getByText("No recent streams available.")).toBeInTheDocument();
+    expect(
+      screen.getByText("No recent streams available."),
+    ).toBeInTheDocument();
     expect(getMetrics).toHaveBeenCalledTimes(1);
     expect(getStreams).toHaveBeenCalledTimes(1);
   });

--- a/src/components/treasuryOverviewPage/useTreasury.ts
+++ b/src/components/treasuryOverviewPage/useTreasury.ts
@@ -1,17 +1,62 @@
-import { useCallback } from "react";
+import { useCallback, useEffect, useState } from "react";
+import {
+  getStreams as fetchStreams,
+  getTreasuryMetrics,
+  streamRecordToTreasuryStream,
+} from "../../lib/api/streamsService";
 import type { Metric } from "./Metric";
 import type { Stream } from "./Stream";
 
-export function useTreasury() {
+export interface TreasuryState {
+  metrics: Metric[];
+  streams: Stream[];
+  loading: boolean;
+  error: string | null;
+  refetch: () => Promise<void>;
+  getMetrics: () => Promise<Metric[]>;
+  getStreams: () => Promise<Stream[]>;
+}
+
+/** Load treasury metrics and recent streams through the typed stream service. */
+export function useTreasury(enabled = true): TreasuryState {
+  const [metrics, setMetrics] = useState<Metric[]>([]);
+  const [streams, setStreams] = useState<Stream[]>([]);
+  const [loading, setLoading] = useState(enabled);
+  const [error, setError] = useState<string | null>(null);
+
   const getMetrics = useCallback(async (): Promise<Metric[]> => {
-    // TODO: Replace with API call when the treasury service is available.
-    return [];
+    return getTreasuryMetrics();
   }, []);
 
   const getStreams = useCallback(async (): Promise<Stream[]> => {
-    // TODO: Replace with API call when the treasury service is available.
-    return [];
+    const records = await fetchStreams();
+    return records.map(streamRecordToTreasuryStream);
   }, []);
 
-  return { getMetrics, getStreams };
+  const refetch = useCallback(async () => {
+    if (!enabled) return;
+
+    setLoading(true);
+    setError(null);
+    try {
+      const [nextMetrics, nextStreams] = await Promise.all([
+        getMetrics(),
+        getStreams(),
+      ]);
+      setMetrics(nextMetrics);
+      setStreams(nextStreams);
+    } catch {
+      setMetrics([]);
+      setStreams([]);
+      setError("Unable to load treasury overview data.");
+    } finally {
+      setLoading(false);
+    }
+  }, [enabled, getMetrics, getStreams]);
+
+  useEffect(() => {
+    void refetch();
+  }, [refetch]);
+
+  return { metrics, streams, loading, error, refetch, getMetrics, getStreams };
 }

--- a/src/components/treasuryOverviewPage/useTreasuryOverviewData.ts
+++ b/src/components/treasuryOverviewPage/useTreasuryOverviewData.ts
@@ -1,4 +1,3 @@
-import { useEffect, useState } from "react";
 import {
   treasuryDemoMetrics,
   treasuryDemoStreams,
@@ -20,63 +19,24 @@ export function isTreasuryDemoMode(value = import.meta.env.VITE_DEMO_MODE) {
 }
 
 export function useTreasuryOverviewData(): TreasuryOverviewData {
-  const { getMetrics, getStreams } = useTreasury();
   const isDemoMode = isTreasuryDemoMode();
-  const [data, setData] = useState<TreasuryOverviewData>({
-    metrics: isDemoMode ? treasuryDemoMetrics : [],
-    streams: isDemoMode ? treasuryDemoStreams : [],
-    isDemoMode,
-    loading: !isDemoMode,
-    error: null,
-  });
+  const treasury = useTreasury(!isDemoMode);
 
-  useEffect(() => {
-    if (isDemoMode) {
-      setData({
-        metrics: treasuryDemoMetrics,
-        streams: treasuryDemoStreams,
-        isDemoMode: true,
-        loading: false,
-        error: null,
-      });
-      return undefined;
-    }
-
-    let cancelled = false;
-    setData({
-      metrics: [],
-      streams: [],
-      isDemoMode: false,
-      loading: true,
+  if (isDemoMode) {
+    return {
+      metrics: treasuryDemoMetrics,
+      streams: treasuryDemoStreams,
+      isDemoMode: true,
+      loading: false,
       error: null,
-    });
-
-    Promise.all([getMetrics(), getStreams()])
-      .then(([metrics, streams]) => {
-        if (cancelled) return;
-        setData({
-          metrics,
-          streams,
-          isDemoMode: false,
-          loading: false,
-          error: null,
-        });
-      })
-      .catch(() => {
-        if (cancelled) return;
-        setData({
-          metrics: [],
-          streams: [],
-          isDemoMode: false,
-          loading: false,
-          error: "Unable to load treasury overview data.",
-        });
-      });
-
-    return () => {
-      cancelled = true;
     };
-  }, [getMetrics, getStreams, isDemoMode]);
+  }
 
-  return data;
+  return {
+    metrics: treasury.metrics,
+    streams: treasury.streams,
+    isDemoMode: false,
+    loading: treasury.loading,
+    error: treasury.error,
+  };
 }

--- a/src/data/streamRecords.ts
+++ b/src/data/streamRecords.ts
@@ -34,6 +34,116 @@ export interface StreamRecord {
   timeline: StreamTimelineEvent[];
 }
 
+type RawStreamRecord = Partial<
+  Omit<
+    StreamRecord,
+    | "monthlyRate"
+    | "depositAmount"
+    | "streamedAmount"
+    | "withdrawableAmount"
+    | "remainingAmount"
+    | "progress"
+    | "tags"
+    | "timeline"
+  >
+> & {
+  monthlyRate?: number | string;
+  depositAmount?: number | string;
+  streamedAmount?: number | string;
+  withdrawableAmount?: number | string;
+  remainingAmount?: number | string;
+  progress?: number | string;
+  tags?: unknown;
+  timeline?: unknown;
+};
+
+const STATUS_VALUES: StreamStatus[] = ["Active", "Paused", "Completed"];
+const HEALTH_VALUES: StreamHealth[] = ["Healthy", "Attention", "Settled"];
+const SAFE_ADDRESS_PATTERN = /^[A-Za-z0-9._:-]{1,80}$/;
+
+function safeText(value: unknown, fallback = ""): string {
+  if (typeof value !== "string") return fallback;
+  return (
+    value
+      .replace(/[<>`"']/g, "")
+      .trim()
+      .slice(0, 240) || fallback
+  );
+}
+
+function safeNumber(value: unknown, fallback = 0): number {
+  const parsed = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function safePercent(value: unknown): number {
+  return Math.max(0, Math.min(100, safeNumber(value)));
+}
+
+/** Sanitize display/copy addresses before they can reach links or clipboard UI. */
+export function sanitizeStreamAddress(value: unknown): string {
+  const text = safeText(value);
+  return SAFE_ADDRESS_PATTERN.test(text) ? text : "";
+}
+
+function normalizeStatus(value: unknown): StreamStatus {
+  return STATUS_VALUES.includes(value as StreamStatus)
+    ? (value as StreamStatus)
+    : "Active";
+}
+
+function normalizeHealth(value: unknown): StreamHealth {
+  return HEALTH_VALUES.includes(value as StreamHealth)
+    ? (value as StreamHealth)
+    : "Healthy";
+}
+
+function normalizeTimeline(value: unknown): StreamTimelineEvent[] {
+  if (!Array.isArray(value)) return [];
+  return value.map((event) => {
+    const item = event as Partial<StreamTimelineEvent>;
+    return {
+      date: safeText(item.date),
+      title: safeText(item.title),
+      detail: safeText(item.detail),
+    };
+  });
+}
+
+/** Normalize untrusted API/RPC stream payloads into the UI's StreamRecord shape. */
+export function normalizeStreamRecord(raw: RawStreamRecord): StreamRecord {
+  const id = safeText(raw.id, "STR-UNKNOWN");
+
+  return {
+    id,
+    name: safeText(raw.name, id),
+    recipientName: safeText(raw.recipientName, "Unknown recipient"),
+    recipientAddress: sanitizeStreamAddress(raw.recipientAddress),
+    treasuryName: safeText(raw.treasuryName, "Treasury"),
+    treasuryAddress: sanitizeStreamAddress(raw.treasuryAddress),
+    asset: safeText(raw.asset, "USDC"),
+    status: normalizeStatus(raw.status),
+    monthlyRate: safeNumber(raw.monthlyRate),
+    depositAmount: safeNumber(raw.depositAmount),
+    streamedAmount: safeNumber(raw.streamedAmount),
+    withdrawableAmount: safeNumber(raw.withdrawableAmount),
+    remainingAmount: safeNumber(raw.remainingAmount),
+    progress: safePercent(raw.progress),
+    startDate: safeText(raw.startDate),
+    endDate: safeText(raw.endDate),
+    cliffDate: safeText(raw.cliffDate) || undefined,
+    nextUnlockDate: safeText(raw.nextUnlockDate) || undefined,
+    summary: safeText(raw.summary),
+    health: normalizeHealth(raw.health),
+    healthNote: safeText(raw.healthNote),
+    auditNote: safeText(raw.auditNote),
+    tags: Array.isArray(raw.tags)
+      ? raw.tags.map((tag) => safeText(tag)).filter(Boolean)
+      : [],
+    timeline: normalizeTimeline(raw.timeline),
+  };
+}
+
 export const streamRecords: StreamRecord[] = [
   {
     id: "STR-001",
@@ -66,7 +176,8 @@ export const streamRecords: StreamRecord[] = [
       {
         date: "2026-01-15",
         title: "Stream activated",
-        detail: "Treasury Ops funded the stream and released the initial schedule.",
+        detail:
+          "Treasury Ops funded the stream and released the initial schedule.",
       },
       {
         date: "2026-03-12",
@@ -76,7 +187,8 @@ export const streamRecords: StreamRecord[] = [
       {
         date: "2026-04-03",
         title: "Next unlock window",
-        detail: "Projected 4,200 USDC becomes available if the stream remains active.",
+        detail:
+          "Projected 4,200 USDC becomes available if the stream remains active.",
       },
     ],
   },
@@ -161,7 +273,8 @@ export const streamRecords: StreamRecord[] = [
       {
         date: "2026-03-18",
         title: "Stream paused",
-        detail: "Treasury Council paused accrual after the monthly review call.",
+        detail:
+          "Treasury Council paused accrual after the monthly review call.",
       },
       {
         date: "2026-04-18",

--- a/src/lib/api/__tests__/streamsService.test.ts
+++ b/src/lib/api/__tests__/streamsService.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  getStreamById,
+  getStreams,
+  getTreasuryMetrics,
+  streamRecordToRecipientStream,
+  streamRecordToTreasuryStream,
+} from "../streamsService";
+
+function mockFetch(payload: unknown, ok = true, status = 200) {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok,
+    status,
+    json: vi.fn().mockResolvedValue(payload),
+  });
+  vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock);
+  return fetchMock;
+}
+
+describe("streamsService", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it("returns seeded streams and metrics in mock mode without network calls", async () => {
+    vi.stubEnv("VITE_USE_MOCKS", "true");
+    const fetchMock = mockFetch({});
+
+    const [metrics, activeStreams] = await Promise.all([
+      getTreasuryMetrics(),
+      getStreams({ status: "Active" }),
+    ]);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(metrics).toHaveLength(3);
+    expect(activeStreams.every((stream) => stream.status === "Active")).toBe(
+      true,
+    );
+  });
+
+  it("builds API queries, unwraps stream payloads, and sanitizes unsafe fields", async () => {
+    vi.stubEnv("VITE_API_URL", "https://api.example.test/v1/");
+    vi.stubEnv("VITE_USE_MOCKS", "false");
+    const fetchMock = mockFetch({
+      streams: [
+        {
+          id: "STR-API",
+          name: "<script>API Stream</script>",
+          recipientName: "Recipient",
+          recipientAddress: "javascript:alert(1)",
+          treasuryName: "Treasury",
+          treasuryAddress: "GSAFEADDRESS",
+          monthlyRate: "720",
+          depositAmount: "1440",
+          streamedAmount: "360",
+          withdrawableAmount: "120",
+          remainingAmount: "1080",
+          progress: "25",
+          status: "Paused",
+          health: "Attention",
+        },
+      ],
+    });
+
+    const streams = await getStreams({
+      status: "Paused",
+      search: "API Stream",
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.example.test/v1/streams?status=Paused&search=API+Stream",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Accept: "application/json" }),
+      }),
+    );
+    expect(streams[0]).toMatchObject({
+      id: "STR-API",
+      name: "scriptAPI Stream/script",
+      recipientAddress: "",
+      treasuryAddress: "GSAFEADDRESS",
+      monthlyRate: 720,
+      progress: 25,
+      status: "Paused",
+      health: "Attention",
+    });
+  });
+
+  it("encodes stream and recipient path segments", async () => {
+    vi.stubEnv("VITE_API_URL", "https://api.example.test");
+    const fetchMock = mockFetch({ stream: { id: "STR 1" } });
+
+    await getStreamById("STR 1/../unsafe");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.example.test/streams/STR%201%2F..%2Funsafe",
+      expect.any(Object),
+    );
+  });
+
+  it("projects stream records into treasury and recipient view models", async () => {
+    vi.stubEnv("VITE_USE_MOCKS", "true");
+    const [stream] = await getStreams({ status: "Active" });
+
+    expect(streamRecordToTreasuryStream(stream!)).toMatchObject({
+      id: stream!.id,
+      name: stream!.name,
+      recipient: stream!.recipientAddress,
+      status: stream!.status,
+    });
+    expect(streamRecordToRecipientStream(stream!)).toMatchObject({
+      id: stream!.id,
+      sender: stream!.treasuryAddress,
+      senderName: stream!.treasuryName,
+      status: "active",
+    });
+  });
+
+  it("fails closed on non-2xx API responses", async () => {
+    vi.stubEnv("VITE_API_URL", "https://api.example.test");
+    mockFetch({}, false, 500);
+
+    await expect(getTreasuryMetrics()).rejects.toThrow(
+      "Fluxora API request failed with 500",
+    );
+  });
+});

--- a/src/lib/api/streamsService.ts
+++ b/src/lib/api/streamsService.ts
@@ -1,0 +1,208 @@
+import { treasuryDemoMetrics } from "../../fixtures/treasury";
+import {
+  normalizeStreamRecord,
+  streamRecords,
+  type StreamRecord,
+  type StreamStatus,
+} from "../../data/streamRecords";
+import type { Metric } from "../../components/treasuryOverviewPage/Metric";
+import type { Stream } from "../../components/treasuryOverviewPage/Stream";
+import type { RecipientStream } from "../../components/recipient/RecipientStreams";
+import { createConfig } from "../config";
+
+export interface StreamFilters {
+  status?: StreamStatus;
+  recipientAddress?: string;
+  treasuryAddress?: string;
+  search?: string;
+}
+
+type ApiEnvelope<T> = T | { data?: T; metrics?: T; streams?: T; stream?: T };
+
+function runtimeConfig() {
+  return createConfig(import.meta.env);
+}
+
+function apiBaseUrl(): string {
+  return runtimeConfig().apiUrl ?? "/api";
+}
+
+function isMockMode(): boolean {
+  return runtimeConfig().useMocks;
+}
+
+function unwrap<T>(
+  payload: ApiEnvelope<T>,
+  key: "data" | "metrics" | "streams" | "stream" = "data",
+): T {
+  if (payload && typeof payload === "object" && key in payload) {
+    return (payload as Record<string, T>)[key];
+  }
+  if (payload && typeof payload === "object" && "data" in payload) {
+    return (payload as Record<string, T>).data;
+  }
+  return payload as T;
+}
+
+function endpoint(path: string, params?: URLSearchParams): string {
+  const base = apiBaseUrl().replace(/\/+$/, "");
+  const url = `${base}${path.startsWith("/") ? path : `/${path}`}`;
+  const query = params?.toString();
+  return query ? `${url}?${query}` : url;
+}
+
+async function fetchJson<T>(
+  path: string,
+  init?: RequestInit,
+  params?: URLSearchParams,
+): Promise<T> {
+  const response = await fetch(endpoint(path, params), {
+    ...init,
+    headers: {
+      Accept: "application/json",
+      ...init?.headers,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Fluxora API request failed with ${response.status}`);
+  }
+
+  return (await response.json()) as T;
+}
+
+function filterMockStreams(filters: StreamFilters = {}): StreamRecord[] {
+  const search = filters.search?.trim().toLowerCase();
+
+  return streamRecords
+    .map(normalizeStreamRecord)
+    .filter((stream) => !filters.status || stream.status === filters.status)
+    .filter(
+      (stream) =>
+        !filters.recipientAddress ||
+        stream.recipientAddress === filters.recipientAddress,
+    )
+    .filter(
+      (stream) =>
+        !filters.treasuryAddress ||
+        stream.treasuryAddress === filters.treasuryAddress,
+    )
+    .filter((stream) => {
+      if (!search) return true;
+      return [
+        stream.id,
+        stream.name,
+        stream.recipientName,
+        stream.recipientAddress,
+      ].some((value) => value.toLowerCase().includes(search));
+    });
+}
+
+function toQuery(filters: StreamFilters): URLSearchParams {
+  const params = new URLSearchParams();
+  if (filters.status) params.set("status", filters.status);
+  if (filters.recipientAddress)
+    params.set("recipientAddress", filters.recipientAddress);
+  if (filters.treasuryAddress)
+    params.set("treasuryAddress", filters.treasuryAddress);
+  if (filters.search) params.set("search", filters.search);
+  return params;
+}
+
+function normalizeMetric(raw: Partial<Metric>): Metric {
+  return {
+    icon: raw.icon ?? "•",
+    label: typeof raw.label === "string" ? raw.label : "Metric",
+    value: typeof raw.value === "string" ? raw.value : String(raw.value ?? ""),
+    desc: typeof raw.desc === "string" ? raw.desc : "",
+  };
+}
+
+/** Project a rich stream record into the compact treasury overview row shape. */
+export function streamRecordToTreasuryStream(stream: StreamRecord): Stream {
+  return {
+    id: stream.id,
+    name: stream.name,
+    recipient: stream.recipientAddress,
+    rate: `${stream.monthlyRate.toLocaleString()} ${stream.asset}/mo`,
+    accruedAmount: stream.streamedAmount,
+    status: stream.status,
+  };
+}
+
+/** Project a rich stream record into the recipient portal card shape. */
+export function streamRecordToRecipientStream(
+  stream: StreamRecord,
+): RecipientStream {
+  const hourlyRate =
+    stream.monthlyRate > 0 ? stream.monthlyRate / (30 * 24) : 0;
+
+  return {
+    id: stream.id,
+    sender: stream.treasuryAddress,
+    senderName: stream.treasuryName,
+    amount: stream.depositAmount,
+    withdrawableAmount: stream.withdrawableAmount,
+    rate: Number(hourlyRate.toFixed(2)),
+    progress: stream.progress,
+    status: stream.status.toLowerCase() as RecipientStream["status"],
+    isPinned: stream.status === "Active",
+    startTime: stream.startDate,
+  };
+}
+
+/** Fetch treasury metrics from the configured API, or seeded data in mock mode. */
+export async function getTreasuryMetrics(): Promise<Metric[]> {
+  if (isMockMode()) {
+    return treasuryDemoMetrics;
+  }
+
+  const payload =
+    await fetchJson<ApiEnvelope<Partial<Metric>[]>>("/treasury/metrics");
+  return unwrap(payload, "metrics").map(normalizeMetric);
+}
+
+/** Fetch stream records with optional filters and normalize untrusted API fields. */
+export async function getStreams(
+  filters: StreamFilters = {},
+): Promise<StreamRecord[]> {
+  if (isMockMode()) {
+    return filterMockStreams(filters);
+  }
+
+  const payload = await fetchJson<ApiEnvelope<Partial<StreamRecord>[]>>(
+    "/streams",
+    undefined,
+    toQuery(filters),
+  );
+  return unwrap(payload, "streams").map(normalizeStreamRecord);
+}
+
+/** Fetch one stream by id while safely encoding the path segment. */
+export async function getStreamById(
+  id: string,
+): Promise<StreamRecord | undefined> {
+  if (isMockMode()) {
+    return filterMockStreams().find((stream) => stream.id === id);
+  }
+
+  const payload = await fetchJson<ApiEnvelope<Partial<StreamRecord>>>(
+    `/streams/${encodeURIComponent(id)}`,
+  );
+  return normalizeStreamRecord(unwrap(payload, "stream"));
+}
+
+/** Fetch streams for a recipient address while safely encoding the path segment. */
+export async function getRecipientStreams(
+  address: string,
+): Promise<StreamRecord[]> {
+  if (isMockMode()) {
+    const recipientMatches = filterMockStreams({ recipientAddress: address });
+    return recipientMatches.length > 0 ? recipientMatches : filterMockStreams();
+  }
+
+  const payload = await fetchJson<ApiEnvelope<Partial<StreamRecord>[]>>(
+    `/recipients/${encodeURIComponent(address)}/streams`,
+  );
+  return unwrap(payload, "streams").map(normalizeStreamRecord);
+}

--- a/src/pages/Recipient.test.tsx
+++ b/src/pages/Recipient.test.tsx
@@ -21,44 +21,50 @@ vi.mock("../components/wallet-connect/Walletcontext", () => ({
   }),
 }));
 
-function renderRecipient() {
+async function renderRecipient() {
   render(<Recipient />);
-  act(() => {
-    vi.advanceTimersByTime(2000);
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(2000);
   });
 }
 
 describe("Recipient wallet source", () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    vi.stubEnv("VITE_USE_MOCKS", "true");
     walletState.connected = false;
     walletState.address = null;
     walletState.network = null;
   });
 
   afterEach(() => {
+    vi.unstubAllEnvs();
     vi.useRealTimers();
   });
 
-  it("uses disconnected state from useWallet for the empty state", () => {
-    renderRecipient();
+  it("uses disconnected state from useWallet for the empty state", async () => {
+    await renderRecipient();
 
-    expect(screen.getByRole("region", { name: "Recipient empty state" })).toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: /Withdraw 22,600 USDC/i }),
+      screen.getByRole("region", { name: "Recipient empty state" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Withdraw 6,700 USDC/i }),
     ).not.toBeInTheDocument();
   });
 
-  it("enables the withdraw surface when useWallet reports a connected wallet", () => {
+  it("enables the withdraw surface when useWallet reports a connected wallet", async () => {
     walletState.connected = true;
+    walletState.address =
+      "GATDOSCZNJ5YZHNOX7IOD4QDCQSTMR2YNF5IXHFNX3H6B4ICCMSDLOWN";
     // Match the expected network so the on-chain mismatch guard does not
     // disable the withdraw action.
     walletState.network = "TESTNET";
 
-    renderRecipient();
+    await renderRecipient();
 
     expect(
-      screen.getByRole("button", { name: /Withdraw 22,600 USDC/i }),
+      screen.getByRole("button", { name: /Withdraw 6,700 USDC/i }),
     ).toBeEnabled();
     expect(screen.getByText("Withdrawable now")).toBeInTheDocument();
   });

--- a/src/pages/Recipient.tsx
+++ b/src/pages/Recipient.tsx
@@ -6,6 +6,11 @@ import ZeroAccrualBanner from "../components/ZeroAccrualBanner";
 import { useWallet } from "../components/wallet-connect/Walletcontext";
 import { useToast } from "../components/toast/ToastProvider";
 import { withdraw } from "../lib/stellar/tx";
+import {
+  getRecipientStreams,
+  streamRecordToRecipientStream,
+} from "../lib/api/streamsService";
+import type { RecipientStream } from "../components/recipient/RecipientStreams";
 import "./Streams.css";
 import "./Recipient.css";
 
@@ -14,18 +19,53 @@ export default function Recipient() {
   const { addToast } = useToast();
 
   const [loading, setLoading] = useState(true);
-  const [txState, setTxState] = useState<"idle" | "signing" | "submitting" | "confirmed" | "error">("idle");
+  const [streams, setStreams] = useState<RecipientStream[]>([]);
+  const [txState, setTxState] = useState<
+    "idle" | "signing" | "submitting" | "confirmed" | "error"
+  >("idle");
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
 
   useEffect(() => {
-    const t = setTimeout(() => setLoading(false), 2000);
-    return () => clearTimeout(t);
-  }, []);
+    if (!wallet.connected || !wallet.address) {
+      setStreams([]);
+      setLoading(false);
+      return undefined;
+    }
 
-  const balance: number = 22600.0;
-  const activeStreams = 2;
-  const totalAccrued = 43250.0;
-  const totalWithdrawn = 20650.0;
+    let cancelled = false;
+    setLoading(true);
+    const minimumSkeleton = new Promise<void>((resolve) => {
+      setTimeout(resolve, 2000);
+    });
+
+    Promise.all([getRecipientStreams(wallet.address), minimumSkeleton])
+      .then(([records]) => {
+        if (cancelled) return;
+        setStreams(records.map(streamRecordToRecipientStream));
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setStreams([]);
+        setErrorMsg("Unable to load incoming streams.");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [wallet.address, wallet.connected]);
+
+  const balance = streams.reduce(
+    (total, stream) => total + (stream.withdrawableAmount ?? 0),
+    0,
+  );
+  const activeStreams = streams.filter(
+    (stream) => stream.status === "active",
+  ).length;
+  const totalAccrued = balance;
+  const totalWithdrawn = 0;
 
   const walletConnected = wallet.connected;
   const hasStreams = activeStreams > 0;
@@ -34,9 +74,10 @@ export default function Recipient() {
 
   // Zero-accrual: connected + streams exist + no withdrawable balance yet
   const isZeroAccrual = walletConnected && hasStreams && balance === 0;
-  
+
   const isPending = txState === "signing" || txState === "submitting";
-  const disabled = !walletConnected || balance === 0 || networkMismatch || isPending;
+  const disabled =
+    !walletConnected || balance === 0 || networkMismatch || isPending;
 
   const handleWithdraw = async () => {
     if (disabled) return;
@@ -53,10 +94,14 @@ export default function Recipient() {
       setTxState("confirmed");
       addToast("Withdrawal completed successfully on-chain!", "success");
       setTimeout(() => setTxState("idle"), 5000);
-    } catch (err: any) {
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
       setTxState("error");
-      setErrorMsg(err.message || "Withdrawal failed.");
-      addToast(`Withdrawal failed: ${err.message || err}`, "error");
+      setErrorMsg(message || "Withdrawal failed.");
+      addToast(
+        `Withdrawal failed: ${message || "Withdrawal failed."}`,
+        "error",
+      );
     }
   };
 
@@ -107,8 +152,12 @@ export default function Recipient() {
             withdrawal to your connected wallet.
           </p>
           {(errorMsg || networkMismatch) && (
-            <p className="validation-message validation-message--error" style={{ color: "var(--color-danger)", marginTop: "1rem" }} role="alert">
-              {networkMismatch 
+            <p
+              className="validation-message validation-message--error"
+              style={{ color: "var(--color-danger)", marginTop: "1rem" }}
+              role="alert"
+            >
+              {networkMismatch
                 ? `Wrong network: Freighter is connected to ${wallet.network?.toUpperCase()}, but Fluxora is configured for ${wallet.expectedNetworkLabel}.`
                 : errorMsg}
             </p>
@@ -158,7 +207,9 @@ export default function Recipient() {
         </div>
         <div className="streams-summary-card">
           <span>Withdrawable now</span>
-          <strong style={{ color: "var(--accent)" }}>{balance.toLocaleString()} USDC</strong>
+          <strong style={{ color: "var(--accent)" }}>
+            {balance.toLocaleString()} USDC
+          </strong>
           <p>Available for immediate withdrawal.</p>
         </div>
       </section>
@@ -169,12 +220,13 @@ export default function Recipient() {
           <div>
             <h2>Incoming streams</h2>
             <p className="streams-subtitle">
-              Review and manage each individual stream currently committing funds to you.
+              Review and manage each individual stream currently committing
+              funds to you.
             </p>
           </div>
         </div>
         <div className="mt-6">
-          <RecipientStreams />
+          <RecipientStreams streams={streams} />
         </div>
       </section>
     </main>

--- a/src/pages/Streams.test.tsx
+++ b/src/pages/Streams.test.tsx
@@ -1,6 +1,13 @@
 vi.unmock("../components/toast/ToastProvider");
 
-import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import Streams from "./Streams";
@@ -22,9 +29,11 @@ function mockMatchMedia(matches: boolean) {
       matches,
       media: "(prefers-reduced-motion: reduce)",
       onchange: null,
-      addEventListener: vi.fn((_: string, callback: MatchMediaChangeHandler) => {
-        listeners.push(callback);
-      }),
+      addEventListener: vi.fn(
+        (_: string, callback: MatchMediaChangeHandler) => {
+          listeners.push(callback);
+        },
+      ),
       removeEventListener: vi.fn(
         (_: string, callback: MatchMediaChangeHandler) => {
           const index = listeners.indexOf(callback);
@@ -44,6 +53,8 @@ function mockMatchMedia(matches: boolean) {
 }
 
 function renderStreams() {
+  vi.stubEnv("VITE_USE_MOCKS", "true");
+
   return render(
     <ToastProvider>
       <MemoryRouter initialEntries={["/app/streams"]}>
@@ -137,7 +148,9 @@ describe("Streams disclosure motion", () => {
 
     expect(list).toHaveAttribute("data-virtualized", "false");
     expect(screen.getByText(streamRecords[0]!.name)).toBeInTheDocument();
-    expect(screen.getByText(streamRecords[streamRecords.length - 1]!.name)).toBeInTheDocument();
+    expect(
+      screen.getByText(streamRecords[streamRecords.length - 1]!.name),
+    ).toBeInTheDocument();
   });
 
   it("keeps the stream list in sync after filtering and sorting", async () => {
@@ -155,9 +168,12 @@ describe("Streams disclosure motion", () => {
     expect(cards[0]).toHaveTextContent("Dev Grant - Alice");
     expect(cards[1]).toHaveTextContent("Marketing Budget");
 
-    fireEvent.change(screen.getByLabelText("Search streams by name, ID or recipient"), {
-      target: { value: "Nebula" },
-    });
+    fireEvent.change(
+      screen.getByLabelText("Search streams by name, ID or recipient"),
+      {
+        target: { value: "Nebula" },
+      },
+    );
 
     expect(screen.getAllByRole("article")).toHaveLength(1);
     expect(screen.getByText("Marketing Budget")).toBeInTheDocument();
@@ -169,13 +185,20 @@ describe("Streams disclosure motion", () => {
     renderStreams();
     await finishLoading();
 
-    expect(screen.queryByText(/^Showing \d+ streams\.$/)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/^Showing \d+ streams\.$/),
+    ).not.toBeInTheDocument();
 
-    fireEvent.change(screen.getByLabelText("Search streams by name, ID or recipient"), {
-      target: { value: "Marketing" },
-    });
+    fireEvent.change(
+      screen.getByLabelText("Search streams by name, ID or recipient"),
+      {
+        target: { value: "Marketing" },
+      },
+    );
 
-    expect(screen.queryByText(/^Showing \d+ streams\.$/)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/^Showing \d+ streams\.$/),
+    ).not.toBeInTheDocument();
 
     await act(async () => {
       vi.advanceTimersByTime(300);
@@ -189,9 +212,12 @@ describe("Streams disclosure motion", () => {
     renderStreams();
     await finishLoading();
 
-    fireEvent.change(screen.getByLabelText("Search streams by name, ID or recipient"), {
-      target: { value: "STR-" },
-    });
+    fireEvent.change(
+      screen.getByLabelText("Search streams by name, ID or recipient"),
+      {
+        target: { value: "STR-" },
+      },
+    );
     fireEvent.click(screen.getByRole("button", { name: "Active" }));
     fireEvent.change(screen.getByLabelText(/Sort streams/i), {
       target: { value: "name" },
@@ -200,7 +226,9 @@ describe("Streams disclosure motion", () => {
     await act(async () => {
       vi.advanceTimersByTime(299);
     });
-    expect(screen.queryByText(/^Showing \d+ streams\.$/)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/^Showing \d+ streams\.$/),
+    ).not.toBeInTheDocument();
 
     await act(async () => {
       vi.advanceTimersByTime(1);
@@ -245,7 +273,9 @@ describe("Streams card recipient copy", () => {
       expect(writeText).toHaveBeenCalledWith(stream.recipientAddress);
     });
     expect(
-      await screen.findByText(`Recipient for ${stream.name} copied to your clipboard.`),
+      await screen.findByText(
+        `Recipient for ${stream.name} copied to your clipboard.`,
+      ),
     ).toBeInTheDocument();
     expect(streamCard).toHaveAttribute("aria-selected", "false");
     expect(streamCard).toHaveAttribute("aria-expanded", "true");

--- a/src/pages/Streams.tsx
+++ b/src/pages/Streams.tsx
@@ -21,12 +21,11 @@ import { Pagination } from "../components/Pagination";
 import StreamTimeline from "../components/StreamTimeline";
 import VirtualList from "../components/VirtualList";
 import {
-  getStreamRecord,
-  streamRecords,
   type StreamHealth,
   type StreamRecord,
   type StreamStatus,
 } from "../data/streamRecords";
+import { getStreams as fetchStreams } from "../lib/api/streamsService";
 import {
   formatDateWithTimezone,
   getRelativeTime,
@@ -38,7 +37,6 @@ import { useLiveAnnouncer } from "../hooks/useLiveAnnouncer";
 import { usePrefersReducedMotion } from "../hooks/usePrefersReducedMotion";
 import "./Streams.css";
 import TruncatedAddress from "../components/common/TruncatedAddress";
-
 
 type StatusFilter = "All" | StreamStatus;
 
@@ -244,16 +242,19 @@ const StreamCard = memo(function StreamCard({
     onCopyRecipientError(stream);
   }, [onCopyRecipientError, stream]);
 
-  const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLElement>) => {
-    // Enter/Space selects the card; do not intercept if a button inside is focused
-    if (
-      e.target === e.currentTarget &&
-      (e.key === "Enter" || e.key === " ")
-    ) {
-      e.preventDefault();
-      handleSelect();
-    }
-  }, [handleSelect]);
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLElement>) => {
+      // Enter/Space selects the card; do not intercept if a button inside is focused
+      if (
+        e.target === e.currentTarget &&
+        (e.key === "Enter" || e.key === " ")
+      ) {
+        e.preventDefault();
+        handleSelect();
+      }
+    },
+    [handleSelect],
+  );
 
   const classNames = [
     "stream-card",
@@ -316,8 +317,8 @@ const StreamCard = memo(function StreamCard({
         <div className="stream-meta-block">
           <span>Recipient</span>
           <strong>{stream.recipientName}</strong>
-          <TruncatedAddress 
-            address={stream.recipientAddress} 
+          <TruncatedAddress
+            address={stream.recipientAddress}
             onCopy={handleRecipientCopied}
             onCopyStateChange={(state) => {
               if (state === "error") {
@@ -351,10 +352,16 @@ const StreamCard = memo(function StreamCard({
             className={`stream-time-bar__item stream-time-bar__cliff is-${cliffStatus}`}
             aria-label={`Cliff date: ${formatDateWithTimezone(stream.cliffDate)} (${cliffStatus})`}
           >
-            <span className="stream-time-bar__icon" aria-hidden="true">⏱</span>
+            <span className="stream-time-bar__icon" aria-hidden="true">
+              ⏱
+            </span>
             <span className="stream-time-bar__label">Cliff</span>
-            <span className="stream-time-bar__date">{formatDateWithTimezone(stream.cliffDate)}</span>
-            <span className="stream-time-bar__relative">({getRelativeTime(stream.cliffDate)})</span>
+            <span className="stream-time-bar__date">
+              {formatDateWithTimezone(stream.cliffDate)}
+            </span>
+            <span className="stream-time-bar__relative">
+              ({getRelativeTime(stream.cliffDate)})
+            </span>
           </div>
         )}
         {stream.endDate && (
@@ -362,9 +369,13 @@ const StreamCard = memo(function StreamCard({
             className={`stream-time-bar__item stream-time-bar__end is-${urgency.end}`}
             aria-label={`End date: ${formatDateWithTimezone(stream.endDate)} (${endRelative})`}
           >
-            <span className="stream-time-bar__icon" aria-hidden="true">→</span>
+            <span className="stream-time-bar__icon" aria-hidden="true">
+              →
+            </span>
             <span className="stream-time-bar__label">End</span>
-            <span className="stream-time-bar__date">{formatDateWithTimezone(stream.endDate)}</span>
+            <span className="stream-time-bar__date">
+              {formatDateWithTimezone(stream.endDate)}
+            </span>
             <span className="stream-time-bar__relative">({endRelative})</span>
           </div>
         )}
@@ -430,7 +441,9 @@ const StreamCard = memo(function StreamCard({
                 <div className="stream-panel__row">
                   <span className="stream-panel__row-label">End date</span>
                   <div className="stream-panel__row-value">
-                    {formatDetailTime(stream.endDate, { includeTimezone: true })}
+                    {formatDetailTime(stream.endDate, {
+                      includeTimezone: true,
+                    })}
                   </div>
                 </div>
                 <div className="stream-panel__row">
@@ -505,8 +518,12 @@ function StreamDetail({
           <div className="stream-detail__meta">
             <span className="stream-chip">{stream.id}</span>
             <span className="stream-chip">{stream.recipientName}</span>
-            <span className="stream-chip">{formatMonthlyRate(stream.monthlyRate)}</span>
-            <span className="stream-chip">Ends {formatDate(stream.endDate)}</span>
+            <span className="stream-chip">
+              {formatMonthlyRate(stream.monthlyRate)}
+            </span>
+            <span className="stream-chip">
+              Ends {formatDate(stream.endDate)}
+            </span>
           </div>
         </div>
 
@@ -590,8 +607,8 @@ function StreamDetail({
                 <div className="stream-panel__row-value">
                   {stream.recipientName}
                   <div className="mt-1">
-                    <TruncatedAddress 
-                      address={stream.recipientAddress} 
+                    <TruncatedAddress
+                      address={stream.recipientAddress}
                       onCopy={onCopyAddress}
                     />
                   </div>
@@ -647,7 +664,10 @@ function StreamDetail({
             <h2 className="stream-panel__header">Timeline</h2>
             <div className="stream-timeline">
               {stream.timeline.map((event) => (
-                <div className="stream-timeline__item" key={event.date + event.title}>
+                <div
+                  className="stream-timeline__item"
+                  key={event.date + event.title}
+                >
                   <div className="stream-timeline__date">
                     {formatDate(event.date)}
                   </div>
@@ -745,12 +765,12 @@ export default function Streams() {
   const hasMountedFilterAnnouncer = useRef(false);
 
   const [loading, setLoading] = useState(true);
+  const [streams, setStreams] = useState<StreamRecord[]>([]);
+  const [streamsError, setStreamsError] = useState<string | null>(null);
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("All");
   const [searchQuery, setSearchQuery] = useState("");
   const [sortBy, setSortBy] = useState("recent");
-  const [expandedStreamId, setExpandedStreamId] = useState<string>(
-    streamRecords[0]?.id ?? "",
-  );
+  const [expandedStreamId, setExpandedStreamId] = useState<string>("");
   const [selectedStreamId, setSelectedStreamId] = useState<string>("");
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
   const [isSuccessModalOpen, setIsSuccessModalOpen] = useState(false);
@@ -766,16 +786,38 @@ export default function Streams() {
   const walletConnected = true;
 
   useEffect(() => {
-    const timer = window.setTimeout(() => setLoading(false), 2000);
-    return () => window.clearTimeout(timer);
+    let cancelled = false;
+    const minimumSkeleton = new Promise<void>((resolve) => {
+      window.setTimeout(resolve, 2000);
+    });
+
+    Promise.all([fetchStreams(), minimumSkeleton])
+      .then(([records]) => {
+        if (cancelled) return;
+        setStreams(records);
+        setExpandedStreamId((current) => current || records[0]?.id || "");
+        setStreamsError(null);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setStreams([]);
+        setStreamsError("Unable to load streams.");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
-  const activeStreams = streamRecords.filter((stream) => stream.status === "Active");
+  const activeStreams = streams.filter((stream) => stream.status === "Active");
   const monthlyOutflow = activeStreams.reduce(
     (total, stream) => total + stream.monthlyRate,
     0,
   );
-  const withdrawableNow = streamRecords.reduce(
+  const withdrawableNow = streams.reduce(
     (total, stream) => total + stream.withdrawableAmount,
     0,
   );
@@ -786,7 +828,7 @@ export default function Streams() {
   const visibleStreams = useMemo(() => {
     const normalizedSearch = searchQuery.toLowerCase();
 
-    return streamRecords
+    return streams
       .filter((stream) => {
         const matchesStatus =
           statusFilter === "All" || stream.status === statusFilter;
@@ -802,7 +844,7 @@ export default function Streams() {
         // Default to recent (higher ID first for demo)
         return b.id.localeCompare(a.id);
       });
-  }, [searchQuery, sortBy, statusFilter]);
+  }, [searchQuery, sortBy, statusFilter, streams]);
 
   useEffect(() => {
     if (!hasMountedFilterAnnouncer.current) {
@@ -820,8 +862,10 @@ export default function Streams() {
 
     return () => window.clearTimeout(timer);
   }, [announce, searchQuery, sortBy, statusFilter, visibleStreams.length]);
-  const selectedStream = streamId ? getStreamRecord(streamId) : undefined;
-  const hasStreams = streamRecords.length > 0;
+  const selectedStream = streamId
+    ? streams.find((stream) => stream.id === streamId)
+    : undefined;
+  const hasStreams = streams.length > 0;
   const showEmptyState = !selectedStream && (!walletConnected || !hasStreams);
   // Zero-accrual: connected + streams exist + nothing is withdrawable yet
   const showZeroAccrual =
@@ -841,38 +885,44 @@ export default function Streams() {
   }, []);
 
   const handleStreamCreated = useCallback(() => {
-    const generatedId = `STR-${String(streamRecords.length + 1).padStart(3, "0")}`;
+    const generatedId = `STR-${String(streams.length + 1).padStart(3, "0")}`;
     setCreatedStream({
       id: generatedId,
       url: `https://fluxora.io/stream/${generatedId}`,
     });
     setIsCreateModalOpen(false);
     setIsSuccessModalOpen(true);
-  }, []);
+  }, [streams.length]);
 
-  const handleCopyRecipient = useCallback(async (stream: StreamRecord) => {
-    try {
-      await navigator.clipboard.writeText(stream.recipientAddress);
+  const handleCopyRecipient = useCallback(
+    async (stream: StreamRecord) => {
+      try {
+        await navigator.clipboard.writeText(stream.recipientAddress);
+        addToast(
+          `Recipient for ${stream.name} copied to your clipboard.`,
+          "success",
+        );
+      } catch {
+        addToast(
+          "Clipboard access is unavailable in this browser. Copy the address manually instead.",
+          "error",
+        );
+      }
+    },
+    [addToast],
+  );
+
+  const handleRecipientCopied = useCallback(
+    (stream: StreamRecord) => {
       addToast(
         `Recipient for ${stream.name} copied to your clipboard.`,
         "success",
       );
-    } catch {
-      addToast(
-        "Clipboard access is unavailable in this browser. Copy the address manually instead.",
-        "error",
-      );
-    }
-  }, [addToast]);
+    },
+    [addToast],
+  );
 
-  const handleRecipientCopied = useCallback((stream: StreamRecord) => {
-    addToast(
-      `Recipient for ${stream.name} copied to your clipboard.`,
-      "success",
-    );
-  }, [addToast]);
-
-  const handleRecipientCopyError = useCallback((_stream: StreamRecord) => {
+  const handleRecipientCopyError = useCallback(() => {
     addToast(
       "Clipboard access is unavailable in this browser. Copy the address manually instead.",
       "error",
@@ -887,9 +937,12 @@ export default function Streams() {
     setSelectedStreamId(streamId);
   }, []);
 
-  const handleOpenStreamDetail = useCallback((streamId: string) => {
-    navigate(`/app/streams/${streamId}`);
-  }, [navigate]);
+  const handleOpenStreamDetail = useCallback(
+    (streamId: string) => {
+      navigate(`/app/streams/${streamId}`);
+    },
+    [navigate],
+  );
 
   const handleAnnounceStreamToggle = useCallback(
     (streamName: string, nextExpanded: boolean) => {
@@ -935,6 +988,14 @@ export default function Streams() {
       <div aria-live="polite" aria-atomic="true" className="sr-only">
         {announcement}
       </div>
+      {streamsError && (
+        <p
+          className="validation-message validation-message--error"
+          role="alert"
+        >
+          {streamsError}
+        </p>
+      )}
 
       {selectedStream ? (
         <StreamDetail
@@ -983,7 +1044,7 @@ export default function Streams() {
               <button
                 type="button"
                 className="streams-secondary-button"
-                onClick={() => navigate(`/app/streams/${streamRecords[0]?.id}`)}
+                onClick={() => navigate(`/app/streams/${streams[0]?.id}`)}
               >
                 Open featured deep dive
               </button>
@@ -997,9 +1058,7 @@ export default function Streams() {
                 reason="cliff"
                 nextEventDate={nextUnlock}
                 onAction={() => {
-                  const first = streamRecords.find(
-                    (s) => s.status === "Active",
-                  );
+                  const first = streams.find((s) => s.status === "Active");
                   if (first) navigate(`/app/streams/${first.id}`);
                 }}
                 actionLabel="Check cliff date"
@@ -1039,7 +1098,10 @@ export default function Streams() {
                   stream detail route for the complete layout.
                 </p>
               </div>
-              <div className="flex flex-wrap items-center gap-3 w-full mt-4" aria-label="Filter and search streams">
+              <div
+                className="flex flex-wrap items-center gap-3 w-full mt-4"
+                aria-label="Filter and search streams"
+              >
                 <div className="flex-1 min-w-[200px]">
                   <Input
                     id="streams-search"

--- a/src/pages/__tests__/Recipient.test.tsx
+++ b/src/pages/__tests__/Recipient.test.tsx
@@ -26,9 +26,11 @@ import Recipient from "../Recipient";
 describe("Recipient page accessibility", () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    vi.stubEnv("VITE_USE_MOCKS", "true");
   });
 
   afterEach(() => {
+    vi.unstubAllEnvs();
     vi.useRealTimers();
   });
 
@@ -54,12 +56,14 @@ describe("Recipient page accessibility", () => {
     await renderLoadedRecipient();
 
     const withdrawButton = screen.getByRole("button", {
-      name: /withdraw 22,600 usdc/i,
+      name: /withdraw 6,700 usdc/i,
     });
     expect(withdrawButton).toBeEnabled();
 
     const summary = screen.getByRole("region", { name: /stream summary/i });
     expect(within(summary).getByText(/withdrawable now/i)).toBeInTheDocument();
-    expect(within(summary).getByText(/22,600 usdc/i)).toBeInTheDocument();
+    expect(within(summary).getAllByText(/6,700 usdc/i).length).toBeGreaterThan(
+      0,
+    );
   });
 });


### PR DESCRIPTION
## Summary

Adds a typed streams service layer for Fluxora's Soroban-backed stream data and wires the Treasury, Streams, and Recipient screens through it while keeping seeded mock mode available for demos/tests.

## Changes

- Added `streamsService` with typed methods for treasury metrics, stream lists, stream detail, and recipient streams.
- Added stream payload normalization/sanitization before API data reaches UI state.
- Updated Treasury overview, Streams, and Recipient pages to consume the shared service layer instead of page-local static data.
- Preserved `VITE_USE_MOCKS=true` fixture behavior and documented expected API endpoints in the README.
- Added/updated focused tests for the service, stream rendering, recipient rendering, and demo mode.

## Testing / Verification

- `npm run build`
- `npm run test -- src/lib/api/__tests__/streamsService.test.ts src/components/__tests__/RecipientStreams.test.tsx src/pages/Streams.test.tsx src/components/treasuryOverviewPage/__tests__/demoMode.test.tsx src/pages/Recipient.test.tsx src/pages/__tests__/Recipient.test.tsx`
- `npx eslint src/lib/api/streamsService.ts src/data/streamRecords.ts src/components/treasuryOverviewPage/useTreasury.ts src/components/treasuryOverviewPage/useTreasuryOverviewData.ts src/pages/Streams.tsx src/pages/Recipient.tsx src/components/recipient/RecipientStreams.tsx src/lib/api/__tests__/streamsService.test.ts src/components/__tests__/RecipientStreams.test.tsx src/pages/Streams.test.tsx src/components/treasuryOverviewPage/__tests__/demoMode.test.tsx src/pages/Recipient.test.tsx src/pages/__tests__/Recipient.test.tsx --quiet`

Full `npm run test` still has unrelated existing failures around date-sensitive `timePresentation` expectations and a broken Vitest localStorage setup (`--localstorage-file` invalid path).

Closes #250.
