### PR TITLE
fix(streams): preserve fractional precision in usdc formatting

### DIFF
--- a/src/pages/Streams.test.tsx
+++ b/src/pages/Streams.test.tsx
@@ -277,3 +277,40 @@ describe("Streams card recipient copy", () => {
     );
   });
 });
+
+describe("formatUsdc", () => {
+  // Import is resolved at module level; we re-import here to keep tests self-contained.
+  let formatUsdc: (value: number) => string;
+
+  beforeEach(async () => {
+    ({ formatUsdc } = await import("./Streams"));
+  });
+
+  it("formats fractional amounts without rounding", () => {
+    expect(formatUsdc(1234.56)).toBe("1,234.56 USDC");
+  });
+
+  it("formats an integer amount with two decimal places", () => {
+    expect(formatUsdc(1000)).toBe("1,000.00 USDC");
+  });
+
+  it("formats zero", () => {
+    expect(formatUsdc(0)).toBe("0.00 USDC");
+  });
+
+  it("formats large amounts with grouping separators", () => {
+    expect(formatUsdc(1_000_000.99)).toBe("1,000,000.99 USDC");
+  });
+
+  it("returns safe placeholder for NaN", () => {
+    expect(formatUsdc(NaN)).toBe("— USDC");
+  });
+
+  it("returns safe placeholder for negative values", () => {
+    expect(formatUsdc(-50)).toBe("— USDC");
+  });
+
+  it("returns safe placeholder for Infinity", () => {
+    expect(formatUsdc(Infinity)).toBe("— USDC");
+  });
+});

--- a/src/pages/Streams.tsx
+++ b/src/pages/Streams.tsx
@@ -48,9 +48,18 @@ const FILTER_ANNOUNCEMENT_DELAY_MS = 300;
 const STREAMS_VIRTUALIZATION_THRESHOLD = 20;
 const STREAM_CARD_ESTIMATED_HEIGHT = 420;
 
-function formatUsdc(value: number) {
+/**
+ * Formats a USDC amount with full fractional precision (2 decimal places).
+ * Returns a safe placeholder for NaN or negative inputs.
+ *
+ * @param value - The numeric USDC amount to format.
+ * @returns A locale-aware string such as "1,234.56 USDC".
+ */
+export function formatUsdc(value: number): string {
+  if (!Number.isFinite(value) || value < 0) return "— USDC";
   return `${new Intl.NumberFormat("en-US", {
-    maximumFractionDigits: 0,
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
   }).format(value)} USDC`;
 }
 


### PR DESCRIPTION
Closes #362

What was done
formatUsdc in src/pages/Streams.tsx was using maximumFractionDigits: 0, which rounded all USDC amounts to whole units (e.g. 1,234.56 → "1,235 USDC"). This misrepresents balances in a financial app.

How it was fixed
Changed Intl.NumberFormat options to minimumFractionDigits: 2, maximumFractionDigits: 2 so amounts always render with exact cents.
Added a guard for NaN, negative, and Infinity inputs that returns a safe "— USDC" placeholder instead of a misleading value.
Exported formatUsdc to allow direct unit testing.
Added 7 unit tests in Streams.test.tsx covering: fractional amounts, integer amounts, zero, large amounts with grouping separators, NaN, negative, and Infinity.