### PR TITLE
Validate Freighter wallet addresses

### DIFF
--- a/src/components/wallet-connect/Walletcontext.tsx
+++ b/src/components/wallet-connect/Walletcontext.tsx
@@ -17,6 +17,7 @@ import {
   isStellarNetworkMismatch,
   type StellarNetwork,
 } from "../../lib/stellarNetwork";
+import { isValidStellarAddress } from "../../lib/stellar";
 import { getNetworkLabel } from "../../lib/config";
 
 /**
@@ -26,6 +27,7 @@ import { getNetworkLabel } from "../../lib/config";
 export type WalletError =
   | { type: "not_installed" }
   | { type: "rejected" }
+  | { type: "invalid_address" }
   | { type: "network_error" }
   | { type: "unknown" };
 
@@ -69,6 +71,10 @@ type FreighterErrorLike = {
   message?: string;
 };
 
+const INVALID_FREIGHTER_ADDRESS_ERROR = {
+  message: "Freighter returned an invalid Stellar address",
+};
+
 function classifyWalletError(error: unknown): WalletError {
   if (!error || typeof error !== "object") {
     return { type: "unknown" };
@@ -94,6 +100,10 @@ function classifyWalletError(error: unknown): WalletError {
     normalizedMessage.includes("not allowed")
   ) {
     return { type: "rejected" };
+  }
+
+  if (normalizedMessage.includes("invalid stellar address")) {
+    return { type: "invalid_address" };
   }
 
   if (
@@ -125,8 +135,17 @@ export function WalletProvider({ children }: { children: ReactNode }) {
   const isNetworkMismatch =
     state.connected && isStellarNetworkMismatch(state.network, expectedNetwork);
 
-  const connect = (address: string, network: string) =>
+  const connect = (address: string, network: string) => {
+    if (!isValidStellarAddress(address)) {
+      setState({
+        ...DISCONNECTED,
+        error: classifyWalletError(INVALID_FREIGHTER_ADDRESS_ERROR),
+      });
+      return;
+    }
+
     setState({ address, network, connected: true, error: null, loading: false });
+  };
 
   const disconnect = () => {
     disconnectVersionRef.current += 1;
@@ -181,6 +200,10 @@ export function WalletProvider({ children }: { children: ReactNode }) {
           restoreError({ message: "Freighter address request rejected" });
           return;
         }
+        if (!isValidStellarAddress(addr.address)) {
+          restoreError(INVALID_FREIGHTER_ADDRESS_ERROR);
+          return;
+        }
 
         const net = await getNetwork();
         if (net.error) {
@@ -221,6 +244,14 @@ export function WalletProvider({ children }: { children: ReactNode }) {
     const watcher = new WatchWalletChanges(2000);
     watcherRef.current = watcher;
     watcher.watch(({ address, network }) => {
+      if (!isValidStellarAddress(address)) {
+        setState({
+          ...DISCONNECTED,
+          error: classifyWalletError(INVALID_FREIGHTER_ADDRESS_ERROR),
+        });
+        return;
+      }
+
       setState((prev) =>
         address === prev.address && network === prev.network
           ? prev

--- a/src/components/wallet-connect/__tests__/Walletcontext.test.tsx
+++ b/src/components/wallet-connect/__tests__/Walletcontext.test.tsx
@@ -25,6 +25,8 @@ const mockedIsConnected = vi.mocked(isConnected);
 const mockedGetAddress = vi.mocked(getAddress);
 const mockedGetNetwork = vi.mocked(getNetwork);
 const mockedWatchWalletChanges = vi.mocked(WatchWalletChanges);
+const VALID_STELLAR_ADDRESS =
+  "GATDOSCZNJ5YZHNOX7IOD4QDCQSTMR2YNF5IXHFNX3H6B4ICCMSDLOWN";
 
 function WalletProbe() {
   const { address, connected, error, network, loading } = useWallet();
@@ -76,7 +78,7 @@ describe("WalletProvider restore errors", () => {
 
   it("restores an approved wallet and clears previous errors", async () => {
     mockedIsConnected.mockResolvedValue({ isConnected: true });
-    mockedGetAddress.mockResolvedValue({ address: "GAPPROVEDADDRESS" });
+    mockedGetAddress.mockResolvedValue({ address: VALID_STELLAR_ADDRESS });
     mockedGetNetwork.mockResolvedValue({
       network: "TESTNET",
       networkPassphrase: "Test SDF Network ; September 2015",
@@ -86,7 +88,7 @@ describe("WalletProvider restore errors", () => {
 
     await waitFor(() =>
       expect(walletState()).toEqual({
-        address: "GAPPROVEDADDRESS",
+        address: VALID_STELLAR_ADDRESS,
         connected: true,
         error: null,
         network: "TESTNET",
@@ -131,9 +133,25 @@ describe("WalletProvider restore errors", () => {
     expect(mockedGetNetwork).not.toHaveBeenCalled();
   });
 
+  it("rejects invalid addresses returned during silent restore", async () => {
+    mockedIsConnected.mockResolvedValue({ isConnected: true });
+    mockedGetAddress.mockResolvedValue({ address: "GINVALID" });
+
+    renderWalletProvider();
+
+    await waitFor(() =>
+      expect(walletState()).toMatchObject({
+        address: null,
+        connected: false,
+        error: "invalid_address",
+      }),
+    );
+    expect(mockedGetNetwork).not.toHaveBeenCalled();
+  });
+
   it("records network_error when network lookup fails", async () => {
     mockedIsConnected.mockResolvedValue({ isConnected: true });
-    mockedGetAddress.mockResolvedValue({ address: "GAPPROVEDADDRESS" });
+    mockedGetAddress.mockResolvedValue({ address: VALID_STELLAR_ADDRESS });
     mockedGetNetwork.mockResolvedValue({
       network: "",
       networkPassphrase: "",
@@ -187,7 +205,7 @@ describe("WalletProvider restore loading", () => {
 
   it("clears loading after restoring a verified address", async () => {
     mockedIsConnected.mockResolvedValue({ isConnected: true });
-    mockedGetAddress.mockResolvedValue({ address: "GAPPROVEDADDRESS" });
+    mockedGetAddress.mockResolvedValue({ address: VALID_STELLAR_ADDRESS });
     mockedGetNetwork.mockResolvedValue({
       network: "TESTNET",
       networkPassphrase: "Test SDF Network ; September 2015",
@@ -197,7 +215,7 @@ describe("WalletProvider restore loading", () => {
 
     await waitFor(() =>
       expect(walletState()).toMatchObject({
-        address: "GAPPROVEDADDRESS",
+        address: VALID_STELLAR_ADDRESS,
         connected: true,
         loading: false,
       }),

--- a/src/components/wallet-connect/__tests__/watcher.test.tsx
+++ b/src/components/wallet-connect/__tests__/watcher.test.tsx
@@ -11,6 +11,8 @@ import { WalletProvider, useWallet } from "../Walletcontext";
 const isConnected = vi.fn();
 const getAddress = vi.fn();
 const getNetwork = vi.fn();
+const VALID_STELLAR_ADDRESS =
+  "GATDOSCZNJ5YZHNOX7IOD4QDCQSTMR2YNF5IXHFNX3H6B4ICCMSDLOWN";
 const watchCallbacks: Array<(change: { address: string; network: string }) => void> =
   [];
 const watcherInstances: Array<{ watch: ReturnType<typeof vi.fn>; stop: ReturnType<typeof vi.fn> }> =
@@ -39,15 +41,23 @@ function deferred<T>() {
 }
 
 function WalletHarness() {
-  const { address, network, connected, connect, disconnect } = useWallet();
+  const { address, network, connected, error, connect, disconnect } =
+    useWallet();
 
   return (
     <div>
       <output aria-label="wallet state">
         {connected ? `${address}:${network}` : "disconnected"}
       </output>
-      <button type="button" onClick={() => connect("GUSER", "TESTNET")}>
+      <output aria-label="wallet error">{error?.type ?? "none"}</output>
+      <button
+        type="button"
+        onClick={() => connect(VALID_STELLAR_ADDRESS, "TESTNET")}
+      >
         Connect
+      </button>
+      <button type="button" onClick={() => connect("GINVALID", "TESTNET")}>
+        Connect invalid
       </button>
       <button type="button" onClick={disconnect}>
         Disconnect
@@ -117,7 +127,7 @@ describe("WalletProvider watcher lifecycle", () => {
     });
 
     expect(screen.getByLabelText("wallet state")).toHaveTextContent(
-      "GUSER:TESTNET",
+      `${VALID_STELLAR_ADDRESS}:TESTNET`,
     );
 
     await act(async () => {
@@ -147,11 +157,46 @@ describe("WalletProvider watcher lifecycle", () => {
     expect(watcherInstances).toHaveLength(1);
 
     await act(async () => {
-      watchCallbacks[0]!({ address: "GNEW", network: "PUBLIC" });
+      watchCallbacks[0]!({ address: VALID_STELLAR_ADDRESS, network: "PUBLIC" });
     });
 
     expect(screen.getByLabelText("wallet state")).toHaveTextContent(
-      "GNEW:PUBLIC",
+      `${VALID_STELLAR_ADDRESS}:PUBLIC`,
     );
+  });
+
+  it("rejects invalid addresses from wallet change events", async () => {
+    renderWallet();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Connect" }));
+    });
+
+    await act(async () => {
+      watchCallbacks[0]!({ address: "GINVALID", network: "PUBLIC" });
+    });
+
+    expect(screen.getByLabelText("wallet state")).toHaveTextContent(
+      "disconnected",
+    );
+    expect(screen.getByLabelText("wallet error")).toHaveTextContent(
+      "invalid_address",
+    );
+  });
+
+  it("rejects invalid addresses passed to connect", async () => {
+    renderWallet();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Connect invalid" }));
+    });
+
+    expect(screen.getByLabelText("wallet state")).toHaveTextContent(
+      "disconnected",
+    );
+    expect(screen.getByLabelText("wallet error")).toHaveTextContent(
+      "invalid_address",
+    );
+    expect(watcherInstances).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary
- validate Freighter-returned Stellar addresses before storing wallet state
- reject invalid addresses from silent restore, direct connect calls, and watcher change events with a safe `invalid_address` wallet error
- update wallet provider and watcher tests to use checksum-valid addresses and cover invalid address rejection paths

## Validation
- `node node_modules/vitest/vitest.mjs run src/components/wallet-connect/__tests__/Walletcontext.test.tsx --reporter=dot` (1 file, 8 tests passed)
- `node node_modules/vitest/vitest.mjs run src/components/wallet-connect/__tests__/watcher.test.tsx --reporter=dot` (1 file, 5 tests passed)
- `node node_modules/typescript/bin/tsc -b`
- `node node_modules/vite/bin/vite.js build`

## Security notes
Invalid Freighter addresses are rejected before they can enter wallet context; no signing, key, or funds-transfer logic changed.

Closes #370