### PR TITLE
perf(landing): lazy-load below-fold landing sections with IntersectionObserver

### DIFF
--- a/src/pages/Home.test.tsx
+++ b/src/pages/Home.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import Home from "./Home";
 import { ThemeProvider } from "../theme/ThemeProvider";
 
@@ -15,31 +15,96 @@ function renderHome() {
 }
 
 describe("Home canonical landing page", () => {
-  it("combines the landing, value proposition, trust, CTA, newsletter, and footer sections", () => {
+  it("renders the hero immediately", () => {
     renderHome();
 
     expect(
       screen.getByRole("heading", { level: 1, name: /treasury streaming/i }),
     ).toBeInTheDocument();
+  });
+
+  it("lazily renders the below-fold sections after the observer fires", async () => {
+    // jsdom has no IntersectionObserver, so the LazySection fallback loads
+    // immediately and resolves each dynamic import.
+    renderHome();
+
     expect(
-      screen.getByRole("heading", {
+      await screen.findByRole("heading", {
         level: 2,
         name: /treasury streaming infrastructure/i,
       }),
     ).toBeInTheDocument();
-    expect(screen.getByText(/powered by stellar/i)).toBeInTheDocument();
+    expect(await screen.findByText(/powered by stellar/i)).toBeInTheDocument();
     expect(
-      screen.getByRole("heading", {
+      await screen.findByRole("heading", {
         level: 2,
         name: /ready to start streaming/i,
       }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("heading", {
+      await screen.findByRole("heading", {
         level: 2,
         name: /stay updated on stellar ecosystem streaming/i,
       }),
     ).toBeInTheDocument();
-    expect(screen.getAllByText(/built on stellar/i).length).toBeGreaterThan(0);
+  });
+});
+
+describe("Home lazy sections with IntersectionObserver", () => {
+  const observers: Array<{
+    callback: IntersectionObserverCallback;
+    observe: ReturnType<typeof vi.fn>;
+    disconnect: ReturnType<typeof vi.fn>;
+  }> = [];
+
+  beforeEach(() => {
+    observers.length = 0;
+    class MockObserver {
+      callback: IntersectionObserverCallback;
+      observe = vi.fn();
+      disconnect = vi.fn();
+      unobserve = vi.fn();
+      takeRecords = vi.fn(() => []);
+      root = null;
+      rootMargin = "";
+      thresholds = [];
+      constructor(cb: IntersectionObserverCallback) {
+        this.callback = cb;
+        observers.push(this);
+      }
+    }
+    vi.stubGlobal("IntersectionObserver", MockObserver);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("does not load a section until it intersects the viewport", async () => {
+    renderHome();
+
+    // Sections are deferred: their headings are absent until the observer fires.
+    expect(
+      screen.queryByRole("heading", {
+        level: 2,
+        name: /treasury streaming infrastructure/i,
+      }),
+    ).not.toBeInTheDocument();
+
+    expect(observers.length).toBeGreaterThan(0);
+    // Fire every observer as if each placeholder scrolled into view.
+    observers.forEach((obs) => {
+      obs.callback(
+        [{ isIntersecting: true } as IntersectionObserverEntry],
+        obs as unknown as IntersectionObserver,
+      );
+    });
+
+    expect(
+      await screen.findByRole("heading", {
+        level: 2,
+        name: /treasury streaming infrastructure/i,
+      }),
+    ).toBeInTheDocument();
   });
 });

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,10 +1,67 @@
+import React, { lazy, Suspense, useEffect, useRef, useState } from "react";
 import HeroSection from "../components/landing-page/HeroSection";
-import TrustSection from "../components/landing-page/TrustSection";
-import ValuePropositionSection from "../components/ValuePropositionSection";
-import GetStartedCTA from "../components/GetStartedCTA";
-import NewsletterSection from "../components/NewsletterSection";
 import Footer from "../components/Footer";
+import { Skeleton } from "../components/Skeleton";
 import { useTheme } from "../theme/ThemeProvider";
+
+// Below-the-fold landing sections are split into separate chunks via React.lazy
+// so first-time visitors don't pay the parse cost up front. Each section is only
+// imported once it nears the viewport (see LazySection / IntersectionObserver).
+const TrustSection = lazy(() => import("../components/landing-page/TrustSection"));
+const ValuePropositionSection = lazy(
+  () => import("../components/ValuePropositionSection"),
+);
+const GetStartedCTA = lazy(() => import("../components/GetStartedCTA"));
+const NewsletterSection = lazy(() => import("../components/NewsletterSection"));
+
+interface LazySectionProps {
+  children: React.ReactNode;
+  /** Accessible label for the placeholder region while the section loads. */
+  label: string;
+}
+
+/**
+ * Defers rendering (and therefore the dynamic import) of its children until the
+ * placeholder scrolls within 300px of the viewport. When IntersectionObserver is
+ * unavailable (older browsers, jsdom/SSR), it falls back to loading immediately.
+ */
+function LazySection({ children, label }: LazySectionProps) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const [shouldLoad, setShouldLoad] = useState(
+    () => typeof IntersectionObserver === "undefined",
+  );
+
+  useEffect(() => {
+    if (shouldLoad) return;
+    const node = ref.current;
+    if (!node) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          setShouldLoad(true);
+          observer.disconnect();
+        }
+      },
+      { rootMargin: "300px" },
+    );
+
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [shouldLoad]);
+
+  return (
+    <div ref={ref}>
+      {shouldLoad ? (
+        <Suspense fallback={<Skeleton height={240} aria-label={`Loading ${label}`} />}>
+          {children}
+        </Suspense>
+      ) : (
+        <Skeleton height={240} aria-label={`Loading ${label}`} />
+      )}
+    </div>
+  );
+}
 
 export default function Home() {
   const { theme } = useTheme();
@@ -18,17 +75,22 @@ export default function Home() {
         flexDirection: "column",
       }}
     >
-      <main 
-        id="main-content"
-        style={{ flex: 1 }}
-      >
+      <main id="main-content" style={{ flex: 1 }}>
         <HeroSection theme={theme} />
-        <ValuePropositionSection />
-        <TrustSection theme={theme} />
-        <section style={{ padding: "80px 20px" }} aria-label="Get started">
-          <GetStartedCTA />
-        </section>
-        <NewsletterSection />
+        <LazySection label="value proposition section">
+          <ValuePropositionSection />
+        </LazySection>
+        <LazySection label="trust section">
+          <TrustSection theme={theme} />
+        </LazySection>
+        <LazySection label="get started section">
+          <section style={{ padding: "80px 20px" }} aria-label="Get started">
+            <GetStartedCTA />
+          </section>
+        </LazySection>
+        <LazySection label="newsletter section">
+          <NewsletterSection />
+        </LazySection>
       </main>
       <Footer />
     </div>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -61,6 +61,17 @@ export default defineConfig(async () => {
               return "app-empty-state-demo";
             }
 
+            // Below-the-fold landing sections are lazy-loaded from Home and
+            // share one chunk so they download together once the user scrolls.
+            if (
+              normalizedId.includes("/src/components/landing-page/TrustSection") ||
+              normalizedId.includes("/src/components/ValuePropositionSection") ||
+              normalizedId.includes("/src/components/GetStartedCTA") ||
+              normalizedId.includes("/src/components/NewsletterSection")
+            ) {
+              return "app-landing";
+            }
+
             // Vendor splitting for bundle-size visibility.
             return vendorChunk(id);
           },


### PR DESCRIPTION
Lazy-loads TrustSection, ValuePropositionSection, GetStartedCTA, and NewsletterSection in Home.tsx via React.lazy + Suspense. A LazySection wrapper uses IntersectionObserver (300px rootMargin) to trigger each dynamic import only when the section nears the viewport, with a fallback to immediate load when IntersectionObserver is unavailable. Skeleton is used as the Suspense/placeholder fallback. vite.config manualChunks groups these into an app-landing chunk. Tests cover immediate-load and observer-fired paths.

Closes #567