### PR TITLE
Enforce bundle size budget

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -1,0 +1,36 @@
+name: Bundle size
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  bundle-size:
+    name: Check bundle size budget
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build and check bundle budget
+        run: npm run build:report
+
+      - name: Upload bundle size report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bundle-size-report
+          path: dist/bundle-size-report.md
+          if-no-files-found: warn

--- a/README.md
+++ b/README.md
@@ -102,6 +102,17 @@ the production build. Vite warns when any chunk exceeds 650 kB, and
 `vite.config.ts` splits vendor code into `vendor-react`, `vendor-stellar`, and
 `vendor-icons` chunks so PR reviewers can spot bundle regressions.
 
+The bundle report also enforces CI budgets:
+
+- Total JavaScript gzip: 230 kB
+- Individual JavaScript chunk gzip: 95 kB
+
+If a budget is intentionally raised, update the defaults in
+`scripts/bundle-size-report.mjs` or override them in CI with
+`BUNDLE_TOTAL_JS_GZIP_BUDGET_KB` and `BUNDLE_JS_CHUNK_GZIP_BUDGET_KB`. The
+bundle-size workflow uploads `dist/bundle-size-report.md` as a PR artifact so
+reviewers can inspect the exact chunk table.
+
 ## Project structure
 
 ```

--- a/scripts/bundle-size-report.mjs
+++ b/scripts/bundle-size-report.mjs
@@ -1,9 +1,28 @@
-import { readdir, readFile, stat } from "node:fs/promises";
-import { join, relative } from "node:path";
+import { mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
+import { dirname, join, relative } from "node:path";
 import { gzipSync } from "node:zlib";
 
 const DIST_DIR = "dist";
 const ASSET_DIR = join(DIST_DIR, "assets");
+const REPORT_PATH =
+  process.env.BUNDLE_SIZE_REPORT_PATH ?? join(DIST_DIR, "bundle-size-report.md");
+
+function readBudgetKb(envName, defaultKb) {
+  const rawValue = process.env[envName];
+  if (rawValue === undefined || rawValue.trim() === "") return defaultKb * 1024;
+
+  const parsed = Number(rawValue);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`${envName} must be a positive number of kilobytes.`);
+  }
+
+  return parsed * 1024;
+}
+
+const budgets = {
+  totalJsGzip: readBudgetKb("BUNDLE_TOTAL_JS_GZIP_BUDGET_KB", 230),
+  jsChunkGzip: readBudgetKb("BUNDLE_JS_CHUNK_GZIP_BUDGET_KB", 95),
+};
 
 function formatKb(bytes) {
   return `${(bytes / 1024).toFixed(2)} kB`;
@@ -44,15 +63,70 @@ const totals = rows.reduce(
   }),
   { raw: 0, gzip: 0 },
 );
+const jsRows = rows.filter((row) => row.file.endsWith(".js"));
+const jsTotals = jsRows.reduce(
+  (sum, row) => ({
+    raw: sum.raw + row.raw,
+    gzip: sum.gzip + row.gzip,
+  }),
+  { raw: 0, gzip: 0 },
+);
+const violations = [];
 
-console.log("Bundle size report");
-console.log("==================");
-console.log(`Assets: ${rows.length}`);
-console.log(`Total raw: ${formatKb(totals.raw)}`);
-console.log(`Total gzip: ${formatKb(totals.gzip)}`);
-console.log("");
-console.log("| Asset | Raw | Gzip |");
-console.log("| --- | ---: | ---: |");
+if (jsTotals.gzip > budgets.totalJsGzip) {
+  violations.push(
+    `Total JS gzip ${formatKb(jsTotals.gzip)} exceeds budget ${formatKb(
+      budgets.totalJsGzip,
+    )}.`,
+  );
+}
+
+for (const row of jsRows) {
+  if (row.gzip > budgets.jsChunkGzip) {
+    violations.push(
+      `${row.file} gzip ${formatKb(row.gzip)} exceeds per-chunk budget ${formatKb(
+        budgets.jsChunkGzip,
+      )}.`,
+    );
+  }
+}
+
+const reportLines = [
+  "Bundle size report",
+  "==================",
+  `Assets: ${rows.length}`,
+  `Total raw: ${formatKb(totals.raw)}`,
+  `Total gzip: ${formatKb(totals.gzip)}`,
+  `Total JS gzip: ${formatKb(jsTotals.gzip)} / ${formatKb(budgets.totalJsGzip)} budget`,
+  `Largest JS chunk gzip budget: ${formatKb(budgets.jsChunkGzip)}`,
+  "",
+  violations.length === 0 ? "Budget status: PASS" : "Budget status: FAIL",
+  "",
+  "| Asset | Raw | Gzip |",
+  "| --- | ---: | ---: |",
+];
+
 for (const row of rows) {
-  console.log(`| ${row.file} | ${formatKb(row.raw)} | ${formatKb(row.gzip)} |`);
+  reportLines.push(`| ${row.file} | ${formatKb(row.raw)} | ${formatKb(row.gzip)} |`);
+}
+
+if (violations.length > 0) {
+  reportLines.push("", "Budget violations:");
+  for (const violation of violations) {
+    reportLines.push(`- ${violation}`);
+  }
+}
+
+const report = `${reportLines.join("\n")}\n`;
+console.log(report);
+
+await mkdir(dirname(REPORT_PATH), { recursive: true });
+await writeFile(REPORT_PATH, report, "utf8");
+
+if (violations.length > 0) {
+  console.error("Bundle budget exceeded:");
+  for (const violation of violations) {
+    console.error(`- ${violation}`);
+  }
+  process.exitCode = 1;
 }


### PR DESCRIPTION
## Summary
- extend the bundle-size report to enforce total JS gzip and per-chunk gzip budgets
- write `dist/bundle-size-report.md` so CI can upload the exact report for review
- add a PR workflow that runs the budget check and uploads the report artifact
- document the budgets and how to intentionally update or override them

## Tests
- `node node_modules/vite/bin/vite.js build`
- `node scripts/bundle-size-report.mjs` (passes with the current baseline)
- `BUNDLE_TOTAL_JS_GZIP_BUDGET_KB=1 BUNDLE_JS_CHUNK_GZIP_BUDGET_KB=1 node scripts/bundle-size-report.mjs` (fails and lists offending chunks)

Fixes #387