### PR TITLE
a11y(toast): explicit variant to aria-live mapping (#378)

### DIFF
--- a/src/components/ToastNotification.tsx
+++ b/src/components/ToastNotification.tsx
@@ -15,17 +15,40 @@ const TOAST_COPY: Record<ToastVariant, { label: string; icon: string }> = {
   warning: { label: "Warning", icon: "⚠" },
 };
 
+/**
+ * Maps each toast variant to its ARIA live-region semantics.
+ *
+ * - `error` / `warning` → `role="alert"` + `aria-live="assertive"` so screen
+ *   readers interrupt the current announcement immediately.
+ * - `success` / `info`  → `role="status"` + `aria-live="polite"` for non-urgent
+ *   updates that wait for a natural pause.
+ * - Unknown variants default to `assertive` alert semantics as the fail-safe
+ *   choice: it is safer to over-announce an unexpected toast than to silently
+ *   miss a potentially critical message.
+ */
+const VARIANT_SEMANTICS: Record<
+  ToastVariant,
+  { role: "alert" | "status"; "aria-live": "assertive" | "polite" }
+> = {
+  error:   { role: "alert",  "aria-live": "assertive" },
+  warning: { role: "alert",  "aria-live": "assertive" },
+  success: { role: "status", "aria-live": "polite" },
+  info:    { role: "status", "aria-live": "polite" },
+};
+
+/** Fail-safe semantics used when a variant is not in {@link VARIANT_SEMANTICS}. */
+const FALLBACK_SEMANTICS = { role: "alert" as const, "aria-live": "assertive" as const };
+
+const FALLBACK_COPY = { label: "Alert", icon: "!" };
+
 export default function ToastNotification({
   message,
   variant,
   onClose,
 }: ToastNotificationProps) {
-  const semantics =
-    variant === "error" || variant === "warning"
-      ? { role: "alert" as const, "aria-live": "assertive" as const }
-      : { role: "status" as const, "aria-live": "polite" as const };
+  const semantics = VARIANT_SEMANTICS[variant] ?? FALLBACK_SEMANTICS;
 
-  const { label, icon } = TOAST_COPY[variant];
+  const { label, icon } = TOAST_COPY[variant] ?? FALLBACK_COPY;
 
   return (
     <div

--- a/src/components/__tests__/ToastNotification.test.tsx
+++ b/src/components/__tests__/ToastNotification.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import ToastNotification from "../ToastNotification";
+import type { ToastVariant } from "../ToastNotification";
+
+const noop = () => {};
+
+describe("ToastNotification aria-live semantics", () => {
+  it.each([
+    ["error",   "alert",  "assertive"],
+    ["warning", "alert",  "assertive"],
+    ["success", "status", "polite"],
+    ["info",    "status", "polite"],
+  ] as [ToastVariant, string, string][])(
+    "%s → role=%s aria-live=%s",
+    (variant, expectedRole, expectedLive) => {
+      render(
+        <ToastNotification message="msg" variant={variant} onClose={noop} />,
+      );
+      const el = screen.getByRole(expectedRole as "alert" | "status");
+      expect(el).toHaveAttribute("aria-live", expectedLive);
+      expect(el).toHaveAttribute("aria-atomic", "true");
+    },
+  );
+
+  it("unknown variant falls back to assertive alert semantics", () => {
+    // Cast to bypass TypeScript's type guard — simulates a runtime unknown value
+    const unknown = "critical" as ToastVariant;
+    render(
+      <ToastNotification message="unknown msg" variant={unknown} onClose={noop} />,
+    );
+    const el = screen.getByRole("alert");
+    expect(el).toHaveAttribute("aria-live", "assertive");
+    expect(el).toHaveAttribute("aria-atomic", "true");
+    expect(screen.getByText("unknown msg")).toBeInTheDocument();
+  });
+
+  it("unknown variant close button still works", () => {
+    const onClose = vi.fn();
+    const unknown = "critical" as ToastVariant;
+    render(
+      <ToastNotification message="msg" variant={unknown} onClose={onClose} />,
+    );
+    screen.getByRole("button", { name: /dismiss/i }).click();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Replaces the ternary in `ToastNotification.tsx` with an explicit `VARIANT_SEMANTICS` lookup table and a documented fail-safe fallback.

## Changes

- **`src/components/ToastNotification.tsx`** — `VARIANT_SEMANTICS` map replaces the `error||warning` ternary. Unknown variants resolve via `??` to `FALLBACK_SEMANTICS` (`role=alert`, `aria-live=assertive`). Added `FALLBACK_COPY` so the component renders without crashing for unknown variants. TSDoc on both constants explains the rationale.
- **`src/components/__tests__/ToastNotification.test.tsx`** (new) — 6 tests: all 4 known variants (role + aria-live + aria-atomic), unknown variant assertive fallback, and unknown variant close-button callback.

## Semantics

| Variant | role | aria-live |
|---------|------|-----------|
| error | alert | assertive |
| warning | alert | assertive |
| success | status | polite |
| info | status | polite |
| *unknown* | alert | assertive |

## Verification

- `tsc -b --noEmit` — clean
- `npm run test` — 406/406 passed (59 test files)

Closes #378