### PR TITLE
refactor(onboarding): centralize dismissal localStorage key and helpers

### DIFF
--- a/src/components/TreasuryOnboarding.tsx
+++ b/src/components/TreasuryOnboarding.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from "react";
+import { writeOnboardingDismissed } from "../lib/onboarding";
 import "./TreasuryOnboarding.css";
 
 interface TreasuryOnboardingProps {
@@ -42,13 +43,25 @@ export default function TreasuryOnboarding({
 
   const isLastStep = step === STEPS.length - 1;
 
+  const handleDismiss = () => {
+    writeOnboardingDismissed(true);
+    onDismiss();
+  };
+
+  const handleComplete = () => {
+    writeOnboardingDismissed(true);
+
+    if (!walletConnected) {
+      onConnectWallet();
+      return;
+    }
+
+    onCreateStream();
+  };
+
   const handleNext = () => {
     if (isLastStep) {
-      if (!walletConnected) {
-        onConnectWallet();
-      } else {
-        onCreateStream();
-      }
+      handleComplete();
     } else {
       setStep((s) => s + 1);
     }
@@ -64,7 +77,11 @@ export default function TreasuryOnboarding({
       aria-atomic="true"
     >
       {/* Progress stepper */}
-      <div className="onboarding-stepper" role="list" aria-label="Onboarding steps">
+      <div
+        className="onboarding-stepper"
+        role="list"
+        aria-label="Onboarding steps"
+      >
         {STEPS.map((s, i) => (
           <div
             key={s.id}
@@ -80,16 +97,33 @@ export default function TreasuryOnboarding({
               tabIndex={i < step ? 0 : -1}
             >
               {i < step ? (
-                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={3} aria-hidden="true">
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                <svg
+                  width="12"
+                  height="12"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={3}
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M5 13l4 4L19 7"
+                  />
                 </svg>
               ) : (
                 <span aria-hidden="true">{i + 1}</span>
               )}
             </button>
-            <span className="onboarding-step-label" aria-hidden="true">{s.label}</span>
+            <span className="onboarding-step-label" aria-hidden="true">
+              {s.label}
+            </span>
             {i < STEPS.length - 1 && (
-              <div className={`onboarding-connector ${i < step ? "done" : ""}`} aria-hidden="true" />
+              <div
+                className={`onboarding-connector ${i < step ? "done" : ""}`}
+                aria-hidden="true"
+              />
             )}
           </div>
         ))}
@@ -101,63 +135,119 @@ export default function TreasuryOnboarding({
         {step === 0 && (
           <div className="onboarding-step-content">
             <div className="onboarding-icon-ring" aria-hidden="true">
-              <svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M3 11.5C5 11.5 6 9.5 8 9.5c2 0 3 2 5 2s3-2 5-2 3 2 5 2" />
-                <path strokeLinecap="round" strokeLinejoin="round" d="M3 15.5C5 15.5 6 13.5 8 13.5c2 0 3 2 5 2s3-2 5-2 3 2 5 2" opacity="0.7" />
-                <path strokeLinecap="round" strokeLinejoin="round" d="M3 19.5C5 19.5 6 17.5 8 17.5c2 0 3 2 5 2s3-2 5-2 3 2 5 2" opacity="0.4" />
+              <svg
+                width="36"
+                height="36"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth={1.5}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M3 11.5C5 11.5 6 9.5 8 9.5c2 0 3 2 5 2s3-2 5-2 3 2 5 2"
+                />
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M3 15.5C5 15.5 6 13.5 8 13.5c2 0 3 2 5 2s3-2 5-2 3 2 5 2"
+                  opacity="0.7"
+                />
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M3 19.5C5 19.5 6 17.5 8 17.5c2 0 3 2 5 2s3-2 5-2 3 2 5 2"
+                  opacity="0.4"
+                />
               </svg>
             </div>
 
-            <h2
-              className="onboarding-heading"
-              ref={headingRef}
-              tabIndex={-1}
-            >
+            <h2 className="onboarding-heading" ref={headingRef} tabIndex={-1}>
               Welcome to Fluxora Treasury
             </h2>
             <p className="onboarding-body">
-              Fluxora lets you stream USDC to recipients in real time — second by
-              second — using Soroban smart contracts on Stellar. No batch payroll.
-              No manual transfers. Just continuous, programmable capital flow.
+              Fluxora lets you stream USDC to recipients in real time — second
+              by second — using Soroban smart contracts on Stellar. No batch
+              payroll. No manual transfers. Just continuous, programmable
+              capital flow.
             </p>
 
-            <div className="onboarding-concept-grid" role="list" aria-label="Key concepts">
+            <div
+              className="onboarding-concept-grid"
+              role="list"
+              aria-label="Key concepts"
+            >
               <div className="onboarding-concept-card" role="listitem">
                 <div className="concept-icon" aria-hidden="true">
-                  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
+                  <svg
+                    width="20"
+                    height="20"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
                     <circle cx="12" cy="12" r="10" />
                     <path strokeLinecap="round" d="M12 8v4l3 3" />
                   </svg>
                 </div>
                 <div>
                   <div className="concept-title">Real-time streams</div>
-                  <div className="concept-desc">USDC accrues per second. Recipients withdraw whenever they want.</div>
+                  <div className="concept-desc">
+                    USDC accrues per second. Recipients withdraw whenever they
+                    want.
+                  </div>
                 </div>
               </div>
 
               <div className="onboarding-concept-card" role="listitem">
                 <div className="concept-icon" aria-hidden="true">
-                  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
+                  <svg
+                    width="20"
+                    height="20"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
                     <rect x="3" y="11" width="18" height="11" rx="2" />
                     <path strokeLinecap="round" d="M7 11V7a5 5 0 0110 0v4" />
                   </svg>
                 </div>
                 <div>
                   <div className="concept-title">Smart-contract lock</div>
-                  <div className="concept-desc">Your deposit is held in a Soroban contract — trustless and auditable.</div>
+                  <div className="concept-desc">
+                    Your deposit is held in a Soroban contract — trustless and
+                    auditable.
+                  </div>
                 </div>
               </div>
 
               <div className="onboarding-concept-card" role="listitem">
                 <div className="concept-icon" aria-hidden="true">
-                  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8V7m0 9v1" />
+                  <svg
+                    width="20"
+                    height="20"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8V7m0 9v1"
+                    />
                     <circle cx="12" cy="12" r="10" />
                   </svg>
                 </div>
                 <div>
                   <div className="concept-title">USDC on Stellar</div>
-                  <div className="concept-desc">Low fees, fast finality. Stellar's USDC is the stream currency.</div>
+                  <div className="concept-desc">
+                    Low fees, fast finality. Stellar's USDC is the stream
+                    currency.
+                  </div>
                 </div>
               </div>
             </div>
@@ -168,8 +258,19 @@ export default function TreasuryOnboarding({
         {step === 1 && (
           <div className="onboarding-step-content">
             <div className="onboarding-icon-ring" aria-hidden="true">
-              <svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+              <svg
+                width="36"
+                height="36"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth={1.5}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"
+                />
               </svg>
             </div>
 
@@ -177,35 +278,44 @@ export default function TreasuryOnboarding({
               How a stream works
             </h2>
             <p className="onboarding-body">
-              Creating a stream takes three steps. Once live, it runs autonomously
-              on-chain — you don't need to stay online.
+              Creating a stream takes three steps. Once live, it runs
+              autonomously on-chain — you don't need to stay online.
             </p>
 
-            <ol className="onboarding-steps-list" aria-label="Stream creation steps">
+            <ol
+              className="onboarding-steps-list"
+              aria-label="Stream creation steps"
+            >
               <li className="onboarding-steps-item">
-                <div className="step-num" aria-hidden="true">1</div>
+                <div className="step-num" aria-hidden="true">
+                  1
+                </div>
                 <div className="step-info">
                   <div className="step-title">Set recipient & deposit</div>
                   <div className="step-desc">
-                    Paste a valid Stellar address (starts with <code>G</code>, 56
-                    chars). Choose how much USDC to lock — must cover the full
-                    stream duration at your chosen rate.
+                    Paste a valid Stellar address (starts with <code>G</code>,
+                    56 chars). Choose how much USDC to lock — must cover the
+                    full stream duration at your chosen rate.
                   </div>
                 </div>
               </li>
               <li className="onboarding-steps-item">
-                <div className="step-num" aria-hidden="true">2</div>
+                <div className="step-num" aria-hidden="true">
+                  2
+                </div>
                 <div className="step-info">
                   <div className="step-title">Configure rate & schedule</div>
                   <div className="step-desc">
                     Pick how fast USDC accrues, when to start (now or a future
-                    date), and optionally add a cliff — a period during which the
-                    stream accumulates but withdrawals are blocked.
+                    date), and optionally add a cliff — a period during which
+                    the stream accumulates but withdrawals are blocked.
                   </div>
                 </div>
               </li>
               <li className="onboarding-steps-item">
-                <div className="step-num" aria-hidden="true">3</div>
+                <div className="step-num" aria-hidden="true">
+                  3
+                </div>
                 <div className="step-info">
                   <div className="step-title">Review & sign</div>
                   <div className="step-desc">
@@ -218,7 +328,15 @@ export default function TreasuryOnboarding({
             </ol>
 
             <div className="onboarding-info-box" role="note">
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} aria-hidden="true">
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth={2}
+                aria-hidden="true"
+              >
                 <circle cx="12" cy="12" r="10" />
                 <path strokeLinecap="round" d="M12 16v-4M12 8h.01" />
               </svg>
@@ -234,21 +352,48 @@ export default function TreasuryOnboarding({
         {/* Step 2: Get started */}
         {step === 2 && (
           <div className="onboarding-step-content">
-            <div className={`onboarding-icon-ring ${walletConnected ? "connected" : "disconnected"}`} aria-hidden="true">
+            <div
+              className={`onboarding-icon-ring ${walletConnected ? "connected" : "disconnected"}`}
+              aria-hidden="true"
+            >
               {walletConnected ? (
-                <svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                <svg
+                  width="36"
+                  height="36"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={1.5}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M5 13l4 4L19 7"
+                  />
                 </svg>
               ) : (
-                <svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M21 12V7H5a2 2 0 010-4h14v4M21 12v5H5a2 2 0 000 4h16v-4" />
+                <svg
+                  width="36"
+                  height="36"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={1.5}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M21 12V7H5a2 2 0 010-4h14v4M21 12v5H5a2 2 0 000 4h16v-4"
+                  />
                   <circle cx="18" cy="12" r="1.5" fill="currentColor" />
                 </svg>
               )}
             </div>
 
             <h2 className="onboarding-heading" ref={headingRef} tabIndex={-1}>
-              {walletConnected ? "You're ready to stream" : "Connect your wallet first"}
+              {walletConnected
+                ? "You're ready to stream"
+                : "Connect your wallet first"}
             </h2>
 
             {walletConnected ? (
@@ -257,9 +402,14 @@ export default function TreasuryOnboarding({
                   Your Stellar wallet is connected
                   {walletAddress && (
                     <>
-                      {" "}as{" "}
-                      <span className="wallet-address-pill" aria-label={`Wallet address ${walletAddress}`}>
-                        {walletAddress.slice(0, 6)}&thinsp;…&thinsp;{walletAddress.slice(-6)}
+                      {" "}
+                      as{" "}
+                      <span
+                        className="wallet-address-pill"
+                        aria-label={`Wallet address ${walletAddress}`}
+                      >
+                        {walletAddress.slice(0, 6)}&thinsp;…&thinsp;
+                        {walletAddress.slice(-6)}
                       </span>
                     </>
                   )}
@@ -267,21 +417,53 @@ export default function TreasuryOnboarding({
                   journey.
                 </p>
 
-                <div className="onboarding-checklist" role="list" aria-label="Pre-flight checklist">
+                <div
+                  className="onboarding-checklist"
+                  role="list"
+                  aria-label="Pre-flight checklist"
+                >
                   <div className="checklist-item done" role="listitem">
-                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} aria-hidden="true">
-                      <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                    <svg
+                      width="16"
+                      height="16"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth={2.5}
+                      aria-hidden="true"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="M5 13l4 4L19 7"
+                      />
                     </svg>
                     <span>Wallet connected</span>
                   </div>
                   <div className="checklist-item" role="listitem">
-                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} aria-hidden="true">
+                    <svg
+                      width="16"
+                      height="16"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth={2}
+                      aria-hidden="true"
+                    >
                       <circle cx="12" cy="12" r="10" />
                     </svg>
                     <span>Recipient Stellar address ready</span>
                   </div>
                   <div className="checklist-item" role="listitem">
-                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} aria-hidden="true">
+                    <svg
+                      width="16"
+                      height="16"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth={2}
+                      aria-hidden="true"
+                    >
                       <circle cx="12" cy="12" r="10" />
                     </svg>
                     <span>USDC balance to cover stream duration</span>
@@ -291,35 +473,58 @@ export default function TreasuryOnboarding({
             ) : (
               <>
                 <p className="onboarding-body">
-                  Fluxora requires a Stellar wallet to sign on-chain transactions.
-                  Connect <strong>Freighter</strong> — the recommended browser
-                  extension — to continue.
+                  Fluxora requires a Stellar wallet to sign on-chain
+                  transactions. Connect <strong>Freighter</strong> — the
+                  recommended browser extension — to continue.
                 </p>
 
-                <div className="onboarding-wallet-options" role="list" aria-label="Supported wallets">
+                <div
+                  className="onboarding-wallet-options"
+                  role="list"
+                  aria-label="Supported wallets"
+                >
                   <div className="wallet-option featured" role="listitem">
                     <div className="wallet-option-icon" aria-hidden="true">
-                      <svg width="24" height="24" viewBox="0 0 32 32" fill="none">
+                      <svg
+                        width="24"
+                        height="24"
+                        viewBox="0 0 32 32"
+                        fill="none"
+                      >
                         <rect width="32" height="32" rx="8" fill="#7B2FF7" />
-                        <path d="M8 22l8-14 8 14H8z" fill="white" opacity="0.9" />
+                        <path
+                          d="M8 22l8-14 8 14H8z"
+                          fill="white"
+                          opacity="0.9"
+                        />
                       </svg>
                     </div>
                     <div className="wallet-option-info">
                       <div className="wallet-option-name">Freighter</div>
-                      <div className="wallet-option-desc">Recommended · Stellar browser extension</div>
+                      <div className="wallet-option-desc">
+                        Recommended · Stellar browser extension
+                      </div>
                     </div>
                     <span className="wallet-badge">Recommended</span>
                   </div>
                 </div>
 
                 <div className="onboarding-info-box" role="note">
-                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} aria-hidden="true">
+                  <svg
+                    width="16"
+                    height="16"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                    aria-hidden="true"
+                  >
                     <circle cx="12" cy="12" r="10" />
                     <path strokeLinecap="round" d="M12 16v-4M12 8h.01" />
                   </svg>
                   <p>
-                    Fluxora connects to Stellar Testnet by default. No real funds
-                    are used during exploration.
+                    Fluxora connects to Stellar Testnet by default. No real
+                    funds are used during exploration.
                   </p>
                 </div>
               </>
@@ -332,7 +537,7 @@ export default function TreasuryOnboarding({
           <button
             type="button"
             className="onboarding-btn-ghost"
-            onClick={onDismiss}
+            onClick={handleDismiss}
             aria-label="Skip onboarding"
           >
             Skip

--- a/src/lib/__tests__/onboarding.test.ts
+++ b/src/lib/__tests__/onboarding.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  ONBOARDING_DISMISSED_STORAGE_KEY,
+  readOnboardingDismissed,
+  writeOnboardingDismissed,
+} from "../onboarding";
+
+describe("onboarding storage helpers", () => {
+  it("uses browser localStorage by default", () => {
+    localStorage.clear();
+
+    writeOnboardingDismissed(true);
+
+    expect(readOnboardingDismissed()).toBe(true);
+    expect(localStorage.getItem(ONBOARDING_DISMISSED_STORAGE_KEY)).toBe("true");
+  });
+
+  it("returns false when the dismissal key is absent", () => {
+    const storage = {
+      getItem: vi.fn(() => null),
+    };
+
+    expect(readOnboardingDismissed(storage)).toBe(false);
+    expect(storage.getItem).toHaveBeenCalledWith(
+      ONBOARDING_DISMISSED_STORAGE_KEY,
+    );
+  });
+
+  it("returns true when the dismissal key is present", () => {
+    const storage = {
+      getItem: vi.fn(() => "true"),
+    };
+
+    expect(readOnboardingDismissed(storage)).toBe(true);
+  });
+
+  it("returns false when storage access throws", () => {
+    const storage = {
+      getItem: vi.fn(() => {
+        throw new DOMException("Blocked", "SecurityError");
+      }),
+    };
+
+    expect(readOnboardingDismissed(storage)).toBe(false);
+  });
+
+  it("returns false and skips writes when storage is unavailable", () => {
+    const originalWindow = globalThis.window;
+
+    try {
+      Object.defineProperty(globalThis, "window", {
+        value: undefined,
+        configurable: true,
+      });
+
+      expect(readOnboardingDismissed()).toBe(false);
+      expect(() => writeOnboardingDismissed(true)).not.toThrow();
+    } finally {
+      Object.defineProperty(globalThis, "window", {
+        value: originalWindow,
+        configurable: true,
+      });
+    }
+  });
+
+  it("writes the shared dismissal key when onboarding is dismissed", () => {
+    const storage = {
+      removeItem: vi.fn(),
+      setItem: vi.fn(),
+    };
+
+    writeOnboardingDismissed(true, storage);
+
+    expect(storage.setItem).toHaveBeenCalledWith(
+      ONBOARDING_DISMISSED_STORAGE_KEY,
+      "true",
+    );
+    expect(storage.removeItem).not.toHaveBeenCalled();
+  });
+
+  it("removes the shared dismissal key when onboarding is reset", () => {
+    const storage = {
+      removeItem: vi.fn(),
+      setItem: vi.fn(),
+    };
+
+    writeOnboardingDismissed(false, storage);
+
+    expect(storage.removeItem).toHaveBeenCalledWith(
+      ONBOARDING_DISMISSED_STORAGE_KEY,
+    );
+    expect(storage.setItem).not.toHaveBeenCalled();
+  });
+
+  it("swallows storage write errors", () => {
+    const storage = {
+      removeItem: vi.fn(),
+      setItem: vi.fn(() => {
+        throw new DOMException("Blocked", "QuotaExceededError");
+      }),
+    };
+
+    expect(() => writeOnboardingDismissed(true, storage)).not.toThrow();
+  });
+});

--- a/src/lib/onboarding.ts
+++ b/src/lib/onboarding.ts
@@ -1,0 +1,66 @@
+export const ONBOARDING_DISMISSED_STORAGE_KEY = "fluxora_onboarding_dismissed";
+
+const ONBOARDING_DISMISSED_VALUE = "true";
+
+type OnboardingStorageReader = Pick<Storage, "getItem">;
+type OnboardingStorageWriter = Pick<Storage, "removeItem" | "setItem">;
+
+function getLocalStorage(): Storage | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  return window.localStorage;
+}
+
+/**
+ * Reads the persisted treasury onboarding dismissal state.
+ *
+ * Returns `false` when storage is unavailable or throws so onboarding checks
+ * never crash the UI in restricted browser environments.
+ */
+export function readOnboardingDismissed(
+  storage: OnboardingStorageReader | null = getLocalStorage(),
+): boolean {
+  if (!storage) {
+    return false;
+  }
+
+  try {
+    return (
+      storage.getItem(ONBOARDING_DISMISSED_STORAGE_KEY) ===
+      ONBOARDING_DISMISSED_VALUE
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Persists the treasury onboarding dismissal state.
+ *
+ * Storage writes are guarded so quota or browser security errors do not break
+ * onboarding dismissal flows.
+ */
+export function writeOnboardingDismissed(
+  dismissed: boolean,
+  storage: OnboardingStorageWriter | null = getLocalStorage(),
+): void {
+  if (!storage) {
+    return;
+  }
+
+  try {
+    if (dismissed) {
+      storage.setItem(
+        ONBOARDING_DISMISSED_STORAGE_KEY,
+        ONBOARDING_DISMISSED_VALUE,
+      );
+      return;
+    }
+
+    storage.removeItem(ONBOARDING_DISMISSED_STORAGE_KEY);
+  } catch {
+    // Storage unavailable; treat dismissal persistence as best effort.
+  }
+}

--- a/src/pages/Dashboard.test.tsx
+++ b/src/pages/Dashboard.test.tsx
@@ -1,5 +1,6 @@
 import { act, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ONBOARDING_DISMISSED_STORAGE_KEY } from "../lib/onboarding";
 import Dashboard from "./Dashboard";
 
 const walletState = vi.hoisted(() => ({
@@ -34,7 +35,7 @@ describe("Dashboard wallet source", () => {
     walletState.connected = false;
     walletState.address = null;
     walletState.network = null;
-    localStorage.setItem("fluxora_onboarding_dismissed", "true");
+    localStorage.setItem(ONBOARDING_DISMISSED_STORAGE_KEY, "true");
   });
 
   afterEach(() => {

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -10,25 +10,8 @@ import ToastNotification, {
 } from "../components/ToastNotification";
 import { useLiveAnnouncer } from "../hooks/useLiveAnnouncer";
 import { useWallet } from "../components/wallet-connect/Walletcontext";
+import { readOnboardingDismissed } from "../lib/onboarding";
 import "../design-tokens.css";
-
-const ONBOARDING_KEY = "fluxora_onboarding_dismissed";
-
-function hasSeenOnboarding(): boolean {
-  try {
-    return localStorage.getItem(ONBOARDING_KEY) === "true";
-  } catch {
-    return false;
-  }
-}
-
-function markOnboardingSeen(): void {
-  try {
-    localStorage.setItem(ONBOARDING_KEY, "true");
-  } catch {
-    // Storage unavailable; treat as transient.
-  }
-}
 
 export default function Dashboard() {
   const [loading, setLoading] = useState(true);
@@ -63,7 +46,7 @@ export default function Dashboard() {
   }, [toast]);
 
   useEffect(() => {
-    if (!loading && streams.length === 0 && !hasSeenOnboarding()) {
+    if (!loading && streams.length === 0 && !readOnboardingDismissed()) {
       setShowOnboarding(true);
     }
 
@@ -89,12 +72,10 @@ export default function Dashboard() {
   }, [withdrawable, announce]);
 
   const handleDismissOnboarding = () => {
-    markOnboardingSeen();
     setShowOnboarding(false);
   };
 
   const handleOnboardingCreateStream = () => {
-    markOnboardingSeen();
     setShowOnboarding(false);
     setIsModalOpen(true);
   };

--- a/src/pages/__tests__/Dashboard.test.tsx
+++ b/src/pages/__tests__/Dashboard.test.tsx
@@ -1,6 +1,7 @@
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import { axe } from "vitest-axe";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ONBOARDING_DISMISSED_STORAGE_KEY } from "../../lib/onboarding";
 import Dashboard from "../Dashboard";
 
 vi.mock("@stellar/freighter-api", () => ({
@@ -59,5 +60,20 @@ describe("Dashboard page accessibility and announcements", () => {
     expect(
       screen.getByRole("dialog", { name: /choose your wallet/i }),
     ).toBeInTheDocument();
+  });
+
+  it("uses the shared onboarding dismissal key across onboarding and dashboard rendering", async () => {
+    const firstRender = await renderLoadedDashboard();
+
+    fireEvent.click(screen.getByRole("button", { name: /skip onboarding/i }));
+    expect(localStorage.getItem(ONBOARDING_DISMISSED_STORAGE_KEY)).toBe("true");
+
+    firstRender.unmount();
+
+    await renderLoadedDashboard();
+
+    expect(
+      screen.queryByRole("region", { name: /treasury onboarding/i }),
+    ).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Closes #443

## Summary
- centralize `fluxora_onboarding_dismissed` in a shared onboarding storage module
- add typed guarded read/write helpers with inline TSDoc
- update `Dashboard` to read dismissal state from the shared helper
- update `TreasuryOnboarding` to persist dismissal through the shared helper
- add helper tests and a dashboard integration test proving both components use the same key

## Why
The dismissal key was duplicated as a magic string, which risked silent divergence between the dashboard and onboarding flow. This change creates a single source of truth and keeps localStorage access guarded against browser security or quota failures.

## Security Notes
- all localStorage reads remain wrapped so blocked or unavailable storage returns a safe fallback
- all localStorage writes remain best-effort and swallow quota/security exceptions so onboarding interactions do not crash the UI

## Validation
- `npm run test` ✅ (`59` files, `407` tests)
- focused onboarding tests ✅ (`13` tests)
- focused coverage for `src/lib/onboarding.ts` ✅ (`100%` statements, branches, functions, lines)

## Notes
- `npm run lint` still reports unrelated pre-existing repository issues outside the scope of this change