### PR TITLE
Add Button component coverage

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -23,43 +23,44 @@
 import React, { ReactNode, ButtonHTMLAttributes } from 'react';
 import styles from './Button.module.css';
 
-interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  /** Icon size */
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  /** Size token applied to the optional icon wrapper. */
   iconSize?: 'xs' | 'sm' | 'md' | 'lg';
-  /** Button content (text, icon, or both) */
+
+  /** Button label, icon-adjacent text, or custom inline content. */
   children?: ReactNode;
-  
-  /** Visual variant */
+
+  /** Visual style variant mapped to the design system button classes. */
   variant?: 'primary' | 'secondary' | 'danger' | 'success' | 'ghost';
-  
-  /** Button size */
+
+  /** Control size; medium is the default base style. */
   size?: 'sm' | 'md' | 'lg';
-  
-  /** Full width button */
+
+  /** Expands the button to fill the width of its parent container. */
   fullWidth?: boolean;
-  
-  /** Icon element (SVG, component, etc.) */
+
+  /** Optional icon element rendered before the button content. */
   icon?: ReactNode;
-  
-  /** Icon-only button (no text) */
+
+  /** Applies icon-only sizing; callers should provide an accessible name. */
   iconOnly?: boolean;
-  
-  /** Loading state - shows spinner and disables interaction */
+
+  /** Shows the loading spinner, sets busy/disabled attributes, and blocks clicks. */
   loading?: boolean;
-  
-  /** Loading spinner content (override default) */
+
+  /** Optional content rendered next to the spinner while loading. */
   loadingContent?: ReactNode;
-  
-  /** Disabled state */
+
+  /** Disables the native button and exposes the disabled state to assistive tech. */
   disabled?: boolean;
-  
-  /** Type of button */
+
+  /** Native button type; defaults to "button" to avoid accidental form submits. */
   type?: 'button' | 'submit' | 'reset';
-  
-  /** Click handler */
+
+  /** Click handler invoked only when the button is not disabled or loading. */
   onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
-  
-  /** Additional CSS classes */
+
+  /** Additional class names appended after the design-system classes. */
   className?: string;
 }
 

--- a/src/components/__tests__/Button.test.tsx
+++ b/src/components/__tests__/Button.test.tsx
@@ -1,0 +1,112 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import Button, { type ButtonProps } from "../Button";
+import styles from "../Button.module.css";
+
+const variants: Array<NonNullable<ButtonProps["variant"]>> = [
+  "primary",
+  "secondary",
+  "danger",
+  "success",
+  "ghost",
+];
+
+function variantClass(variant: NonNullable<ButtonProps["variant"]>) {
+  return styles[
+    `button${variant.charAt(0).toUpperCase()}${variant.slice(1)}` as keyof typeof styles
+  ];
+}
+
+describe("Button", () => {
+  it.each(variants)("renders the %s variant class", (variant) => {
+    render(<Button variant={variant}>{variant}</Button>);
+
+    expect(screen.getByRole("button", { name: variant })).toHaveClass(
+      styles.button,
+      variantClass(variant),
+    );
+  });
+
+  it("defaults to a non-submitting button type", () => {
+    render(<Button>Save</Button>);
+
+    expect(screen.getByRole("button", { name: "Save" })).toHaveAttribute(
+      "type",
+      "button",
+    );
+  });
+
+  it("invokes the click handler when enabled", () => {
+    const onClick = vi.fn();
+
+    render(<Button onClick={onClick}>Continue</Button>);
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("suppresses clicks and exposes disabled state when disabled", () => {
+    const onClick = vi.fn();
+
+    render(
+      <Button disabled onClick={onClick}>
+        Disabled action
+      </Button>,
+    );
+
+    const button = screen.getByRole("button", { name: "Disabled action" });
+    fireEvent.click(button);
+
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute("aria-disabled", "true");
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("suppresses clicks and exposes busy state while loading", () => {
+    const onClick = vi.fn();
+
+    render(
+      <Button loading loadingContent="Working" onClick={onClick}>
+        Submit
+      </Button>,
+    );
+
+    const button = screen.getByRole("button", { name: "Working" });
+    fireEvent.click(button);
+
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute("aria-busy", "true");
+    expect(button).toHaveAttribute("aria-disabled", "true");
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("forwards accessibility attributes and caller class names", () => {
+    render(
+      <Button
+        aria-describedby="button-help"
+        aria-label="Refresh streams"
+        className="custom-button"
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: "Refresh streams" });
+
+    expect(button).toHaveAttribute("aria-describedby", "button-help");
+    expect(button).toHaveClass(styles.button, "custom-button");
+  });
+
+  it("renders icon-only buttons with the supplied accessible name", () => {
+    render(
+      <Button
+        aria-label="Close"
+        icon={<svg data-testid="close-icon" />}
+        iconOnly
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Close" })).toHaveClass(
+      styles.buttonIconOnly,
+    );
+    expect(screen.getByTestId("close-icon")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- export and document the shared Button props interface with clearer TSDoc
- add focused unit tests for all visual variants, default type handling, click handling, disabled/loading states, forwarded ARIA attributes, caller classes, and icon-only rendering
- verify loading buttons expose busy/disabled semantics and suppress clicks

## Validation
- `node node_modules/vitest/vitest.mjs run src/components/__tests__/Button.test.tsx --reporter=dot` (1 file, 11 tests passed)
- `node node_modules/vitest/vitest.mjs run Button --reporter=dot` (3 files, 17 tests passed)
- `node node_modules/typescript/bin/tsc -b`
- `node node_modules/vite/bin/vite.js build`

## Security notes
Tests and documentation only; no funds-transfer or wallet logic changed.

Closes #381