### PR TITLE
Add cross-browser Playwright projects

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -6,6 +6,25 @@ Run the browser smoke suite with:
 npm run test:e2e
 ```
 
+This runs the configured Chromium, Firefox, and WebKit projects. For the fast
+local path that matches the previous Chromium-only run, use:
+
+```bash
+npm run test:e2e:chromium
+```
+
+To be explicit when validating all browser engines locally or in CI, use:
+
+```bash
+npm run test:e2e:browsers
+```
+
+You can also target a single Playwright project directly, for example:
+
+```bash
+npm run test:e2e -- --project=webkit
+```
+
 The suite starts the Vite dev server from `playwright.config.ts` and covers the
 current create-stream wizard plus the recipient withdrawal surface. These tests
 use local demo data only; they do not connect to wallets, sign transactions, or

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "format:check": "prettier eslint.config.js .prettierrc package.json --check",
     "test": "vitest run",
     "test:e2e": "playwright test",
+    "test:e2e:chromium": "playwright test --project=chromium",
+    "test:e2e:browsers": "playwright test --project=chromium --project=firefox --project=webkit",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage"
   },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -31,5 +31,17 @@ export default defineConfig({
         channel: browserChannel,
       },
     },
+    {
+      name: "firefox",
+      use: {
+        ...devices["Desktop Firefox"],
+      },
+    },
+    {
+      name: "webkit",
+      use: {
+        ...devices["Desktop Safari"],
+      },
+    },
   ],
 });


### PR DESCRIPTION
## Summary
- add Firefox and WebKit Playwright projects alongside the existing Chromium project
- add explicit e2e scripts for the Chromium fast path and all-browser runs
- document cross-browser and single-project e2e commands

## Tests
- `node node_modules/@playwright/test/cli.js test --list`
- `node node_modules/typescript/bin/tsc -b`

Fixes #385