### PR TITLE
security(routing): sanitize post-connect returnTo target

### DIFF
--- a/src/components/RequireWallet.tsx
+++ b/src/components/RequireWallet.tsx
@@ -2,6 +2,35 @@ import { ReactNode } from "react";
 import { Navigate, useLocation } from "react-router-dom";
 import { useWallet } from "./wallet-connect/Walletcontext";
 
+const SAFE_DEFAULT = "/app";
+
+/**
+ * Sanitizes a post-connect redirect target to prevent open-redirect attacks.
+ *
+ * Only allows same-origin, in-app relative paths starting with `/`.
+ * Rejects absolute URLs (`http://`, `https://`), protocol-relative URLs (`//`),
+ * dangerous schemes (`javascript:`), path-traversal segments (`..`), and
+ * non-string / empty values.
+ *
+ * @param returnTo - The raw redirect target from location state (untrusted).
+ * @returns A safe redirect path, defaulting to `"/app"` when validation fails.
+ */
+export function sanitizeReturnTo(returnTo: unknown): string {
+  if (typeof returnTo !== "string" || returnTo.trim() === "") {
+    return SAFE_DEFAULT;
+  }
+
+  const trimmed = returnTo.trim();
+
+  if (/^https?:\/\//i.test(trimmed)) return SAFE_DEFAULT;
+  if (/^\/\//.test(trimmed)) return SAFE_DEFAULT;
+  if (/^\w+:/i.test(trimmed)) return SAFE_DEFAULT;
+  if (!trimmed.startsWith("/")) return SAFE_DEFAULT;
+  if (trimmed.includes("..")) return SAFE_DEFAULT;
+
+  return trimmed;
+}
+
 interface RequireWalletProps {
   children: ReactNode;
 }
@@ -37,7 +66,7 @@ export default function RequireWallet({ children }: RequireWalletProps) {
       <Navigate
         to="/connect-wallet"
         replace
-        state={{ returnTo }}
+        state={{ returnTo: sanitizeReturnTo(returnTo) }}
       />
     );
   }

--- a/src/components/__tests__/RequireWallet.test.tsx
+++ b/src/components/__tests__/RequireWallet.test.tsx
@@ -6,7 +6,7 @@ import {
   Routes,
   useLocation,
 } from "react-router-dom";
-import RequireWallet from "../RequireWallet";
+import RequireWallet, { sanitizeReturnTo } from "../RequireWallet";
 
 const walletState = vi.hoisted(() => ({
   connected: false,
@@ -58,8 +58,104 @@ function renderGuard(initialPath = "/app/streams?status=active#row-1") {
   );
 }
 
+describe("sanitizeReturnTo", () => {
+  it("allows valid in-app relative paths", () => {
+    expect(sanitizeReturnTo("/app")).toBe("/app");
+    expect(sanitizeReturnTo("/app/streams")).toBe("/app/streams");
+    expect(sanitizeReturnTo("/app/recipient/new")).toBe("/app/recipient/new");
+  });
+
+  it("allows paths with query strings and hashes", () => {
+    expect(sanitizeReturnTo("/app/streams?status=active")).toBe(
+      "/app/streams?status=active",
+    );
+    expect(sanitizeReturnTo("/app/streams#section-1")).toBe(
+      "/app/streams#section-1",
+    );
+    expect(
+      sanitizeReturnTo("/app/streams?status=active&sort=asc#row-1"),
+    ).toBe("/app/streams?status=active&sort=asc#row-1");
+  });
+
+  it("allows root path", () => {
+    expect(sanitizeReturnTo("/")).toBe("/");
+  });
+
+  it("rejects absolute http URLs", () => {
+    expect(sanitizeReturnTo("http://evil.com/phish")).toBe("/app");
+  });
+
+  it("rejects absolute https URLs", () => {
+    expect(sanitizeReturnTo("https://evil.com/phish")).toBe("/app");
+  });
+
+  it("rejects uppercase scheme URLs", () => {
+    expect(sanitizeReturnTo("HTTP://evil.com")).toBe("/app");
+    expect(sanitizeReturnTo("HTTPS://evil.com")).toBe("/app");
+  });
+
+  it("rejects protocol-relative URLs", () => {
+    expect(sanitizeReturnTo("//evil.com/phish")).toBe("/app");
+    expect(sanitizeReturnTo("//www.example.com")).toBe("/app");
+  });
+
+  it("rejects javascript: URIs", () => {
+    expect(sanitizeReturnTo("javascript:alert(1)")).toBe("/app");
+  });
+
+  it("rejects data: URIs", () => {
+    expect(sanitizeReturnTo("data:text/html,<script>alert(1)</script>")).toBe(
+      "/app",
+    );
+  });
+
+  it("rejects vbscript: URIs", () => {
+    expect(sanitizeReturnTo("vbscript:msgbox(1)")).toBe("/app");
+  });
+
+  it("rejects empty string", () => {
+    expect(sanitizeReturnTo("")).toBe("/app");
+  });
+
+  it("rejects whitespace-only string", () => {
+    expect(sanitizeReturnTo("   ")).toBe("/app");
+  });
+
+  it("rejects null", () => {
+    expect(sanitizeReturnTo(null)).toBe("/app");
+  });
+
+  it("rejects undefined", () => {
+    expect(sanitizeReturnTo(undefined)).toBe("/app");
+  });
+
+  it("rejects number", () => {
+    expect(sanitizeReturnTo(42)).toBe("/app");
+  });
+
+  it("rejects object", () => {
+    expect(sanitizeReturnTo({ path: "/app" })).toBe("/app");
+  });
+
+  it("rejects path traversal with ..", () => {
+    expect(sanitizeReturnTo("/app/../../etc/passwd")).toBe("/app");
+    expect(sanitizeReturnTo("/../secret")).toBe("/app");
+    expect(sanitizeReturnTo("/app/..")).toBe("/app");
+  });
+
+  it("rejects relative paths not starting with /", () => {
+    expect(sanitizeReturnTo("app/streams")).toBe("/app");
+    expect(sanitizeReturnTo("relative/path")).toBe("/app");
+  });
+
+  it("rejects mixed-case scheme bypass attempts", () => {
+    expect(sanitizeReturnTo("JAVASCRIPT:alert(1)")).toBe("/app");
+    expect(sanitizeReturnTo("Data:text/html,<script>")).toBe("/app");
+  });
+});
+
 describe("RequireWallet", () => {
-  it("redirects disconnected users to connect-wallet with returnTo state", () => {
+  it("redirects disconnected users to connect-wallet with sanitized returnTo", () => {
     walletState.connected = false;
     walletState.loading = false;
 
@@ -89,5 +185,16 @@ describe("RequireWallet", () => {
       "Restoring wallet session...",
     );
     expect(screen.queryByText("/connect-wallet")).not.toBeInTheDocument();
+  });
+
+  it("sanitizes returnTo through the component for a valid path", () => {
+    walletState.connected = false;
+    walletState.loading = false;
+
+    renderGuard("/app/tx/123?view=detail#confirm");
+
+    expect(
+      screen.getByText("/connect-wallet returnTo=/app/tx/123?view=detail#confirm"),
+    ).toBeInTheDocument();
   });
 });

--- a/src/pages/ConnectWallet.tsx
+++ b/src/pages/ConnectWallet.tsx
@@ -3,20 +3,16 @@ import { Navigate, useLocation } from "react-router-dom";
 import GlowingDot from "../components/GlowingDot";
 import WalletIcon from "../components/WalletIcon";
 import ConnectWalletModal from "../components/ConnectWalletModal";
+import { sanitizeReturnTo } from "../components/RequireWallet";
 import { useWallet } from "../components/wallet-connect/Walletcontext";
-
-interface ConnectWalletLocationState {
-  returnTo?: string;
-}
 
 export default function ConnectWallet() {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isCtaFocused, setIsCtaFocused] = useState(false);
   const wallet = useWallet();
   const location = useLocation();
-  const state = location.state as ConnectWalletLocationState | null;
-  const returnTo =
-    state?.returnTo?.startsWith("/app") ? state.returnTo : "/app";
+  const state = location.state as { returnTo?: string } | null;
+  const returnTo = sanitizeReturnTo(state?.returnTo);
 
   useEffect(() => {
     if (!wallet.connected) return;


### PR DESCRIPTION
Closes #366

---

Add sanitizeReturnTo utility that rejects absolute URLs, protocol-relative URLs, dangerous schemes, path traversal, and non-strings. Validate at both store (RequireWallet.tsx) and consume (ConnectWallet.tsx) time. Default to /app on invalid input.
Add comprehensive tests covering all hostile input classes.

Closes# 366