### PR TITLE
feat(config): validate api and rpc url protocols

### DIFF
--- a/src/lib/__tests__/config.test.ts
+++ b/src/lib/__tests__/config.test.ts
@@ -4,6 +4,7 @@ import {
   getNetworkLabel,
   getNetworkPassphrase,
   parseBooleanFlag,
+  validateUrl,
 } from "../config";
 
 function env(overrides: Partial<ImportMetaEnv> = {}): ImportMetaEnv {
@@ -52,5 +53,154 @@ describe("config", () => {
     );
     expect(parseBooleanFlag("1")).toBe(true);
     expect(parseBooleanFlag("false")).toBe(false);
+  });
+});
+
+describe("validateUrl", () => {
+  it("accepts https URLs", () => {
+    expect(validateUrl("apiUrl", "https://api.example.com")).toBe(
+      "https://api.example.com",
+    );
+  });
+
+  it("accepts https URLs with paths and query strings", () => {
+    expect(
+      validateUrl("rpcUrl", "https://rpc.example.com/v1?key=abc"),
+    ).toBe("https://rpc.example.com/v1?key=abc");
+  });
+
+  it("accepts http://localhost", () => {
+    expect(validateUrl("rpcUrl", "http://localhost:8000")).toBe(
+      "http://localhost:8000",
+    );
+  });
+
+  it("accepts http://127.0.0.1", () => {
+    expect(validateUrl("apiUrl", "http://127.0.0.1:3000/api")).toBe(
+      "http://127.0.0.1:3000/api",
+    );
+  });
+
+  it("trims surrounding whitespace before validating", () => {
+    expect(validateUrl("apiUrl", "  https://api.example.com  ")).toBe(
+      "https://api.example.com",
+    );
+  });
+
+  it("rejects a plain non-URL string", () => {
+    const result = validateUrl("apiUrl", "not-a-url");
+    expect(result).toMatchObject({
+      field: "apiUrl",
+      message: expect.stringContaining("not a valid URL"),
+    });
+  });
+
+  it("rejects an empty-looking string (spaces only via trim)", () => {
+    const result = validateUrl("apiUrl", "   ");
+    expect(result).toMatchObject({ field: "apiUrl" });
+  });
+
+  it("rejects ftp:// protocol", () => {
+    const result = validateUrl("rpcUrl", "ftp://files.example.com");
+    expect(result).toMatchObject({
+      field: "rpcUrl",
+      message: expect.stringContaining("ftp:"),
+    });
+  });
+
+  it("rejects javascript: protocol", () => {
+    const result = validateUrl("apiUrl", "javascript:alert(1)");
+    expect(result).toMatchObject({
+      field: "apiUrl",
+      message: expect.stringContaining("javascript:"),
+    });
+  });
+
+  it("rejects data: protocol", () => {
+    const result = validateUrl("rpcUrl", "data:text/html,<h1>hi</h1>");
+    expect(result).toMatchObject({
+      field: "rpcUrl",
+      message: expect.stringContaining("data:"),
+    });
+  });
+
+  it("rejects http:// for non-local hosts", () => {
+    const result = validateUrl("apiUrl", "http://api.example.com");
+    expect(result).toMatchObject({
+      field: "apiUrl",
+      message: expect.stringContaining("http:"),
+    });
+  });
+
+  it("includes the field name in the error message", () => {
+    const result = validateUrl("rpcUrl", "garbage");
+    expect(result).toMatchObject({
+      field: "rpcUrl",
+      message: expect.stringContaining("rpcUrl"),
+    });
+  });
+});
+
+describe("createConfig URL validation", () => {
+  it("leaves apiUrl and rpcUrl null when unset", () => {
+    const config = createConfig(env());
+    expect(config.apiUrl).toBeNull();
+    expect(config.rpcUrl).toBeNull();
+  });
+
+  it("throws for a malformed apiUrl", () => {
+    expect(() =>
+      createConfig(env({ VITE_API_URL: "not-a-url" })),
+    ).toThrow(/apiUrl/);
+  });
+
+  it("throws for a malformed rpcUrl", () => {
+    expect(() =>
+      createConfig(env({ VITE_RPC_URL: "garbage" })),
+    ).toThrow(/rpcUrl/);
+  });
+
+  it("throws for a disallowed protocol on apiUrl", () => {
+    expect(() =>
+      createConfig(env({ VITE_API_URL: "ftp://files.example.com" })),
+    ).toThrow(/apiUrl/);
+  });
+
+  it("throws for http:// rpcUrl on a non-local host", () => {
+    expect(() =>
+      createConfig(env({ VITE_RPC_URL: "http://rpc.example.com" })),
+    ).toThrow(/rpcUrl/);
+  });
+
+  it("throws for javascript: injection in apiUrl", () => {
+    expect(() =>
+      createConfig(env({ VITE_API_URL: "javascript:alert(1)" })),
+    ).toThrow(/apiUrl/);
+  });
+
+  it("accumulates errors from both fields in one throw", () => {
+    expect(() =>
+      createConfig(
+        env({ VITE_API_URL: "bad-api", VITE_RPC_URL: "bad-rpc" }),
+      ),
+    ).toThrow(/apiUrl.*rpcUrl|rpcUrl.*apiUrl/);
+  });
+
+  it("accepts https apiUrl and rpcUrl", () => {
+    const config = createConfig(
+      env({
+        VITE_API_URL: "https://api.example.com",
+        VITE_RPC_URL: "https://rpc.example.com",
+      }),
+    );
+    expect(config.apiUrl).toBe("https://api.example.com");
+    expect(config.rpcUrl).toBe("https://rpc.example.com");
+  });
+
+  it("accepts http localhost for rpcUrl", () => {
+    const config = createConfig(
+      env({ VITE_RPC_URL: "http://localhost:8000" }),
+    );
+    expect(config.rpcUrl).toBe("http://localhost:8000");
   });
 });

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -23,6 +23,54 @@ export interface AppConfig {
   useMocks: boolean;
 }
 
+export interface ConfigError {
+  field: string;
+  message: string;
+}
+
+/**
+ * Validates a URL string, ensuring it is parseable and uses an allowed protocol.
+ *
+ * Accepted protocols: `https:` for all hosts; `http:` is additionally permitted
+ * for `localhost` and `127.0.0.1` to support local development.
+ *
+ * Rejected: `javascript:`, `data:`, `ftp:`, and any other non-http/https scheme.
+ *
+ * @returns The trimmed URL string on success, or a `ConfigError` if invalid.
+ */
+export function validateUrl(
+  field: string,
+  value: string,
+): string | ConfigError {
+  const trimmed = value.trim();
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return { field, message: `${field}: "${trimmed}" is not a valid URL` };
+  }
+
+  const isLocal =
+    parsed.hostname === "localhost" || parsed.hostname === "127.0.0.1";
+
+  if (parsed.protocol === "https:") return trimmed;
+  if (parsed.protocol === "http:" && isLocal) return trimmed;
+
+  return {
+    field,
+    message: `${field}: protocol "${parsed.protocol}" is not allowed; use https${isLocal ? " or http (localhost only)" : ""}`,
+  };
+}
+
+function optionalUrl(
+  field: string,
+  value: string | undefined,
+): string | null | ConfigError {
+  const trimmed = value?.trim();
+  if (!trimmed) return null;
+  return validateUrl(field, trimmed);
+}
+
 function optionalString(value: string | undefined): string | null {
   const trimmed = value?.trim();
   return trimmed ? trimmed : null;
@@ -43,12 +91,25 @@ export function getNetworkPassphrase(network: StellarNetwork): string {
 export function createConfig(env: ImportMetaEnv): AppConfig {
   const network = getExpectedStellarNetwork(env.VITE_NETWORK);
 
+  const apiUrlResult = optionalUrl("apiUrl", env.VITE_API_URL);
+  const rpcUrlResult = optionalUrl("rpcUrl", env.VITE_RPC_URL);
+
+  const errors: ConfigError[] = [];
+  if (apiUrlResult && typeof apiUrlResult === "object")
+    errors.push(apiUrlResult);
+  if (rpcUrlResult && typeof rpcUrlResult === "object")
+    errors.push(rpcUrlResult);
+
+  if (errors.length > 0) {
+    throw new Error(errors.map((e) => e.message).join("; "));
+  }
+
   return {
-    apiUrl: optionalString(env.VITE_API_URL),
+    apiUrl: apiUrlResult as string | null,
     network,
     networkLabel: getNetworkLabel(network),
     networkPassphrase: getNetworkPassphrase(network),
-    rpcUrl: optionalString(env.VITE_RPC_URL),
+    rpcUrl: rpcUrlResult as string | null,
     streamContractId: optionalString(env.VITE_STREAM_CONTRACT_ID),
     useMocks: parseBooleanFlag(env.VITE_USE_MOCKS),
   };


### PR DESCRIPTION
  feat(config): validate api and rpc url protocols
  
  optionalString() previously accepted any string for apiUrl and rpcUrl, allowing malformed
  values or non-https schemes to propagate silently.
  
  Changes
  
  - Added validateUrl(field, value) — parses with new URL() constructor and allow-lists
  protocols: https: everywhere, http: only for localhost/127.0.0.1
  - Added ConfigError interface for typed, field-specific error messages
  - createConfig now collects errors from both URL fields before throwing, so all problems
  surface in one startup failure
  - Unset/blank values remain null (optional behaviour unchanged)
  - TSDoc on validateUrl documents accepted protocols
  
  Security
  
  - Blocks javascript:, data:, ftp:, and all other non-http/https schemes
  - Prevents transport downgrade (http:// on non-local hosts)
  - Invalid values fail fast at config init rather than at request time
  
  Tested
  
  - 25/25 tests pass
  - Covers: valid https, http localhost/127.0.0.1, whitespace trimming, malformed strings,
  ftp://, javascript:, data:, http:// on remote hosts, unset fields, and multi-field error
  accumulation

closes #361