### PR TITLE
Add Freighter network timeout

### DIFF
--- a/src/lib/stellar/__tests__/tx.test.ts
+++ b/src/lib/stellar/__tests__/tx.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   createStream,
   withdraw,
@@ -6,6 +6,7 @@ import {
   cancelStream,
   getTransactionStatus,
   TransactionError,
+  FREIGHTER_NETWORK_TIMEOUT_MS,
 } from "../tx";
 import * as freighter from "@stellar/freighter-api";
 import { rpc as SorobanRpc, Account } from "@stellar/stellar-sdk";
@@ -99,6 +100,10 @@ describe("Soroban transaction layer (tx.ts)", () => {
     });
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   // ── 1. Happy Paths ─────────────────────────────────────────────────────────
 
   it("should create a stream successfully", async () => {
@@ -175,6 +180,25 @@ describe("Soroban transaction layer (tx.ts)", () => {
     );
   });
 
+  it("should throw timeout error if Freighter network validation hangs", async () => {
+    vi.useFakeTimers();
+    vi.mocked(freighter.getNetwork).mockReturnValue(new Promise(() => {}) as any);
+
+    const expectation = expect(
+      createStream(mockAddress, mockAddress, "1000", 100, 1000)
+    ).rejects.toThrowError(
+      new TransactionError(
+        "timeout",
+        "Freighter did not respond while checking the Stellar network. Please unlock or refresh Freighter and try again.",
+      )
+    );
+
+    await vi.advanceTimersByTimeAsync(FREIGHTER_NETWORK_TIMEOUT_MS);
+    await expectation;
+
+    expect(serverInstance.getAccount).not.toHaveBeenCalled();
+  });
+
   it("should throw rejected error if Freighter signing request is declined by the user", async () => {
     vi.mocked(freighter.signTransaction).mockRejectedValue(new Error("User reject this request"));
 
@@ -219,6 +243,5 @@ describe("Soroban transaction layer (tx.ts)", () => {
 
     // Default maxRetries is 15
     expect(serverInstance.getTransaction).toHaveBeenCalledTimes(15);
-    vi.useRealTimers();
   });
 });

--- a/src/lib/stellar/tx.ts
+++ b/src/lib/stellar/tx.ts
@@ -23,6 +23,33 @@ export class TransactionError extends Error {
 }
 
 /**
+ * Maximum time to wait for Freighter to report its active Stellar network.
+ * Extension updates or locked wallet state can otherwise hang stream creation.
+ */
+export const FREIGHTER_NETWORK_TIMEOUT_MS = 10_000;
+
+/**
+ * Runs an async operation with a timeout and clears the timer on both success
+ * and failure to avoid dangling timers after a fast Freighter response.
+ */
+function withTimeout<T>(
+  operation: Promise<T>,
+  timeoutMs: number,
+  createError: () => Error,
+): Promise<T> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => reject(createError()), timeoutMs);
+  });
+
+  return Promise.race([operation, timeout]).finally(() => {
+    if (timeoutId !== undefined) {
+      clearTimeout(timeoutId);
+    }
+  });
+}
+
+/**
  * Returns the appropriate network passphrase for a given network name.
  * @param networkName - The name of the network (e.g. "TESTNET", "PUBLIC").
  */
@@ -67,8 +94,18 @@ async function validateNetwork(): Promise<void> {
   const expectedNet = appConfig.network;
   let connectedNetRes;
   try {
-    connectedNetRes = await getNetwork();
+    connectedNetRes = await withTimeout(
+      getNetwork(),
+      FREIGHTER_NETWORK_TIMEOUT_MS,
+      () => new TransactionError(
+        "timeout",
+        "Freighter did not respond while checking the Stellar network. Please unlock or refresh Freighter and try again.",
+      ),
+    );
   } catch (err: any) {
+    if (err instanceof TransactionError) {
+      throw err;
+    }
     throw new TransactionError("rpc", `Freighter not connected or unavailable. Error: ${err.message || err}`);
   }
 


### PR DESCRIPTION
## Summary
- add a named Freighter network timeout around `getNetwork()`
- throw a typed `TransactionError("timeout", ...)` instead of hanging stream submission
- clear the timeout on fast success/failure and cover the hanging wallet path in tests

## Tests
- `node node_modules/vitest/vitest.mjs run src/lib/stellar/__tests__/tx.test.ts --reporter=dot`
- `node node_modules/typescript/bin/tsc -b`

Fixes #357