### PR TITLE
fix(recipient): use selected stream for withdrawals

### DIFF
--- a/src/pages/Recipient.test.tsx
+++ b/src/pages/Recipient.test.tsx
@@ -1,12 +1,28 @@
-import { act, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import Recipient from "./Recipient";
+import Recipient, {
+  getWithdrawAmount,
+  isValidWithdrawStreamId,
+  selectWithdrawStream,
+} from "./Recipient";
 
 const walletState = vi.hoisted(() => ({
   connected: false,
   address: null as string | null,
   network: null as string | null,
 }));
+
+const recipientStreamsState = vi.hoisted(() => ({
+  streams: [] as Array<{
+    id: string;
+    status: "Active" | "Paused" | "Completed";
+    withdrawableAmount: number;
+    streamedAmount: number;
+    isPinned?: boolean;
+  }>,
+}));
+
+const withdrawMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../components/wallet-connect/Walletcontext", () => ({
   useWallet: () => ({
@@ -30,11 +46,15 @@ vi.mock("../components/treasuryOverviewPage/useTreasury", () => ({
     refetch: vi.fn(),
   }),
   useRecipientStreams: () => ({
-    streams: [],
+    streams: recipientStreamsState.streams,
     loading: false,
     error: null,
     refetch: vi.fn(),
   }),
+}));
+
+vi.mock("../lib/stellar/tx", () => ({
+  withdraw: withdrawMock,
 }));
 
 function renderRecipient() {
@@ -50,6 +70,9 @@ describe("Recipient wallet source", () => {
     walletState.connected = false;
     walletState.address = null;
     walletState.network = null;
+    recipientStreamsState.streams = [];
+    withdrawMock.mockReset();
+    withdrawMock.mockResolvedValue({});
   });
 
   afterEach(() => {
@@ -67,6 +90,7 @@ describe("Recipient wallet source", () => {
 
   it("enables the withdraw surface when useWallet reports a connected wallet", () => {
     walletState.connected = true;
+    walletState.address = "GATDOSCZNJ5YZHNOX7IOD4QDCQSTMR2YNF5IXHFNX3H6B4ICCMSDLOWN";
     // Match the expected network so the on-chain mismatch guard does not
     // disable the withdraw action.
     walletState.network = "TESTNET";
@@ -77,5 +101,50 @@ describe("Recipient wallet source", () => {
       screen.getByRole("button", { name: /Withdraw 22,600 USDC/i }),
     ).toBeEnabled();
     expect(screen.getByText("Withdrawable now")).toBeInTheDocument();
+  });
+
+  it("withdraws using the selected live recipient stream id", async () => {
+    walletState.connected = true;
+    walletState.address = "GATDOSCZNJ5YZHNOX7IOD4QDCQSTMR2YNF5IXHFNX3H6B4ICCMSDLOWN";
+    walletState.network = "TESTNET";
+    recipientStreamsState.streams = [
+      {
+        id: "2",
+        status: "Active",
+        withdrawableAmount: 4200,
+        streamedAmount: 5000,
+      },
+    ];
+
+    renderRecipient();
+
+    fireEvent.click(screen.getByRole("button", { name: /Withdraw 4,200 USDC/i }));
+
+    await act(async () => {});
+
+    expect(withdrawMock).toHaveBeenCalledWith(
+      walletState.address,
+      "2",
+      "42000000000",
+    );
+  });
+
+  it("selects only active withdrawable streams with valid contract ids", () => {
+    expect(
+      selectWithdrawStream([
+        { id: "STR-1", status: "Active", withdrawableAmount: 100 },
+        { id: "7", status: "Paused", withdrawableAmount: 100 },
+        { id: "8", status: "Active", withdrawableAmount: 0 },
+        { id: "9", status: "Active", withdrawableAmount: 100 },
+      ])?.id,
+    ).toBe("9");
+    expect(selectWithdrawStream([])).toBeNull();
+    expect(isValidWithdrawStreamId("0")).toBe(false);
+  });
+
+  it("validates withdraw amounts before contract calls", () => {
+    expect(getWithdrawAmount(22_600)).toBe("226000000000");
+    expect(getWithdrawAmount(0)).toBeNull();
+    expect(getWithdrawAmount(Number.NaN)).toBeNull();
   });
 });

--- a/src/pages/Recipient.tsx
+++ b/src/pages/Recipient.tsx
@@ -6,6 +6,7 @@ import ZeroAccrualBanner from "../components/ZeroAccrualBanner";
 import { useWallet } from "../components/wallet-connect/Walletcontext";
 import { useToast } from "../components/toast/ToastProvider";
 import { useRecipientStreams } from "../components/treasuryOverviewPage/useTreasury";
+import type { StreamRecord } from "../data/streamRecords";
 import { withdraw } from "../lib/stellar/tx";
 import "./Streams.css";
 import "./Recipient.css";
@@ -16,6 +17,58 @@ const DEMO_BALANCE = 22600.0;
 const DEMO_ACTIVE = 2;
 const DEMO_TOTAL_ACCRUED = 43250.0;
 const DEMO_TOTAL_WITHDRAWN = 20650.0;
+const USDC_SCALE = 10_000_000;
+const MAX_U64 = 18_446_744_073_709_551_615n;
+
+type WithdrawStreamCandidate = Pick<
+  StreamRecord,
+  "id" | "status" | "withdrawableAmount"
+> & {
+  isPinned?: boolean;
+};
+
+/** Returns true when a stream id can be encoded as a positive Soroban u64. */
+export function isValidWithdrawStreamId(
+  streamId: string | null | undefined,
+): streamId is string {
+  if (!streamId) return false;
+
+  const normalized = streamId.trim();
+  if (!/^\d+$/.test(normalized)) return false;
+
+  const value = BigInt(normalized);
+  return value > 0n && value <= MAX_U64;
+}
+
+/**
+ * Selects the recipient stream that should back the next withdrawal.
+ * Live recipient data takes precedence; the demo fallback is only used when
+ * no backend stream is available yet.
+ */
+export function selectWithdrawStream(
+  streams: WithdrawStreamCandidate[],
+): WithdrawStreamCandidate | null {
+  const activeWithdrawableStreams = streams.filter(
+    (stream) =>
+      stream.status === "Active" &&
+      stream.withdrawableAmount > 0 &&
+      isValidWithdrawStreamId(stream.id),
+  );
+
+  return (
+    activeWithdrawableStreams.find((stream) => stream.isPinned) ??
+    activeWithdrawableStreams[0] ??
+    null
+  );
+}
+
+/** Converts the displayed USDC balance to the 7-decimal on-chain amount. */
+export function getWithdrawAmount(balance: number): string | null {
+  if (!Number.isFinite(balance) || balance <= 0) return null;
+
+  const scaledAmount = Math.floor(balance * USDC_SCALE);
+  return scaledAmount > 0 ? scaledAmount.toString() : null;
+}
 
 export default function Recipient() {
   const wallet = useWallet();
@@ -62,6 +115,15 @@ export default function Recipient() {
   const liveStreams = recipientStreams.streams;
   const hasLiveStreams = liveStreams.length > 0;
 
+  const demoWithdrawStream: WithdrawStreamCandidate = {
+    id: "1",
+    status: "Active",
+    withdrawableAmount: DEMO_BALANCE,
+  };
+  const selectedWithdrawStream = selectWithdrawStream(
+    hasLiveStreams ? liveStreams : [demoWithdrawStream],
+  );
+
   const balance = hasLiveStreams
     ? liveStreams.reduce((sum, stream) => sum + stream.withdrawableAmount, 0)
     : DEMO_BALANCE;
@@ -87,7 +149,13 @@ export default function Recipient() {
   const isZeroAccrual = walletConnected && hasStreams && balance === 0;
   
   const isPending = txState === "signing" || txState === "submitting";
-  const disabled = !walletConnected || balance === 0 || networkMismatch || isPending;
+  const disabled =
+    !walletConnected ||
+    !wallet.address ||
+    balance === 0 ||
+    networkMismatch ||
+    isPending ||
+    !selectedWithdrawStream;
 
   const handleWithdraw = async () => {
     if (disabled) return;
@@ -95,8 +163,18 @@ export default function Recipient() {
     setErrorMsg(null);
 
     const recipientAddr = wallet.address!;
-    const amountStr = Math.floor(balance * 10_000_000).toString(); // Scale to 7 decimals
-    const streamId = "1"; // Default stream ID
+    const amountStr = getWithdrawAmount(balance);
+    const streamId = selectedWithdrawStream?.id;
+
+    if (!isValidWithdrawStreamId(streamId) || !amountStr) {
+      const message = !streamId
+        ? "No valid stream is available for withdrawal."
+        : "Withdrawal amount must be greater than zero.";
+      setTxState("error");
+      setErrorMsg(message);
+      addToast(message, "error");
+      return;
+    }
 
     try {
       setTxState("submitting");


### PR DESCRIPTION
Closes #451

## Summary
- Select the withdrawal stream from recipient stream data instead of hardcoding stream id `1`.
- Validate the stream id and USDC amount before calling the contract withdraw helper.
- Keep the existing demo fallback documented for addresses with no backend stream data yet.

## Test plan
- `node node_modules/vitest/vitest.mjs run src/pages/Recipient.test.tsx`
- Result: 1 file passed, 5 tests passed.
