### PR TITLE
Enforce minimum stream duration

### DIFF
--- a/src/components/CreateStreamModal.tsx
+++ b/src/components/CreateStreamModal.tsx
@@ -32,6 +32,11 @@ export function sanitizeDepositAmountInput(value: string): string {
 
 // Keep demo stream math below JS safe-integer territory while still allowing large institutional schedules.
 export const MAX_ACCRUAL_RATE = 100_000;
+/**
+ * Minimum schedule length in days. A one-day floor prevents accidental
+ * near-instant streams that make accrual and withdrawal behavior hard to read.
+ */
+export const MIN_STREAM_DURATION_DAYS = 1;
 export const MAX_DURATION_DAYS = 3_650;
 export const MAX_REQUIRED_DEPOSIT = MAX_ACCRUAL_RATE * MAX_DURATION_DAYS;
 
@@ -88,6 +93,11 @@ function validateDuration(value: string): string | undefined {
 
   if (!value.trim() || isNaN(numericValue) || numericValue <= 0) {
     return 'Duration must be a positive number.';
+  }
+
+  if (numericValue < MIN_STREAM_DURATION_DAYS) {
+    const unit = MIN_STREAM_DURATION_DAYS === 1 ? 'day' : 'days';
+    return `Duration must be at least ${MIN_STREAM_DURATION_DAYS.toLocaleString()} ${unit}.`;
   }
 
   if (numericValue > MAX_DURATION_DAYS) {

--- a/src/components/__tests__/CreateStreamModal.bounds.test.tsx
+++ b/src/components/__tests__/CreateStreamModal.bounds.test.tsx
@@ -4,6 +4,7 @@ import CreateStreamModal, {
   MAX_ACCRUAL_RATE,
   MAX_DURATION_DAYS,
   MAX_REQUIRED_DEPOSIT,
+  MIN_STREAM_DURATION_DAYS,
 } from '../CreateStreamModal';
 
 // Checksum-valid Stellar public key (required by the centralized
@@ -49,6 +50,14 @@ describe('CreateStreamModal upper bounds', () => {
     expect(screen.queryByText(/or less\./i)).not.toBeInTheDocument();
     expect(rateInput.closest('.input-container')).toHaveClass('input-container--success');
     expect(durationInput.closest('.input-container')).toHaveClass('input-container--success');
+
+    fireEvent.change(durationInput, {
+      target: { value: String(MIN_STREAM_DURATION_DAYS) },
+    });
+    fireEvent.blur(durationInput);
+
+    expect(screen.queryByText(/at least/i)).not.toBeInTheDocument();
+    expect(durationInput.closest('.input-container')).toHaveClass('input-container--success');
   });
 
   it('blocks over-bound accrual rates with an inline validation message', () => {
@@ -77,6 +86,23 @@ describe('CreateStreamModal upper bounds', () => {
 
     expect(
       screen.getByText(`Duration must be ${MAX_DURATION_DAYS.toLocaleString()} days or less.`),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /rate & schedule/i })).toBeInTheDocument();
+  });
+
+  it('blocks durations below the configured minimum with an inline validation message', () => {
+    const { container } = renderModal();
+    advanceToStep2(container);
+
+    const unit = MIN_STREAM_DURATION_DAYS === 1 ? 'day' : 'days';
+
+    fireEvent.change(container.querySelector('#create-stream-duration')!, {
+      target: { value: String(MIN_STREAM_DURATION_DAYS - 0.5) },
+    });
+    fireEvent.click(within(container).getByRole('button', { name: /^next$/i }));
+
+    expect(
+      screen.getByText(`Duration must be at least ${MIN_STREAM_DURATION_DAYS.toLocaleString()} ${unit}.`),
     ).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: /rate & schedule/i })).toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary
- add an exported `MIN_STREAM_DURATION_DAYS` constant with rationale for the one-day floor
- reject sub-minimum stream durations with an inline validation message
- extend duration bounds coverage for minimum and maximum values

## Tests
- `node node_modules/vitest/vitest.mjs run src/components/__tests__/CreateStreamModal.bounds.test.tsx --reporter=dot`
- `node node_modules/typescript/bin/tsc -b`

Fixes #355