### PR TITLE
Classify transaction polling errors

### DIFF
--- a/src/hooks/__tests__/useTransactionStatus.test.tsx
+++ b/src/hooks/__tests__/useTransactionStatus.test.tsx
@@ -1,6 +1,7 @@
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  classifyTransactionStatusError,
   createDemoTransactionStatusSource,
   useTransactionStatus,
   type TransactionStatusSource,
@@ -89,6 +90,90 @@ describe("useTransactionStatus", () => {
     expect(result.current.error).toBe("Transaction confirmation timed out.");
   });
 
+  it("retries transient RPC errors within the existing attempt budget", async () => {
+    const getStatus = vi
+      .fn<TransactionStatusSource>()
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+      .mockResolvedValueOnce("confirmed");
+
+    const { result } = renderHook(() =>
+      useTransactionStatus("tx-transient", {
+        getStatus,
+        pollIntervalMs: 100,
+        maxAttempts: 3,
+        backoffFactor: 1,
+      }),
+    );
+
+    await flushPromises();
+
+    expect(result.current.status).toBe("pending");
+    expect(result.current.error).toBeNull();
+
+    await act(async () => {
+      vi.advanceTimersByTime(100);
+      await Promise.resolve();
+    });
+
+    expect(getStatus).toHaveBeenCalledTimes(2);
+    expect(result.current.status).toBe("confirmed");
+    expect(result.current.error).toBeNull();
+  });
+
+  it("fails fast on permanent polling errors with the original message", async () => {
+    const getStatus = vi
+      .fn<TransactionStatusSource>()
+      .mockRejectedValue(new Error("Malformed transaction hash."));
+
+    const { result } = renderHook(() =>
+      useTransactionStatus("tx-permanent", {
+        getStatus,
+        pollIntervalMs: 100,
+        maxAttempts: 3,
+      }),
+    );
+
+    await flushPromises();
+
+    expect(getStatus).toHaveBeenCalledTimes(1);
+    expect(result.current.status).toBe("failed");
+    expect(result.current.error).toBe("Malformed transaction hash.");
+
+    await act(async () => {
+      vi.advanceTimersByTime(300);
+      await Promise.resolve();
+    });
+
+    expect(getStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves the last transient error message when retries are exhausted", async () => {
+    const getStatus = vi
+      .fn<TransactionStatusSource>()
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+      .mockRejectedValueOnce(new Error("RPC timeout after 10s"));
+
+    const { result } = renderHook(() =>
+      useTransactionStatus("tx-transient-exhausted", {
+        getStatus,
+        pollIntervalMs: 100,
+        maxAttempts: 2,
+        backoffFactor: 1,
+      }),
+    );
+
+    await flushPromises();
+
+    await act(async () => {
+      vi.advanceTimersByTime(100);
+      await Promise.resolve();
+    });
+
+    expect(getStatus).toHaveBeenCalledTimes(2);
+    expect(result.current.status).toBe("failed");
+    expect(result.current.error).toBe("RPC timeout after 10s");
+  });
+
   it("cleans up polling and aborts the status source on unmount", async () => {
     let signal: AbortSignal | undefined;
     const getStatus = vi.fn<TransactionStatusSource>().mockImplementation(
@@ -135,5 +220,24 @@ describe("useTransactionStatus", () => {
         signal: new AbortController().signal,
       }),
     ).resolves.toBe("confirmed");
+  });
+});
+
+describe("classifyTransactionStatusError", () => {
+  it.each([
+    new TypeError("Failed to fetch"),
+    new Error("RPC request timed out"),
+    new Error("503 Service Unavailable"),
+    new Error("429 Too Many Requests"),
+  ])("classifies %s as transient", (error) => {
+    expect(classifyTransactionStatusError(error)).toBe("transient");
+  });
+
+  it.each([
+    new Error("Malformed transaction hash."),
+    new Error("VITE_RPC_URL is not configured in environment variables."),
+    new Error("Transaction execution failed on-chain."),
+  ])("classifies %s as permanent", (error) => {
+    expect(classifyTransactionStatusError(error)).toBe("permanent");
   });
 });

--- a/src/hooks/useTransactionStatus.ts
+++ b/src/hooks/useTransactionStatus.ts
@@ -34,6 +34,8 @@ export interface UseTransactionStatusOptions {
   backoffFactor?: number;
 }
 
+export type TransactionStatusErrorKind = "transient" | "permanent";
+
 function getErrorMessage(error: unknown) {
   return error instanceof Error
     ? error.message
@@ -42,6 +44,50 @@ function getErrorMessage(error: unknown) {
 
 function isAbortError(error: unknown) {
   return error instanceof DOMException && error.name === "AbortError";
+}
+
+/**
+ * Classifies polling source errors without changing the public hook API.
+ * Transient RPC/network failures keep using the existing attempt budget, while
+ * deterministic input/configuration failures stop polling immediately.
+ */
+export function classifyTransactionStatusError(
+  error: unknown,
+): TransactionStatusErrorKind {
+  if (isAbortError(error)) {
+    return "transient";
+  }
+
+  const name = error instanceof Error ? error.name.toLowerCase() : "";
+  const message = getErrorMessage(error).toLowerCase();
+  const transientSignals = [
+    "failed to fetch",
+    "fetch failed",
+    "network error",
+    "networkerror",
+    "timeout",
+    "timed out",
+    "temporarily unavailable",
+    "rate limit",
+    "too many requests",
+    "econnreset",
+    "econnrefused",
+    "etimedout",
+    "socket hang up",
+    "503",
+    "502",
+    "504",
+    "429",
+  ];
+
+  if (
+    (name === "typeerror" && message.includes("fetch")) ||
+    transientSignals.some(signal => message.includes(signal))
+  ) {
+    return "transient";
+  }
+
+  return "permanent";
 }
 
 /**
@@ -147,8 +193,22 @@ export function useTransactionStatus(
         }, delay);
       } catch (caughtError) {
         if (cancelled || isAbortError(caughtError)) return;
+
+        const message = getErrorMessage(caughtError);
+        const errorKind = classifyTransactionStatusError(caughtError);
+
+        if (errorKind === "transient" && attempt < maxAttempts) {
+          const delay = Math.round(
+            pollIntervalMs * Math.pow(backoffFactor, attempt - 1),
+          );
+          timerRef.current = window.setTimeout(() => {
+            void poll(attempt + 1);
+          }, delay);
+          return;
+        }
+
         setStatus("failed");
-        setError(getErrorMessage(caughtError));
+        setError(message);
       }
     };
 


### PR DESCRIPTION
## Summary
- add a transaction polling error classifier for transient RPC/network failures vs permanent failures
- retry transient errors within the existing polling attempt budget
- fail fast on permanent errors and preserve the terminal error message shown to users

## Tests
- `node node_modules/vitest/vitest.mjs run src/hooks/__tests__/useTransactionStatus.test.tsx --reporter=dot`
- `node node_modules/typescript/bin/tsc -b`

Fixes #358