### PR TITLE
fix(nav): use segment-aware active link matching

### DIFF
--- a/src/components/navigation/NavLink.tsx
+++ b/src/components/navigation/NavLink.tsx
@@ -7,21 +7,60 @@ interface NavLinkProps {
   icon?: React.ReactNode;
   onClick?: () => void;
   disabled?: boolean;
-    variant?: "primary" | "secondary"; // added
+  variant?: "primary" | "secondary";
+  /**
+   * When `true`, the link is considered active only when the current
+   * pathname matches exactly (same number of segments). Useful for
+   * index-style links like `/` or `/dashboard`.
+   * @default false
+   */
+  end?: boolean;
+}
+
+/**
+ * Compares `pathname` and `to` segment-by-segment, avoiding false
+ * positives from raw string prefix matching (e.g. `/app/stream` vs
+ * `/app/streams`).
+ *
+ * - Splits both paths on `/` and discards empty segments.
+ * - In prefix mode (default): the link is active when every segment of
+ *   `to` matches the corresponding segment of `pathname` and `to` has
+ *   fewer or equal segments (i.e. `to` is a pathname prefix).
+ * - In exact mode (`end = true`): both paths must have the same number
+ *   of segments and every segment must match.
+ * - The root path `"/"` is always exact — it only activates on exactly `/`.
+ */
+function segmentMatch(pathname: string, to: string, end = false): boolean {
+  const pathSegments = pathname.split("/").filter(Boolean);
+  const toSegments = to.split("/").filter(Boolean);
+
+  if (to === "/" || end) {
+    return (
+      pathSegments.length === toSegments.length &&
+      toSegments.every((seg, i) => seg === pathSegments[i])
+    );
+  }
+
+  if (toSegments.length > pathSegments.length) {
+    return false;
+  }
+
+  return toSegments.every((seg, i) => seg === pathSegments[i]);
 }
 
 /**
  * Navigation Link Component
  * ──────────────────────────────────────
  * Implements DESIGN_SPEC.md § 4.2 Navigation specifications
- * 
+ *
  * Features:
- * - Auto-active state detection
+ * - Auto-active state detection via segment-aware matching
  * - aria-current="page" for screen readers
  * - Proper focus state with visible ring
  * - Hover/active/focus states from design spec
  * - Icon + label support
  * - Keyboard accessible (Tab, Enter)
+ * - `end` prop for exact-match index links
  */
 export default function NavLink({
   to,
@@ -29,10 +68,11 @@ export default function NavLink({
   icon,
   onClick,
   disabled = false,
-  variant = "primary", //added
+  variant = "primary",
+  end = false,
 }: NavLinkProps) {
   const { pathname } = useLocation();
-  const isActive = pathname === to || (to !== "/" && pathname.startsWith(to));
+  const isActive = segmentMatch(pathname, to, end);
 
   return (
     <Link

--- a/src/components/navigation/__tests__/NavLink.test.tsx
+++ b/src/components/navigation/__tests__/NavLink.test.tsx
@@ -1,0 +1,208 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { axe } from "vitest-axe";
+import { describe, expect, it } from "vitest";
+import NavLink from "../NavLink";
+
+function renderNavLink(props: Partial<React.ComponentProps<typeof NavLink>> = {}) {
+  return render(
+    <MemoryRouter initialEntries={["/app/streams"]}>
+      <NavLink to="/app/streams" label="Streams" {...props} />
+    </MemoryRouter>
+  );
+}
+
+describe("NavLink active state", () => {
+  it("marks active when pathname matches exactly", () => {
+    render(
+      <MemoryRouter initialEntries={["/app/streams"]}>
+        <NavLink to="/app/streams" label="Streams" />
+      </MemoryRouter>
+    );
+    const link = screen.getByRole("link", { name: "Streams" });
+    expect(link).toHaveAttribute("aria-current", "page");
+  });
+
+  it("does not mark sibling route with shared prefix as active", () => {
+    render(
+      <MemoryRouter initialEntries={["/app/streams"]}>
+        <>
+          <NavLink to="/app/stream" label="Single Stream" />
+          <NavLink to="/app/streams" label="All Streams" />
+        </>
+      </MemoryRouter>
+    );
+    expect(screen.getByRole("link", { name: "All Streams" })).toHaveAttribute(
+      "aria-current",
+      "page"
+    );
+    expect(
+      screen.getByRole("link", { name: "Single Stream" })
+    ).not.toHaveAttribute("aria-current");
+  });
+
+  it("marks parent active for nested detail routes (prefix segment match)", () => {
+    render(
+      <MemoryRouter initialEntries={["/app/streams/abc-123"]}>
+        <NavLink to="/app/streams" label="Streams" />
+      </MemoryRouter>
+    );
+    expect(screen.getByRole("link", { name: "Streams" })).toHaveAttribute(
+      "aria-current",
+      "page"
+    );
+  });
+
+  it("does not mark active for completely different route", () => {
+    render(
+      <MemoryRouter initialEntries={["/app/treasury"]}>
+        <NavLink to="/app/streams" label="Streams" />
+      </MemoryRouter>
+    );
+    expect(
+      screen.getByRole("link", { name: "Streams" })
+    ).not.toHaveAttribute("aria-current");
+  });
+
+  it("root path only activates on exact /", () => {
+    render(
+      <MemoryRouter initialEntries={["/app/streams"]}>
+        <NavLink to="/" label="Home" />
+      </MemoryRouter>
+    );
+    expect(screen.getByRole("link", { name: "Home" })).not.toHaveAttribute(
+      "aria-current"
+    );
+  });
+
+  it("root path activates on exactly /", () => {
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <NavLink to="/" label="Home" />
+      </MemoryRouter>
+    );
+    expect(screen.getByRole("link", { name: "Home" })).toHaveAttribute(
+      "aria-current",
+      "page"
+    );
+  });
+
+  it("end prop prevents match on nested routes", () => {
+    render(
+      <MemoryRouter initialEntries={["/app/streams/abc-123"]}>
+        <NavLink to="/app/streams" label="Streams" end />
+      </MemoryRouter>
+    );
+    expect(
+      screen.getByRole("link", { name: "Streams" })
+    ).not.toHaveAttribute("aria-current");
+  });
+
+  it("end prop still matches on exact pathname", () => {
+    render(
+      <MemoryRouter initialEntries={["/app/streams"]}>
+        <NavLink to="/app/streams" label="Streams" end />
+      </MemoryRouter>
+    );
+    expect(screen.getByRole("link", { name: "Streams" })).toHaveAttribute(
+      "aria-current",
+      "page"
+    );
+  });
+});
+
+describe("NavLink prefix collision cases", () => {
+  it.each([
+    { current: "/a", to: "/ab", shouldBeActive: false },
+    { current: "/ab", to: "/a", shouldBeActive: false },
+    { current: "/a/b", to: "/a", shouldBeActive: true },
+    { current: "/a/b/c", to: "/a/b", shouldBeActive: true },
+    { current: "/a/b", to: "/a/b", shouldBeActive: true },
+    { current: "/a", to: "/a", shouldBeActive: true },
+  ])(
+    "current=$current to=$to → active=$shouldBeActive",
+    ({ current, to, shouldBeActive }) => {
+      render(
+        <MemoryRouter initialEntries={[current]}>
+          <NavLink to={to} label="Link" />
+        </MemoryRouter>
+      );
+      const link = screen.getByRole("link", { name: "Link" });
+      if (shouldBeActive) {
+        expect(link).toHaveAttribute("aria-current", "page");
+      } else {
+        expect(link).not.toHaveAttribute("aria-current");
+      }
+    }
+  );
+});
+
+describe("NavLink with trailing slash", () => {
+  it("matches when pathname has trailing slash and to does not", () => {
+    render(
+      <MemoryRouter initialEntries={["/app/streams/"]}>
+        <NavLink to="/app/streams" label="Streams" />
+      </MemoryRouter>
+    );
+    expect(screen.getByRole("link", { name: "Streams" })).toHaveAttribute(
+      "aria-current",
+      "page"
+    );
+  });
+
+  it("matches when to has trailing slash and pathname does not", () => {
+    render(
+      <MemoryRouter initialEntries={["/app/streams"]}>
+        <NavLink to="/app/streams/" label="Streams" />
+      </MemoryRouter>
+    );
+    expect(screen.getByRole("link", { name: "Streams" })).toHaveAttribute(
+      "aria-current",
+      "page"
+    );
+  });
+});
+
+describe("NavLink disabled state", () => {
+  it("applies disabled styles and aria-disabled", () => {
+    renderNavLink({ disabled: true });
+    const link = screen.getByRole("link", { name: "Streams" });
+    expect(link).toHaveAttribute("aria-disabled", "true");
+    expect(link).toHaveStyle({ pointerEvents: "none" });
+  });
+});
+
+describe("NavLink accessibility", () => {
+  it("has no automated accessibility violations", async () => {
+    const { container } = render(
+      <MemoryRouter initialEntries={["/app/streams"]}>
+        <NavLink to="/app/streams" label="Streams" />
+      </MemoryRouter>
+    );
+    const results = await axe(container);
+    expect(results.violations).toEqual([]);
+  });
+
+  it("does not set aria-current when not active", () => {
+    render(
+      <MemoryRouter initialEntries={["/other"]}>
+        <NavLink to="/app/streams" label="Streams" />
+      </MemoryRouter>
+    );
+    expect(
+      screen.getByRole("link", { name: "Streams" })
+    ).not.toHaveAttribute("aria-current");
+  });
+});
+
+describe("NavLink variant styling", () => {
+  it("applies secondary class when variant is secondary", () => {
+    const { container } = render(
+      <MemoryRouter initialEntries={["/app/streams"]}>
+        <NavLink to="/app/streams" label="Streams" variant="secondary" />
+      </MemoryRouter>
+    );
+    const link = container.firstChild as HTMLElement;
+    expect(link.className).toMatch(/navItemSecondary/);
+  });
+});


### PR DESCRIPTION
## Summary

Replaces `pathname.startsWith(to)` with segment-aware matching in `NavLink.tsx` to fix false-positive active states on sibling routes that share a string prefix (e.g. `/app/stream` vs `/app/streams`).

Closes #365

## Changes

### `src/components/navigation/NavLink.tsx`
- Introduced `segmentMatch(pathname, to, end)` — splits both paths on `/`, discards empty segments, and compares segment-by-segment
- Root path `/` always uses exact matching
- Added optional `end` prop for index-style links that should only activate on an exact segment count match
- Preserved `aria-current="page"` alignment with the new active detection
- Added TSDoc documentation on the `end` prop and the `segmentMatch` function

### `src/components/navigation/__tests__/NavLink.test.tsx` (new)
20 tests covering:
- Exact path match
- Prefix-collision siblings — `/app/stream` is no longer active on `/app/streams`
- Nested detail routes — `/app/streams/abc-123` still activates `/app/streams`
- Completely different routes
- Root `/` exact-only behavior
- `end` prop prevents match on deeper routes, allows match on exact
- 6 parameterized prefix-collision edge cases (`/a` vs `/ab`, etc.)
- Trailing slash equivalence (both directions)
- Disabled state styles and `aria-disabled`
- Accessibility — zero `axe` violations
- Variant class application

## Test output

```
✓ src/components/navigation/__tests__/NavLink.test.tsx (20 tests)
 Test Files  1 passed (1)
      Tests  20 passed (20)
```

## Security notes

N/A. No new dependencies, no network calls, no user input evaluated as code.