### PR TITLE
Add StreamTimeline segment coverage

### DIFF
--- a/src/components/StreamTimeline.tsx
+++ b/src/components/StreamTimeline.tsx
@@ -1,15 +1,38 @@
 import React from "react";
+import { usePrefersReducedMotion } from "../hooks/usePrefersReducedMotion";
 import "./StreamTimeline.module.css";
 
 export interface StreamTimelineProps {
+  /** ISO-compatible date string for when the stream begins. */
   startDate: string;
+  /** ISO-compatible date string for when the cliff ends, or null for no cliff. */
   cliffDate: string | null;
+  /** ISO-compatible date string used to place the progress marker. */
   currentDate: string;
+  /** ISO-compatible date string for when the stream fully ends. */
   endDate: string;
+  /** Amount currently available for withdrawal, displayed in the screen-reader summary. */
   withdrawableAmount: number;
+  /** Total stream amount, displayed in the screen-reader summary. */
   totalAmount: number;
+  /** Current stream lifecycle state used to style timeline segments. */
   status: "active" | "paused" | "completed" | "upcoming";
+  /** Shows a polite loading indicator while timeline data is refreshing. */
   isLoading?: boolean;
+}
+
+function clampPercent(value: number) {
+  return Math.max(0, Math.min(100, value));
+}
+
+function percentBetween(startTime: number, endTime: number, valueTime: number) {
+  const duration = endTime - startTime;
+
+  if (duration <= 0) {
+    return valueTime >= endTime ? 100 : 0;
+  }
+
+  return clampPercent(((valueTime - startTime) / duration) * 100);
 }
 
 /**
@@ -37,6 +60,8 @@ export const StreamTimeline: React.FC<StreamTimelineProps> = ({
   status,
   isLoading = false,
 }) => {
+  const prefersReducedMotion = usePrefersReducedMotion();
+
   // Parse dates
   const start = new Date(startDate);
   const cliff = cliffDate ? new Date(cliffDate) : null;
@@ -61,22 +86,20 @@ export const StreamTimeline: React.FC<StreamTimelineProps> = ({
   }
 
   // Calculate segments
-  const totalDuration = end.getTime() - start.getTime();
   const cliffEnd = cliff ? cliff.getTime() : start.getTime();
   const currentTime = Math.min(current.getTime(), end.getTime());
 
   // Cliff segment percentage (0-100)
-  const cliffPercent = cliff
-    ? Math.max(
-        0,
-        Math.min(100, ((cliffEnd - start.getTime()) / totalDuration) * 100),
-      )
-    : 0;
+  const cliffPercent =
+    cliff && cliffEnd > start.getTime()
+      ? percentBetween(start.getTime(), end.getTime(), cliffEnd)
+      : 0;
 
   // Accrual segment percentage (from start to current)
-  const accrualPercent = Math.max(
-    0,
-    Math.min(100, ((currentTime - start.getTime()) / totalDuration) * 100),
+  const accrualPercent = percentBetween(
+    start.getTime(),
+    end.getTime(),
+    currentTime,
   );
 
   // Format date for display (handle long Stellar addresses)
@@ -101,6 +124,7 @@ export const StreamTimeline: React.FC<StreamTimelineProps> = ({
       className="stream-timeline-container"
       role="region"
       aria-label="Stream timeline visualization"
+      data-reduced-motion={prefersReducedMotion ? "true" : "false"}
     >
       {/* Accessible text summary for screen readers */}
       <div className="stream-timeline__sr-summary" role="doc-subtitle">

--- a/src/components/__tests__/StreamTimeline.test.tsx
+++ b/src/components/__tests__/StreamTimeline.test.tsx
@@ -1,0 +1,145 @@
+import { render, screen } from "@testing-library/react";
+import type { ComponentProps } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { StreamTimeline } from "../StreamTimeline";
+
+type ChangeHandler = (event: MediaQueryListEvent) => void;
+
+function mockReducedMotion(matches: boolean) {
+  const listeners: ChangeHandler[] = [];
+  const mediaQuery = {
+    matches,
+    media: "(prefers-reduced-motion: reduce)",
+    addEventListener: vi.fn((_: string, listener: ChangeHandler) => {
+      listeners.push(listener);
+    }),
+    removeEventListener: vi.fn((_: string, listener: ChangeHandler) => {
+      const index = listeners.indexOf(listener);
+      if (index !== -1) listeners.splice(index, 1);
+    }),
+    addListener: vi.fn((listener: ChangeHandler) => {
+      listeners.push(listener);
+    }),
+    removeListener: vi.fn((listener: ChangeHandler) => {
+      const index = listeners.indexOf(listener);
+      if (index !== -1) listeners.splice(index, 1);
+    }),
+  };
+
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    writable: true,
+    value: vi.fn().mockReturnValue(mediaQuery),
+  });
+}
+
+function renderTimeline(
+  props: Partial<ComponentProps<typeof StreamTimeline>> = {},
+) {
+  return render(
+    <StreamTimeline
+      startDate="2026-01-01T00:00:00Z"
+      cliffDate="2026-01-26T00:00:00Z"
+      currentDate="2026-02-20T00:00:00Z"
+      endDate="2026-04-11T00:00:00Z"
+      withdrawableAmount={500}
+      totalAmount={1_000}
+      status="active"
+      {...props}
+    />,
+  );
+}
+
+describe("StreamTimeline", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders cliff, accrual, remaining, and current marker positions", () => {
+    mockReducedMotion(false);
+
+    renderTimeline();
+
+    expect(
+      screen.getByRole("progressbar", { name: /stream accrual progress/i }),
+    ).toHaveAttribute("aria-valuenow", "50");
+    expect(screen.getByRole("img", { name: /cliff period/i })).toHaveStyle({
+      width: "25%",
+    });
+    expect(screen.getByRole("img", { name: /accrual period/i })).toHaveStyle({
+      width: "25%",
+    });
+    expect(screen.getByRole("img", { name: /remaining period/i })).toHaveStyle({
+      width: "50%",
+    });
+    expect(screen.getByRole("img", { name: /current date/i })).toHaveStyle({
+      left: "50%",
+    });
+  });
+
+  it("keeps accrual hidden until progress passes the cliff", () => {
+    mockReducedMotion(false);
+
+    renderTimeline({
+      currentDate: "2026-01-11T00:00:00Z",
+    });
+
+    expect(
+      screen.getByRole("progressbar", { name: /stream accrual progress/i }),
+    ).toHaveAttribute("aria-valuenow", "10");
+    expect(
+      screen.queryByRole("img", { name: /accrual period/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("img", { name: /remaining period/i })).toHaveStyle({
+      width: "90%",
+    });
+  });
+
+  it("caps completed timelines at 100 percent and hides remaining state", () => {
+    mockReducedMotion(false);
+
+    renderTimeline({
+      currentDate: "2026-04-20T00:00:00Z",
+      status: "completed",
+    });
+
+    expect(
+      screen.getByRole("progressbar", { name: /stream accrual progress/i }),
+    ).toHaveAttribute("aria-valuenow", "100");
+    expect(
+      screen.queryByRole("img", { name: /remaining period/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("img", { name: /current date/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("exposes the reduced-motion rendering path", () => {
+    mockReducedMotion(true);
+
+    renderTimeline();
+
+    expect(
+      screen.getByRole("region", { name: /stream timeline visualization/i }),
+    ).toHaveAttribute("data-reduced-motion", "true");
+  });
+
+  it("handles start, cliff, and end on the same instant without NaN styles", () => {
+    mockReducedMotion(false);
+
+    const { container } = renderTimeline({
+      startDate: "2026-01-01T00:00:00Z",
+      cliffDate: "2026-01-01T00:00:00Z",
+      currentDate: "2026-01-01T00:00:00Z",
+      endDate: "2026-01-01T00:00:00Z",
+    });
+
+    expect(
+      screen.getByRole("progressbar", { name: /stream accrual progress/i }),
+    ).toHaveAttribute("aria-valuenow", "100");
+    expect(
+      screen.queryByRole("img", { name: /cliff period/i }),
+    ).not.toBeInTheDocument();
+    expect(container.innerHTML).not.toContain("NaN");
+  });
+});


### PR DESCRIPTION
## Summary
- add safe timeline percentage helpers so degenerate start/end and zero-length cliff cases do not produce NaN styles
- expose the reduced-motion rendering path through the existing reduced-motion hook
- document StreamTimeline props with TSDoc and add focused tests for cliff/accrual/remaining segments, the progress marker, completed state, reduced motion, and degenerate dates

## Validation
- `node node_modules/vitest/vitest.mjs run StreamTimeline --reporter=dot` (1 file, 5 tests passed)
- `node node_modules/typescript/bin/tsc -b`
- `node node_modules/vite/bin/vite.js build`

## Security notes
Presentation-only timeline rendering and tests; no funds-transfer logic changed.

Closes #382