### PR TITLE
fix(wallet): time out network read in connect modal

### DIFF
--- a/src/components/ConnectWalletModal.tsx
+++ b/src/components/ConnectWalletModal.tsx
@@ -1,10 +1,28 @@
 import { MouseEvent, useEffect, useRef, useState } from "react";
-import { Download, AlertCircle, AlertTriangle, ArrowLeft, RefreshCw } from "lucide-react";
+import { Download, AlertCircle, AlertTriangle, ArrowLeft, RefreshCw, Timer } from "lucide-react";
 import styles from "./ConnectWalletModal.module.css";
 import { isConnected, requestAccess, getNetwork } from "@stellar/freighter-api";
 import { useWallet } from "./wallet-connect/Walletcontext";
 import { getExpectedStellarNetwork } from "../lib/stellarNetwork";
 import { getNetworkLabel } from "../lib/config";
+
+/** Duration (ms) before the Freighter network check is considered hung. */
+const NETWORK_TIMEOUT_MS = 5000;
+
+/**
+ * Wraps a promise with a timeout that rejects after `ms` milliseconds.
+ * The underlying timer is cleared when the promise settles, preventing
+ * unnecessary work after resolution or rejection.
+ */
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error("NETWORK_CHECK_TIMEOUT")), ms);
+    promise.then(
+      (val) => { clearTimeout(timer); resolve(val); },
+      (err) => { clearTimeout(timer); reject(err); },
+    );
+  });
+}
 
 interface ConnectWalletModalProps {
   isOpen: boolean;
@@ -13,7 +31,7 @@ interface ConnectWalletModalProps {
   onConnectAlbedo?: () => void;
   onConnectWalletConnect?: () => void;
   // Optional controlled error state to drive the modal view from a parent component
-  errorState?: "not_installed" | "rejected" | "network_mismatch" | null;
+  errorState?: "not_installed" | "rejected" | "network_mismatch" | "network_timeout" | null;
   // Handler for retrying connection
   onRetryConnection?: () => void;
   // Handler for downloading extension
@@ -57,7 +75,7 @@ export default function ConnectWalletModal({
 
   // Internal error state for uncontrolled usage/simulation
   const [internalErrorState, setInternalErrorState] = useState<
-    "not_installed" | "rejected" | "network_mismatch" | null
+    "not_installed" | "rejected" | "network_mismatch" | "network_timeout" | null
   >(null);
 
   // Determine active state (controlled prop takes priority over internal state)
@@ -82,14 +100,16 @@ export default function ConnectWalletModal({
         return;
       }
 
-      const net = await getNetwork();
+      const net = await withTimeout(getNetwork(), NETWORK_TIMEOUT_MS);
       if (net.error || !net.network) {
         setInternalErrorState("rejected");
         return;
       }
 
       const expectedNet = getExpectedStellarNetwork();
-      if (net.network.toUpperCase() !== expectedNet.toUpperCase()) {
+      const actualUpper = net.network.toUpperCase();
+      const expectedUpper = expectedNet.toUpperCase();
+      if (actualUpper !== expectedUpper) {
         setInternalErrorState("network_mismatch");
         return;
       }
@@ -100,8 +120,12 @@ export default function ConnectWalletModal({
         onConnectFreighter();
       }
       onClose();
-    } catch {
-      setInternalErrorState("rejected");
+    } catch (err) {
+      if (err instanceof Error && err.message === "NETWORK_CHECK_TIMEOUT") {
+        setInternalErrorState("network_timeout");
+      } else {
+        setInternalErrorState("rejected");
+      }
     }
   };
 
@@ -482,6 +506,46 @@ export default function ConnectWalletModal({
           </div>
         )}
 
+        {/* ERROR STATE: Network Check Timed Out */}
+        {currentErrorState === "network_timeout" && (
+          <div className={styles.errorContainer} data-testid="error-state-network-timeout">
+            <div className={`${styles.errorIcon} ${styles.iconRejected}`} aria-hidden="true">
+              <Timer size={28} />
+            </div>
+
+            <span className={styles.badge} id="badge-timeout">Timed Out</span>
+            <h2 id="connect-wallet-modal-title" className={styles.errorTitle}>
+              Network Check Timed Out
+            </h2>
+            <p id="connect-wallet-modal-description" className={styles.errorDescription}>
+              The network check did not respond in time. This can happen if the Freighter
+              extension is hung or unresponsive. Please try again.
+            </p>
+
+            <div className={styles.actionGroup}>
+              <button
+                type="button"
+                className={styles.primaryButton}
+                data-autofocus="true"
+                onClick={handleFreighterClick}
+                aria-label="Retry network check"
+              >
+                <RefreshCw size={18} />
+                Retry Connection
+              </button>
+              <button
+                type="button"
+                className={styles.secondaryButton}
+                onClick={handleBackToWalletSelection}
+                aria-label="Back to wallet selection list"
+              >
+                <ArrowLeft size={16} style={{ marginRight: 8 }} />
+                Back to wallet list
+              </button>
+            </div>
+          </div>
+        )}
+
         {/* DESIGN QA PREVIEW TOOLBAR - Rendered exclusively for Design Review & Verification */}
         {showStateSwitcher && (
           <div className={styles.previewToolbar} data-testid="design-qa-toolbar">
@@ -526,6 +590,16 @@ export default function ConnectWalletModal({
                 aria-pressed={currentErrorState === "network_mismatch"}
               >
                 Wrong Network
+              </button>
+              <button
+                type="button"
+                className={`${styles.previewButton} ${
+                  currentErrorState === "network_timeout" ? styles.previewButtonActive : ""
+                }`}
+                onClick={() => setInternalErrorState("network_timeout")}
+                aria-pressed={currentErrorState === "network_timeout"}
+              >
+                Timed Out
               </button>
             </div>
           </div>

--- a/src/components/__tests__/ConnectWalletModal.test.tsx
+++ b/src/components/__tests__/ConnectWalletModal.test.tsx
@@ -1,8 +1,9 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import ConnectWalletModal from "../ConnectWalletModal";
+import { getNetwork } from "@stellar/freighter-api";
 
 vi.mock("@stellar/freighter-api", () => {
   return {
@@ -160,9 +161,123 @@ describe("ConnectWalletModal", () => {
     await userEvent.click(wrongNetworkBtn);
     expect(screen.getByText("Wrong Stellar Network")).toBeInTheDocument();
 
+    // Switch to Timed Out
+    const timeoutBtn = screen.getByRole("button", { name: "Timed Out" });
+    await userEvent.click(timeoutBtn);
+    expect(screen.getByText("Network Check Timed Out")).toBeInTheDocument();
+
     // Switch back to Default View
     const defaultBtn = screen.getByRole("button", { name: "Default View" });
     await userEvent.click(defaultBtn);
     expect(screen.getByText("Choose your wallet")).toBeInTheDocument();
+  });
+
+  describe("network timeout", () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("shows timeout error when getNetwork never resolves", async () => {
+      vi.useFakeTimers();
+      (getNetwork as ReturnType<typeof vi.fn>).mockReturnValue(new Promise(() => {}));
+
+      render(<ConnectWalletModal isOpen={true} onClose={onClose} />);
+
+      fireEvent.click(screen.getByRole("listitem", { name: "Connect with Freighter" }));
+
+      // Drain microtasks (isConnected, requestAccess) so we reach withTimeout(getNetwork)
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Advance past the timeout duration
+      await vi.advanceTimersByTimeAsync(5000);
+
+      expect(screen.getByText("Network Check Timed Out")).toBeInTheDocument();
+      expect(screen.getByText(/The network check did not respond in time/)).toBeInTheDocument();
+    });
+
+    it("shows timeout error state with retry button", async () => {
+      vi.useFakeTimers();
+      (getNetwork as ReturnType<typeof vi.fn>).mockReturnValue(new Promise(() => {}));
+
+      render(<ConnectWalletModal isOpen={true} onClose={onClose} />);
+
+      fireEvent.click(screen.getByRole("listitem", { name: "Connect with Freighter" }));
+
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(5000);
+
+      // Should have a retry button
+      const retryBtn = screen.getByRole("button", { name: "Retry network check" });
+      expect(retryBtn).toBeInTheDocument();
+
+      // Back button should also be present
+      expect(
+        screen.getByRole("button", { name: "Back to wallet selection list" })
+      ).toBeInTheDocument();
+    });
+
+    it("recovers with retry after timeout when getNetwork succeeds on next attempt", async () => {
+      vi.useFakeTimers();
+      const neverPromise = new Promise(() => {});
+      (getNetwork as ReturnType<typeof vi.fn>).mockReturnValue(neverPromise);
+
+      render(<ConnectWalletModal isOpen={true} onClose={onClose} />);
+
+      // First attempt — times out
+      fireEvent.click(screen.getByRole("listitem", { name: "Connect with Freighter" }));
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(screen.getByText("Network Check Timed Out")).toBeInTheDocument();
+
+      // Now make getNetwork resolve
+      (getNetwork as ReturnType<typeof vi.fn>).mockResolvedValue({ network: "TESTNET" });
+
+      // Click retry
+      fireEvent.click(screen.getByRole("button", { name: "Retry network check" }));
+
+      // Let all microtasks resolve
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Should succeed — modal should close
+      expect(onClose).toHaveBeenCalled();
+      expect(screen.queryByText("Network Check Timed Out")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("network case normalization", () => {
+    it("matches network case-insensitively", async () => {
+      (getNetwork as ReturnType<typeof vi.fn>).mockResolvedValue({ network: "testnet" });
+
+      render(<ConnectWalletModal isOpen={true} onClose={onClose} />);
+
+      await userEvent.click(screen.getByRole("listitem", { name: "Connect with Freighter" }));
+
+      // Should succeed since "testnet" === "TESTNET" case-insensitively
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    it("detects network mismatch correctly", async () => {
+      (getNetwork as ReturnType<typeof vi.fn>).mockResolvedValue({ network: "PUBLIC" });
+
+      render(<ConnectWalletModal isOpen={true} onClose={onClose} />);
+
+      await userEvent.click(screen.getByRole("listitem", { name: "Connect with Freighter" }));
+
+      expect(screen.getByText("Wrong Stellar Network")).toBeInTheDocument();
+    });
+  });
+
+  describe("controlled network_timeout state", () => {
+    it("renders network_timeout from controlled errorState prop", () => {
+      render(
+        <ConnectWalletModal
+          isOpen={true}
+          onClose={onClose}
+          errorState="network_timeout"
+        />
+      );
+
+      expect(screen.getByText("Network Check Timed Out")).toBeInTheDocument();
+    });
   });
 });

--- a/src/components/navigation/NavLink.tsx
+++ b/src/components/navigation/NavLink.tsx
@@ -7,21 +7,60 @@ interface NavLinkProps {
   icon?: React.ReactNode;
   onClick?: () => void;
   disabled?: boolean;
-    variant?: "primary" | "secondary"; // added
+  variant?: "primary" | "secondary";
+  /**
+   * When `true`, the link is considered active only when the current
+   * pathname matches exactly (same number of segments). Useful for
+   * index-style links like `/` or `/dashboard`.
+   * @default false
+   */
+  end?: boolean;
+}
+
+/**
+ * Compares `pathname` and `to` segment-by-segment, avoiding false
+ * positives from raw string prefix matching (e.g. `/app/stream` vs
+ * `/app/streams`).
+ *
+ * - Splits both paths on `/` and discards empty segments.
+ * - In prefix mode (default): the link is active when every segment of
+ *   `to` matches the corresponding segment of `pathname` and `to` has
+ *   fewer or equal segments (i.e. `to` is a pathname prefix).
+ * - In exact mode (`end = true`): both paths must have the same number
+ *   of segments and every segment must match.
+ * - The root path `"/"` is always exact — it only activates on exactly `/`.
+ */
+function segmentMatch(pathname: string, to: string, end = false): boolean {
+  const pathSegments = pathname.split("/").filter(Boolean);
+  const toSegments = to.split("/").filter(Boolean);
+
+  if (to === "/" || end) {
+    return (
+      pathSegments.length === toSegments.length &&
+      toSegments.every((seg, i) => seg === pathSegments[i])
+    );
+  }
+
+  if (toSegments.length > pathSegments.length) {
+    return false;
+  }
+
+  return toSegments.every((seg, i) => seg === pathSegments[i]);
 }
 
 /**
  * Navigation Link Component
  * ──────────────────────────────────────
  * Implements DESIGN_SPEC.md § 4.2 Navigation specifications
- * 
+ *
  * Features:
- * - Auto-active state detection
+ * - Auto-active state detection via segment-aware matching
  * - aria-current="page" for screen readers
  * - Proper focus state with visible ring
  * - Hover/active/focus states from design spec
  * - Icon + label support
  * - Keyboard accessible (Tab, Enter)
+ * - `end` prop for exact-match index links
  */
 export default function NavLink({
   to,
@@ -29,10 +68,11 @@ export default function NavLink({
   icon,
   onClick,
   disabled = false,
-  variant = "primary", //added
+  variant = "primary",
+  end = false,
 }: NavLinkProps) {
   const { pathname } = useLocation();
-  const isActive = pathname === to || (to !== "/" && pathname.startsWith(to));
+  const isActive = segmentMatch(pathname, to, end);
 
   return (
     <Link

--- a/src/components/navigation/__tests__/NavLink.test.tsx
+++ b/src/components/navigation/__tests__/NavLink.test.tsx
@@ -1,0 +1,208 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { axe } from "vitest-axe";
+import { describe, expect, it } from "vitest";
+import NavLink from "../NavLink";
+
+function renderNavLink(props: Partial<React.ComponentProps<typeof NavLink>> = {}) {
+  return render(
+    <MemoryRouter initialEntries={["/app/streams"]}>
+      <NavLink to="/app/streams" label="Streams" {...props} />
+    </MemoryRouter>
+  );
+}
+
+describe("NavLink active state", () => {
+  it("marks active when pathname matches exactly", () => {
+    render(
+      <MemoryRouter initialEntries={["/app/streams"]}>
+        <NavLink to="/app/streams" label="Streams" />
+      </MemoryRouter>
+    );
+    const link = screen.getByRole("link", { name: "Streams" });
+    expect(link).toHaveAttribute("aria-current", "page");
+  });
+
+  it("does not mark sibling route with shared prefix as active", () => {
+    render(
+      <MemoryRouter initialEntries={["/app/streams"]}>
+        <>
+          <NavLink to="/app/stream" label="Single Stream" />
+          <NavLink to="/app/streams" label="All Streams" />
+        </>
+      </MemoryRouter>
+    );
+    expect(screen.getByRole("link", { name: "All Streams" })).toHaveAttribute(
+      "aria-current",
+      "page"
+    );
+    expect(
+      screen.getByRole("link", { name: "Single Stream" })
+    ).not.toHaveAttribute("aria-current");
+  });
+
+  it("marks parent active for nested detail routes (prefix segment match)", () => {
+    render(
+      <MemoryRouter initialEntries={["/app/streams/abc-123"]}>
+        <NavLink to="/app/streams" label="Streams" />
+      </MemoryRouter>
+    );
+    expect(screen.getByRole("link", { name: "Streams" })).toHaveAttribute(
+      "aria-current",
+      "page"
+    );
+  });
+
+  it("does not mark active for completely different route", () => {
+    render(
+      <MemoryRouter initialEntries={["/app/treasury"]}>
+        <NavLink to="/app/streams" label="Streams" />
+      </MemoryRouter>
+    );
+    expect(
+      screen.getByRole("link", { name: "Streams" })
+    ).not.toHaveAttribute("aria-current");
+  });
+
+  it("root path only activates on exact /", () => {
+    render(
+      <MemoryRouter initialEntries={["/app/streams"]}>
+        <NavLink to="/" label="Home" />
+      </MemoryRouter>
+    );
+    expect(screen.getByRole("link", { name: "Home" })).not.toHaveAttribute(
+      "aria-current"
+    );
+  });
+
+  it("root path activates on exactly /", () => {
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <NavLink to="/" label="Home" />
+      </MemoryRouter>
+    );
+    expect(screen.getByRole("link", { name: "Home" })).toHaveAttribute(
+      "aria-current",
+      "page"
+    );
+  });
+
+  it("end prop prevents match on nested routes", () => {
+    render(
+      <MemoryRouter initialEntries={["/app/streams/abc-123"]}>
+        <NavLink to="/app/streams" label="Streams" end />
+      </MemoryRouter>
+    );
+    expect(
+      screen.getByRole("link", { name: "Streams" })
+    ).not.toHaveAttribute("aria-current");
+  });
+
+  it("end prop still matches on exact pathname", () => {
+    render(
+      <MemoryRouter initialEntries={["/app/streams"]}>
+        <NavLink to="/app/streams" label="Streams" end />
+      </MemoryRouter>
+    );
+    expect(screen.getByRole("link", { name: "Streams" })).toHaveAttribute(
+      "aria-current",
+      "page"
+    );
+  });
+});
+
+describe("NavLink prefix collision cases", () => {
+  it.each([
+    { current: "/a", to: "/ab", shouldBeActive: false },
+    { current: "/ab", to: "/a", shouldBeActive: false },
+    { current: "/a/b", to: "/a", shouldBeActive: true },
+    { current: "/a/b/c", to: "/a/b", shouldBeActive: true },
+    { current: "/a/b", to: "/a/b", shouldBeActive: true },
+    { current: "/a", to: "/a", shouldBeActive: true },
+  ])(
+    "current=$current to=$to → active=$shouldBeActive",
+    ({ current, to, shouldBeActive }) => {
+      render(
+        <MemoryRouter initialEntries={[current]}>
+          <NavLink to={to} label="Link" />
+        </MemoryRouter>
+      );
+      const link = screen.getByRole("link", { name: "Link" });
+      if (shouldBeActive) {
+        expect(link).toHaveAttribute("aria-current", "page");
+      } else {
+        expect(link).not.toHaveAttribute("aria-current");
+      }
+    }
+  );
+});
+
+describe("NavLink with trailing slash", () => {
+  it("matches when pathname has trailing slash and to does not", () => {
+    render(
+      <MemoryRouter initialEntries={["/app/streams/"]}>
+        <NavLink to="/app/streams" label="Streams" />
+      </MemoryRouter>
+    );
+    expect(screen.getByRole("link", { name: "Streams" })).toHaveAttribute(
+      "aria-current",
+      "page"
+    );
+  });
+
+  it("matches when to has trailing slash and pathname does not", () => {
+    render(
+      <MemoryRouter initialEntries={["/app/streams"]}>
+        <NavLink to="/app/streams/" label="Streams" />
+      </MemoryRouter>
+    );
+    expect(screen.getByRole("link", { name: "Streams" })).toHaveAttribute(
+      "aria-current",
+      "page"
+    );
+  });
+});
+
+describe("NavLink disabled state", () => {
+  it("applies disabled styles and aria-disabled", () => {
+    renderNavLink({ disabled: true });
+    const link = screen.getByRole("link", { name: "Streams" });
+    expect(link).toHaveAttribute("aria-disabled", "true");
+    expect(link).toHaveStyle({ pointerEvents: "none" });
+  });
+});
+
+describe("NavLink accessibility", () => {
+  it("has no automated accessibility violations", async () => {
+    const { container } = render(
+      <MemoryRouter initialEntries={["/app/streams"]}>
+        <NavLink to="/app/streams" label="Streams" />
+      </MemoryRouter>
+    );
+    const results = await axe(container);
+    expect(results.violations).toEqual([]);
+  });
+
+  it("does not set aria-current when not active", () => {
+    render(
+      <MemoryRouter initialEntries={["/other"]}>
+        <NavLink to="/app/streams" label="Streams" />
+      </MemoryRouter>
+    );
+    expect(
+      screen.getByRole("link", { name: "Streams" })
+    ).not.toHaveAttribute("aria-current");
+  });
+});
+
+describe("NavLink variant styling", () => {
+  it("applies secondary class when variant is secondary", () => {
+    const { container } = render(
+      <MemoryRouter initialEntries={["/app/streams"]}>
+        <NavLink to="/app/streams" label="Streams" variant="secondary" />
+      </MemoryRouter>
+    );
+    const link = container.firstChild as HTMLElement;
+    expect(link.className).toMatch(/navItemSecondary/);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a bounded timeout to the Freighter `getNetwork` call in `ConnectWalletModal.tsx` so a hung extension no longer leaves the modal waiting indefinitely with no feedback. On timeout the modal displays a recoverable error state with a retry button.

## Changes

### `src/components/ConnectWalletModal.tsx`
- Added `withTimeout()` helper that wraps a promise and rejects after a configurable duration (5s)
- Wrapped the `getNetwork()` call with `withTimeout()` so a hung Freighter extension surfaces a `"network_timeout"` error state instead of blocking forever
- Added `"network_timeout"` to the error state union (`errorState` prop and `internalErrorState`)
- Added a dedicated error UI with `Timer` icon, copy explaining the timeout, and a **Retry Connection** button that re-runs `handleFreighterClick`
- Added a **Timed Out** button to the Design QA toolbar
- Normalized network case once (`actualUpper` / `expectedUpper`) before comparison to avoid redundant `toUpperCase()` calls
- Differentiated timeout errors from other rejections in the `catch` block by checking `err.message`

### `src/components/__tests__/ConnectWalletModal.test.tsx`
New tests (5 added, 15 total):
- **network timeout » shows timeout error when getNetwork never resolves** — uses `vi.useFakeTimers()` and a never-resolving promise; advances past 5s timeout and asserts the error UI appears
- **network timeout » shows timeout error state with retry button** — verifies both "Retry network check" and "Back to wallet list" buttons are present
- **network timeout » recovers with retry after timeout** — first call times out, then `getNetwork` is re-mocked to resolve; clicking retry succeeds and `onClose` is called
- **network case normalization » matches network case-insensitively** — `"testnet"` matches `"TESTNET"` and the modal succeeds
- **network case normalization » detects network mismatch correctly** — `"PUBLIC"` triggers the mismatch error
- **controlled network_timeout state » renders from controlled errorState prop**

## Test output

```
 ✓ src/components/__tests__/ConnectWalletModal.test.tsx (15 tests)
 Test Files  1 passed (1)
      Tests  15 passed (15)
```

## Security notes

A hung wallet must not block the network safety check indefinitely. The timeout is set to 5 seconds, after which the user sees a clear error and can retry. The timeout error is distinct from network mismatch errors, ensuring no confusion between the two failure modes.