### PR TITLE
Surface zero-rate accrual reason

### DIFF
--- a/src/pages/Streams.test.tsx
+++ b/src/pages/Streams.test.tsx
@@ -4,7 +4,7 @@ import { act, fireEvent, render, screen, waitFor, within } from "@testing-librar
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import Streams from "./Streams";
-import { streamRecords } from "../data/streamRecords";
+import { streamRecords, type StreamRecord } from "../data/streamRecords";
 import { ToastProvider } from "../components/toast/ToastProvider";
 
 type MatchMediaChangeHandler = (event: MediaQueryListEvent) => void;
@@ -62,11 +62,133 @@ function mockClipboard(writeText: ClipboardMock["writeText"]) {
   });
 }
 
+function cloneStreamRecords(records: StreamRecord[] = streamRecords): StreamRecord[] {
+  return records.map((record) => ({
+    ...record,
+    tags: [...record.tags],
+    timeline: record.timeline.map((event) => ({ ...event })),
+  }));
+}
+
+const originalStreamRecords = cloneStreamRecords();
+
+function replaceStreamRecords(records: StreamRecord[]) {
+  streamRecords.splice(0, streamRecords.length, ...cloneStreamRecords(records));
+}
+
+function restoreStreamRecords() {
+  replaceStreamRecords(originalStreamRecords);
+}
+
+function zeroWithdrawableRecords(
+  activeOverride: Partial<StreamRecord>,
+): StreamRecord[] {
+  return originalStreamRecords.map((record, index) =>
+    index === 0
+      ? {
+          ...record,
+          ...activeOverride,
+          status: "Active",
+          withdrawableAmount: 0,
+        }
+      : {
+          ...record,
+          status: "Completed",
+          withdrawableAmount: 0,
+          remainingAmount: 0,
+          progress: 100,
+        },
+  );
+}
+
 async function finishLoading() {
   await act(async () => {
     vi.advanceTimersByTime(2000);
   });
 }
+
+describe("Streams zero accrual banner reason", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-26T12:00:00Z"));
+    vi.spyOn(window, "scrollTo").mockImplementation(() => {});
+    mockMatchMedia(false);
+  });
+
+  afterEach(() => {
+    restoreStreamRecords();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("shows the rate-zero reason once active streams are past schedule gates", async () => {
+    replaceStreamRecords(
+      zeroWithdrawableRecords({
+        monthlyRate: 0,
+        startDate: "2026-01-01",
+        cliffDate: "2026-01-15",
+        nextUnlockDate: "2026-07-01",
+      }),
+    );
+
+    renderStreams();
+    await finishLoading();
+
+    expect(screen.getByText("Streams configured with zero rate")).toBeInTheDocument();
+    expect(screen.queryByText(/cliff period in progress/i)).not.toBeInTheDocument();
+  });
+
+  it("keeps schedule-future ahead of the rate-zero reason", async () => {
+    replaceStreamRecords(
+      zeroWithdrawableRecords({
+        monthlyRate: 0,
+        startDate: "2026-12-01",
+        cliffDate: "2026-12-15",
+        nextUnlockDate: "2026-12-15",
+      }),
+    );
+
+    renderStreams();
+    await finishLoading();
+
+    expect(screen.getByText(/Streams scheduled/i)).toBeInTheDocument();
+    expect(screen.queryByText("Streams configured with zero rate")).not.toBeInTheDocument();
+  });
+
+  it("keeps cliff ahead of the rate-zero reason after the start date", async () => {
+    replaceStreamRecords(
+      zeroWithdrawableRecords({
+        monthlyRate: 0,
+        startDate: "2026-01-01",
+        cliffDate: "2026-12-01",
+        nextUnlockDate: "2026-12-01",
+      }),
+    );
+
+    renderStreams();
+    await finishLoading();
+
+    expect(screen.getByText(/Streams are live/i)).toBeInTheDocument();
+    expect(screen.queryByText("Streams configured with zero rate")).not.toBeInTheDocument();
+  });
+
+  it("does not show rate-zero copy for nonzero-rate active streams", async () => {
+    replaceStreamRecords(
+      zeroWithdrawableRecords({
+        monthlyRate: 1000,
+        startDate: "2026-01-01",
+        cliffDate: "2026-01-15",
+        nextUnlockDate: "2026-07-01",
+      }),
+    );
+
+    renderStreams();
+    await finishLoading();
+
+    expect(screen.getByText(/Streams are live/i)).toBeInTheDocument();
+    expect(screen.queryByText("Streams configured with zero rate")).not.toBeInTheDocument();
+  });
+});
 
 describe("Streams disclosure motion", () => {
   beforeEach(() => {

--- a/src/pages/Streams.tsx
+++ b/src/pages/Streams.tsx
@@ -16,7 +16,9 @@ import StreamCreatedModal from "../components/Streams/StreamCreatedModal";
 import { useToast } from "../components/toast/ToastProvider";
 import StreamsLoading from "../components/StreamsLoading";
 import Input from "../components/Input";
-import ZeroAccrualBanner from "../components/ZeroAccrualBanner";
+import ZeroAccrualBanner, {
+  type ZeroAccrualReason,
+} from "../components/ZeroAccrualBanner";
 import { Pagination } from "../components/Pagination";
 import StreamTimeline from "../components/StreamTimeline";
 import VirtualList from "../components/VirtualList";
@@ -61,6 +63,62 @@ function formatMonthlyRate(value: number) {
 function formatDate(value?: string) {
   if (!value) return "Not scheduled";
   return formatDateWithTimezone(value);
+}
+
+function isFutureDate(value: string | undefined, currentDate: Date) {
+  return Boolean(value && new Date(value).getTime() > currentDate.getTime());
+}
+
+/**
+ * Selects the most actionable zero-accrual explanation.
+ *
+ * Schedule and cliff states are time gates, so they keep priority over a zero
+ * rate. Once a stream is active past those gates, a zero monthly rate gets the
+ * explicit `rate-zero` reason instead of the generic cliff fallback.
+ */
+function getZeroAccrualContext(
+  activeStreams: StreamRecord[],
+  currentDate = new Date(),
+): { reason: ZeroAccrualReason; nextEventDate?: string; actionLabel: string } {
+  const futureStart = activeStreams
+    .map((stream) => stream.startDate)
+    .filter((date) => isFutureDate(date, currentDate))
+    .sort()[0];
+  if (futureStart) {
+    return {
+      reason: "schedule-future",
+      nextEventDate: futureStart,
+      actionLabel: "View schedule",
+    };
+  }
+
+  const futureCliff = activeStreams
+    .map((stream) => stream.cliffDate)
+    .filter((date) => isFutureDate(date, currentDate))
+    .sort()[0];
+  if (futureCliff) {
+    return {
+      reason: "cliff",
+      nextEventDate: futureCliff,
+      actionLabel: "Check cliff date",
+    };
+  }
+
+  if (activeStreams.some((stream) => stream.monthlyRate === 0)) {
+    return {
+      reason: "rate-zero",
+      actionLabel: "Review streams",
+    };
+  }
+
+  return {
+    reason: "cliff",
+    nextEventDate: activeStreams
+      .map((stream) => stream.nextUnlockDate)
+      .filter(Boolean)
+      .sort()[0],
+    actionLabel: "Check cliff date",
+  };
 }
 
 function getStatusClassName(status: StreamStatus) {
@@ -830,6 +888,7 @@ export default function Streams() {
     hasStreams &&
     withdrawableNow === 0 &&
     activeStreams.length > 0;
+  const zeroAccrualContext = getZeroAccrualContext(activeStreams);
   const effectiveExpandedId = visibleStreams.some(
     (stream) => stream.id === expandedStreamId,
   )
@@ -994,15 +1053,15 @@ export default function Streams() {
           {showZeroAccrual && (
             <div style={{ marginBottom: "2rem" }}>
               <ZeroAccrualBanner
-                reason="cliff"
-                nextEventDate={nextUnlock}
+                reason={zeroAccrualContext.reason}
+                nextEventDate={zeroAccrualContext.nextEventDate ?? nextUnlock}
                 onAction={() => {
                   const first = streamRecords.find(
                     (s) => s.status === "Active",
                   );
                   if (first) navigate(`/app/streams/${first.id}`);
                 }}
-                actionLabel="Check cliff date"
+                actionLabel={zeroAccrualContext.actionLabel}
               />
             </div>
           )}


### PR DESCRIPTION
## Summary
- select the zero-accrual banner reason from active stream schedule, cliff, and monthly-rate state
- preserve schedule-future and cliff priority before using the explicit `rate-zero` reason
- add Streams tests for schedule-future, cliff, rate-zero, and nonzero-rate fallback branches

## Validation
- `node node_modules/vitest/vitest.mjs run src/pages/Streams.test.tsx` (12 tests passed)
- `node node_modules/typescript/bin/tsc -b`
- `node node_modules/vite/bin/vite.js build`

## Security notes
Presentation-only change; no funds or transaction logic depends on the banner reason.

Closes #364