### PR TITLE
Restore wallet disconnect focus handling

### DIFF
--- a/src/components/navigation/AppNavbar.tsx
+++ b/src/components/navigation/AppNavbar.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { Menu, X, Moon, Sun } from "lucide-react";
 import { useWallet } from "../wallet-connect/Walletcontext";
@@ -134,6 +134,9 @@ export default function AppNavbar({
   } = useWallet();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [connecting, setConnecting] = useState(false);
+  const [restoreConnectFocus, setRestoreConnectFocus] = useState(false);
+  const [walletAnnouncement, setWalletAnnouncement] = useState("");
+  const connectWalletRef = useRef<HTMLAnchorElement>(null);
 
   // Simulate a brief "connecting" state on first mount when wallet restores session
   useEffect(() => {
@@ -141,6 +144,20 @@ export default function AppNavbar({
     const t = setTimeout(() => setConnecting(false), 600);
     return () => clearTimeout(t);
   }, []);
+
+  useEffect(() => {
+    if (!connecting && !connected && restoreConnectFocus) {
+      connectWalletRef.current?.focus();
+      setRestoreConnectFocus(false);
+    }
+  }, [connected, connecting, restoreConnectFocus]);
+
+  useEffect(() => {
+    if (!walletAnnouncement) return undefined;
+
+    const timer = setTimeout(() => setWalletAnnouncement(""), 1500);
+    return () => clearTimeout(timer);
+  }, [walletAnnouncement]);
 
 const location = useLocation();
   const isAppView = connected && location.pathname.startsWith("/app");
@@ -158,12 +175,23 @@ const location = useLocation();
 
   const closeMobile = () => setMobileMenuOpen(false);
 
+  const handleWalletDisconnect = () => {
+    setRestoreConnectFocus(true);
+    setWalletAnnouncement(
+      "Wallet disconnected. Use Connect Wallet to reconnect.",
+    );
+    disconnect();
+  };
+
   return (
     <header
       role="banner"
       aria-label="Global navigation"
       className="sticky top-0 z-50 w-full border-b border-[var(--navbar-border)] bg-[var(--navbar-bg)]/80 backdrop-blur-md"
     >
+      <div className="sr-only" aria-live="polite" aria-atomic="true">
+        {walletAnnouncement}
+      </div>
       <div className="mx-auto flex h-16 max-w-7xl items-center justify-between px-4 sm:px-6">
         {/* Left: Logo */}
         <div className="flex items-center gap-4">
@@ -240,10 +268,11 @@ const location = useLocation();
               network={network ?? "TESTNET"}
               expectedNetwork={expectedNetwork}
               isNetworkMismatch={isNetworkMismatch}
-              onDisconnect={disconnect}
+              onDisconnect={handleWalletDisconnect}
             />
           ) : (
             <Link
+              ref={connectWalletRef}
               to="/connect-wallet"
               aria-label="Connect your Stellar wallet"
               className="px-5 h-[44px] rounded-full bg-[var(--cta-bg)] text-white text-sm font-semibold shadow-[var(--cta-shadow)] hover:opacity-90 transition-opacity outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] flex items-center"
@@ -323,12 +352,13 @@ const location = useLocation();
                 expectedNetwork={expectedNetwork}
                 isNetworkMismatch={isNetworkMismatch}
                 onDisconnect={() => {
-                  disconnect();
+                  handleWalletDisconnect();
                   closeMobile();
                 }}
               />
             ) : (
               <Link
+                ref={connectWalletRef}
                 to="/connect-wallet"
                 onClick={closeMobile}
                 aria-label="Connect your Stellar wallet"

--- a/src/components/navigation/WalletStatus.tsx
+++ b/src/components/navigation/WalletStatus.tsx
@@ -81,10 +81,17 @@ export default function WalletStatus({
     triggerRef.current?.focus();
   };
 
+  const closeMenuWithoutFocus = () => {
+    setOpen(false);
+    setConfirmingDisconnect(false);
+  };
+
   const handleConfirmDisconnect = () => {
     onDisconnect?.();
     setAnnouncement("Wallet disconnected. Use Connect Wallet to reconnect.");
-    closeMenu();
+    // The connected trigger may unmount after disconnect; the parent focuses
+    // the newly rendered Connect Wallet trigger instead.
+    closeMenuWithoutFocus();
   };
 
   return (

--- a/src/components/navigation/__tests__/AppNavbar.disconnect.test.tsx
+++ b/src/components/navigation/__tests__/AppNavbar.disconnect.test.tsx
@@ -1,4 +1,5 @@
 import { act, fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import AppNavbar from "../AppNavbar";
 import { ThemeProvider } from "../../../theme/ThemeProvider";
@@ -8,6 +9,12 @@ let walletState = {
   connected: true,
   address: "GABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890" as string | undefined,
   network: "TESTNET" as string | undefined,
+};
+type MockLinkProps = Omit<
+  React.AnchorHTMLAttributes<HTMLAnchorElement>,
+  "href"
+> & {
+  to: string;
 };
 
 vi.mock("../../wallet-connect/Walletcontext", () => ({
@@ -23,14 +30,12 @@ vi.mock("../../wallet-connect/Walletcontext", () => ({
 }));
 
 vi.mock("react-router-dom", () => ({
-  Link: ({
-    children,
-    to,
-    ...props
-  }: React.PropsWithChildren<{ to: string; [key: string]: unknown }>) => (
-    <a href={to} {...props}>
-      {children}
-    </a>
+  Link: React.forwardRef<HTMLAnchorElement, MockLinkProps>(
+    ({ children, to, ...props }, ref) => (
+      <a ref={ref} href={to} {...props}>
+        {children}
+      </a>
+    ),
   ),
   useLocation: () => ({ pathname: "/app" }),
 }));
@@ -58,8 +63,8 @@ describe("AppNavbar wallet disconnect flow", () => {
     vi.useRealTimers();
   });
 
-  it("requires confirmation before disconnecting and returns focus to the wallet trigger", () => {
-    renderNavbar();
+  it("requires confirmation before disconnecting and returns focus to the connect trigger", () => {
+    const { rerender } = renderNavbar();
     act(() => vi.runAllTimers());
 
     const walletTrigger = screen.getByRole("button", {
@@ -81,10 +86,27 @@ describe("AppNavbar wallet disconnect flow", () => {
     fireEvent.click(screen.getByRole("button", { name: /disconnect wallet/i }));
 
     expect(disconnect).toHaveBeenCalledTimes(1);
-    expect(walletTrigger).toHaveFocus();
     expect(
-      screen.getByText("Wallet disconnected. Use Connect Wallet to reconnect."),
-    ).toBeInTheDocument();
+      screen.getAllByText(
+        "Wallet disconnected. Use Connect Wallet to reconnect.",
+      ),
+    ).not.toHaveLength(0);
+
+    walletState = {
+      connected: false,
+      address: "",
+      network: undefined,
+    };
+
+    rerender(
+      <ThemeProvider>
+        <AppNavbar />
+      </ThemeProvider>,
+    );
+
+    expect(
+      screen.getByRole("link", { name: /connect your stellar wallet/i }),
+    ).toHaveFocus();
   });
 
   it("shows the canonical connect-wallet affordance after disconnect", () => {
@@ -116,5 +138,6 @@ describe("AppNavbar wallet disconnect flow", () => {
       name: /connect your stellar wallet/i,
     });
     expect(connectWallet).toHaveAttribute("href", "/connect-wallet");
+    expect(connectWallet).toHaveFocus();
   });
 });

--- a/src/components/wallet-connect/Walletbutton.tsx
+++ b/src/components/wallet-connect/Walletbutton.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from "react";
+import React, { useEffect, useState, useRef } from "react";
 import { useWallet } from "./Walletcontext";
 import ConnectWalletModal from "../ConnectWalletModal";
 
@@ -15,7 +15,24 @@ export default function WalletButton() {
   const [modalOpen, setModalOpen] = useState(false);
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [restoreConnectFocus, setRestoreConnectFocus] = useState(false);
+  const [announcement, setAnnouncement] = useState("");
   const containerRef = useRef<HTMLDivElement>(null);
+  const connectTriggerRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!connected && restoreConnectFocus) {
+      connectTriggerRef.current?.focus();
+      setRestoreConnectFocus(false);
+    }
+  }, [connected, restoreConnectFocus]);
+
+  useEffect(() => {
+    if (!announcement) return undefined;
+
+    const timer = setTimeout(() => setAnnouncement(""), 1500);
+    return () => clearTimeout(timer);
+  }, [announcement]);
 
   // The canonical ConnectWalletModal performs the Freighter connection and
   // error handling internally; WalletButton just closes once it succeeds.
@@ -41,6 +58,8 @@ export default function WalletButton() {
   }
 
   function handleDisconnect() {
+    setRestoreConnectFocus(true);
+    setAnnouncement("Wallet disconnected. Use Connect wallet to reconnect.");
     disconnect();
     setDropdownOpen(false);
   }
@@ -53,7 +72,11 @@ export default function WalletButton() {
   if (!connected) {
     return (
       <>
+        <div className="sr-only" aria-live="polite" aria-atomic="true">
+          {announcement}
+        </div>
         <button
+          ref={connectTriggerRef}
           onClick={handleOpenModal}
           className="px-4 py-3 text-base font-medium text-white rounded-lg transition-all duration-200 ease-in-out cursor-pointer"
           style={{

--- a/src/components/wallet-connect/__tests__/Walletbutton.test.tsx
+++ b/src/components/wallet-connect/__tests__/Walletbutton.test.tsx
@@ -104,4 +104,32 @@ describe("WalletButton canonical modal", () => {
     expect(screen.getByText("Connection Rejected")).toBeInTheDocument();
     expect(wallet.connect).not.toHaveBeenCalled();
   });
+
+  it("returns focus to the connect trigger after disconnect", async () => {
+    const user = userEvent.setup();
+    wallet.connected = true;
+    wallet.address = "GABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
+    wallet.network = "TESTNET";
+
+    const { rerender } = render(<WalletButton />);
+
+    await user.click(
+      screen.getByRole("button", { name: /gabcde.*7890/i }),
+    );
+    await user.click(screen.getByRole("menuitem", { name: /^disconnect$/i }));
+
+    expect(wallet.disconnect).toHaveBeenCalledTimes(1);
+
+    wallet.connected = false;
+    wallet.address = null;
+    wallet.network = null;
+    rerender(<WalletButton />);
+
+    expect(
+      screen.getByText("Wallet disconnected. Use Connect wallet to reconnect."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Connect wallet" }),
+    ).toHaveFocus();
+  });
 });


### PR DESCRIPTION
## Summary
- restore focus to the newly rendered Connect Wallet trigger after wallet disconnects in AppNavbar
- keep a live-region disconnect announcement available after WalletStatus unmounts
- add the same focus handoff and announcement behavior to the standalone WalletButton flow
- update disconnect tests to assert the new focus target and WalletButton coverage

## Validation
- `node node_modules/vitest/vitest.mjs run disconnect --reporter=dot` (1 file, 2 tests passed)
- `node node_modules/vitest/vitest.mjs run src/components/wallet-connect/__tests__/Walletbutton.test.tsx --reporter=dot` (1 file, 4 tests passed)
- `node node_modules/typescript/bin/tsc -b`
- `node node_modules/vite/bin/vite.js build`

## Security notes
Accessibility-only focus management; no wallet signing, keys, or funds-transfer logic changed.

Closes #372