### PR TITLE
Make wallet watch interval configurable

### DIFF
--- a/src/components/wallet-connect/Walletcontext.tsx
+++ b/src/components/wallet-connect/Walletcontext.tsx
@@ -64,6 +64,37 @@ const DISCONNECTED: WalletState = {
   loading: false,
 };
 
+/** Default Freighter account/network watcher polling interval. */
+export const WALLET_WATCH_INTERVAL_MS = 2000;
+
+/** Minimum watcher interval allowed to avoid hammering the wallet extension. */
+export const MIN_WALLET_WATCH_INTERVAL_MS = 500;
+
+/**
+ * Resolves the Freighter watcher interval from Vite config with a safe default.
+ *
+ * Invalid values fall back to `WALLET_WATCH_INTERVAL_MS`; valid values below
+ * `MIN_WALLET_WATCH_INTERVAL_MS` are clamped to avoid a tight polling loop.
+ */
+export function getWalletWatchIntervalMs() {
+  const configuredInterval = import.meta.env.VITE_WALLET_WATCH_INTERVAL_MS;
+
+  if (!configuredInterval) {
+    return WALLET_WATCH_INTERVAL_MS;
+  }
+
+  const parsedInterval = Number(configuredInterval);
+
+  if (!Number.isFinite(parsedInterval)) {
+    return WALLET_WATCH_INTERVAL_MS;
+  }
+
+  return Math.max(
+    MIN_WALLET_WATCH_INTERVAL_MS,
+    Math.round(parsedInterval),
+  );
+}
+
 type FreighterErrorLike = {
   code?: number;
   message?: string;
@@ -218,7 +249,7 @@ export function WalletProvider({ children }: { children: ReactNode }) {
     clearWatcher();
     if (!state.connected) return undefined;
 
-    const watcher = new WatchWalletChanges(2000);
+    const watcher = new WatchWalletChanges(getWalletWatchIntervalMs());
     watcherRef.current = watcher;
     watcher.watch(({ address, network }) => {
       setState((prev) =>

--- a/src/components/wallet-connect/__tests__/watcher.test.tsx
+++ b/src/components/wallet-connect/__tests__/watcher.test.tsx
@@ -6,7 +6,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // actual implementation here.
 vi.unmock("../Walletcontext");
 
-import { WalletProvider, useWallet } from "../Walletcontext";
+import {
+  MIN_WALLET_WATCH_INTERVAL_MS,
+  WalletProvider,
+  WALLET_WATCH_INTERVAL_MS,
+  useWallet,
+} from "../Walletcontext";
 
 const isConnected = vi.fn();
 const getAddress = vi.fn();
@@ -15,19 +20,23 @@ const watchCallbacks: Array<(change: { address: string; network: string }) => vo
   [];
 const watcherInstances: Array<{ watch: ReturnType<typeof vi.fn>; stop: ReturnType<typeof vi.fn> }> =
   [];
+const watcherIntervals: number[] = [];
 
 vi.mock("@stellar/freighter-api", () => ({
   isConnected: () => isConnected(),
   getAddress: () => getAddress(),
   getNetwork: () => getNetwork(),
-  WatchWalletChanges: vi.fn().mockImplementation(function WatchWalletChanges() {
-    const watcher = {
-      watch: vi.fn((callback) => watchCallbacks.push(callback)),
-      stop: vi.fn(),
-    };
-    watcherInstances.push(watcher);
-    return watcher;
-  }),
+  WatchWalletChanges: vi
+    .fn()
+    .mockImplementation(function WatchWalletChanges(intervalMs: number) {
+      const watcher = {
+        watch: vi.fn((callback) => watchCallbacks.push(callback)),
+        stop: vi.fn(),
+      };
+      watcherIntervals.push(intervalMs);
+      watcherInstances.push(watcher);
+      return watcher;
+    }),
 }));
 
 function deferred<T>() {
@@ -71,6 +80,8 @@ describe("WalletProvider watcher lifecycle", () => {
     getNetwork.mockReset();
     watchCallbacks.length = 0;
     watcherInstances.length = 0;
+    watcherIntervals.length = 0;
+    vi.unstubAllEnvs();
     isConnected.mockResolvedValue({ isConnected: false });
   });
 
@@ -82,6 +93,7 @@ describe("WalletProvider watcher lifecycle", () => {
     });
 
     expect(watcherInstances).toHaveLength(1);
+    expect(watcherIntervals[0]).toBe(WALLET_WATCH_INTERVAL_MS);
     expect(watcherInstances[0]!.watch).toHaveBeenCalledTimes(1);
 
     await act(async () => {
@@ -102,6 +114,30 @@ describe("WalletProvider watcher lifecycle", () => {
     unmount();
 
     expect(watcherInstances[1]!.stop).toHaveBeenCalled();
+  });
+
+  it("uses the configured watcher interval when provided", async () => {
+    vi.stubEnv("VITE_WALLET_WATCH_INTERVAL_MS", "1250");
+
+    renderWallet();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Connect" }));
+    });
+
+    expect(watcherIntervals[0]).toBe(1250);
+  });
+
+  it("clamps the configured watcher interval to the safe minimum", async () => {
+    vi.stubEnv("VITE_WALLET_WATCH_INTERVAL_MS", "10");
+
+    renderWallet();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Connect" }));
+    });
+
+    expect(watcherIntervals[0]).toBe(MIN_WALLET_WATCH_INTERVAL_MS);
   });
 
   it("does not let silent restore reconnect after a user disconnect", async () => {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -10,6 +10,7 @@ interface ImportMetaEnv {
   readonly VITE_TX_POLL_MAX_ATTEMPTS?: string;
   readonly VITE_TX_POLL_BACKOFF_FACTOR?: string;
   readonly VITE_TX_DEMO_CONFIRMATION_ATTEMPTS?: string;
+  readonly VITE_WALLET_WATCH_INTERVAL_MS?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary
- replace the hardcoded Freighter watcher polling interval with documented wallet watch interval constants
- allow `VITE_WALLET_WATCH_INTERVAL_MS` to tune the interval with a safe default and minimum clamp
- add watcher lifecycle tests for the default interval, configured interval, and below-minimum clamp while preserving start/stop behavior

## Validation
- `node node_modules/vitest/vitest.mjs run watcher --reporter=dot` (1 file, 5 tests passed)
- `node node_modules/typescript/bin/tsc -b`
- `node node_modules/vite/bin/vite.js build`

## Security notes
The configured interval is clamped to avoid tight polling loops against the wallet extension; no signing, key, or funds-transfer logic changed.

Closes #371