### PR TITLE
feat(hooks): add useClipboard hook with failure feedback and execCommand fallback

### DIFF
--- a/src/components/__tests__/TruncatedAddress.test.tsx
+++ b/src/components/__tests__/TruncatedAddress.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import TruncatedAddress from "../common/TruncatedAddress";
+import { useOptionalToast } from "../toast/ToastProvider";
 
 const ADDRESS = "GABCDEFGHIJKLMNOPQRSTUVWXYZ2345678901234567890123456789";
 
@@ -76,6 +77,26 @@ describe("TruncatedAddress", () => {
     await waitFor(() => expect(onCopyStateChange).toHaveBeenCalledWith("error"));
     expect(onCopy).not.toHaveBeenCalled();
     expect(screen.getByText("Address could not be copied")).toBeInTheDocument();
+  });
+
+  it("fires an error toast when copying fails", async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error("denied"));
+    setClipboard(writeText);
+    const addToast = (
+      useOptionalToast() as unknown as { addToast: ReturnType<typeof vi.fn> }
+    ).addToast;
+    addToast.mockClear();
+
+    render(<TruncatedAddress address={ADDRESS} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /copy address/i }));
+
+    await waitFor(() =>
+      expect(addToast).toHaveBeenCalledWith(
+        expect.stringMatching(/failed to copy/i),
+        "error",
+      ),
+    );
   });
 
   it("announces an error when the fallback copy command fails", async () => {

--- a/src/components/common/TruncatedAddress.tsx
+++ b/src/components/common/TruncatedAddress.tsx
@@ -1,5 +1,7 @@
-import React, { useState } from "react";
+import React, { useEffect } from "react";
 import { AlertCircle, Check, Copy } from "lucide-react";
+import { useClipboard } from "../../hooks/useClipboard";
+import { useOptionalToast } from "../toast/ToastProvider";
 
 type CopyState = "idle" | "copied" | "error";
 
@@ -11,15 +13,20 @@ interface TruncatedAddressProps {
   onCopyStateChange?: (state: CopyState) => void;
 }
 
+/** Map the shared hook status to this component's public CopyState. */
+function toCopyState(status: "idle" | "copied" | "failed"): CopyState {
+  return status === "failed" ? "error" : status;
+}
+
 /**
  * TruncatedAddress component provides a consistent way to display Stellar addresses
  * with truncation (ABCD...WXYZ), optional labeling, and copy-to-clipboard functionality.
  * It uses standard design tokens for typography and colors.
  *
- * Copy behavior first uses the async Clipboard API. If the API is unavailable
- * or denied, the component falls back to a temporary textarea copy path and
- * exposes the result as `idle`, `copied`, or `error` through visible state,
- * an ARIA live status, and `onCopyStateChange`.
+ * Copy behavior is delegated to the shared `useClipboard` hook, which uses the
+ * async Clipboard API with an `execCommand` fallback for insecure contexts.
+ * Failures surface as a visible icon/state, an ARIA live status, an error toast
+ * (when a ToastProvider is mounted), and `onCopyStateChange`.
  */
 export default function TruncatedAddress({
   address,
@@ -28,7 +35,9 @@ export default function TruncatedAddress({
   onCopy,
   onCopyStateChange,
 }: TruncatedAddressProps) {
-  const [copyState, setCopyState] = useState<CopyState>("idle");
+  const { copy, status } = useClipboard();
+  const toast = useOptionalToast();
+  const copyState = toCopyState(status);
 
   // Stellar address truncation: first 6 characters + "..." + last 4 characters
   const truncated =
@@ -36,51 +45,18 @@ export default function TruncatedAddress({
       ? `${address.slice(0, 6)}...${address.slice(-4)}`
       : address;
 
-  const setCopyResult = (state: CopyState) => {
-    setCopyState(state);
-    onCopyStateChange?.(state);
-  };
-
-  const fallbackCopy = () => {
-    const textarea = document.createElement("textarea");
-    textarea.value = address;
-    textarea.setAttribute("readonly", "");
-    textarea.style.position = "fixed";
-    textarea.style.left = "-9999px";
-    textarea.style.opacity = "0";
-    document.body.appendChild(textarea);
-    textarea.select();
-
-    try {
-      return document.execCommand("copy");
-    } finally {
-      document.body.removeChild(textarea);
-    }
-  };
-
-  const copyAddress = async () => {
-    if (navigator.clipboard?.writeText) {
-      await navigator.clipboard.writeText(address);
-      return true;
-    }
-
-    return fallbackCopy();
-  };
+  // Notify consumers whenever the copy state changes.
+  useEffect(() => {
+    onCopyStateChange?.(copyState);
+  }, [copyState, onCopyStateChange]);
 
   const handleCopy = async (e: React.MouseEvent | React.KeyboardEvent) => {
     e.stopPropagation();
-    try {
-      const didCopy = await copyAddress();
-      if (!didCopy) {
-        throw new Error("Fallback copy command failed");
-      }
-
-      setCopyResult("copied");
+    const didCopy = await copy(address);
+    if (didCopy) {
       onCopy?.(address);
-      setTimeout(() => setCopyResult("idle"), 2000);
-    } catch {
-      setCopyResult("error");
-      setTimeout(() => setCopyResult("idle"), 3000);
+    } else {
+      toast?.addToast("Failed to copy address. Please copy manually.", "error");
     }
   };
 
@@ -97,7 +73,7 @@ export default function TruncatedAddress({
       title={address}
     >
       {label && (
-        <span 
+        <span
           className="text-label-sm whitespace-nowrap"
           style={{ color: "var(--color-text-muted)" }}
         >
@@ -117,9 +93,9 @@ export default function TruncatedAddress({
         }}
         aria-label={`${copyState === "copied" ? "Copied" : "Copy"} ${label || "address"}: ${address}`}
       >
-        <code 
+        <code
           className="text-mono-sm truncate"
-          style={{ 
+          style={{
             background: "var(--surface-raised)",
             padding: "2px 8px",
             borderRadius: "var(--radius-sm)",

--- a/src/components/navigation/WalletStatus.tsx
+++ b/src/components/navigation/WalletStatus.tsx
@@ -5,6 +5,8 @@ import {
   normalizeStellarNetwork,
 } from "../../lib/stellarNetwork";
 import { maskAddress, stellarExplorerUrl } from "../../lib/stellar";
+import { useClipboard } from "../../hooks/useClipboard";
+import { useOptionalToast } from "../toast/ToastProvider";
 
 interface WalletStatusProps {
   address: string;
@@ -23,9 +25,11 @@ export default function WalletStatus({
   onDisconnect,
 }: WalletStatusProps) {
   const [open, setOpen] = useState(false);
-  const [copied, setCopied] = useState(false);
   const [confirmingDisconnect, setConfirmingDisconnect] = useState(false);
   const [announcement, setAnnouncement] = useState("");
+  const { copy, status: copyStatus } = useClipboard();
+  const toast = useOptionalToast();
+  const copied = copyStatus === "copied";
   const ref = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const focusRingClassName =
@@ -68,52 +72,17 @@ export default function WalletStatus({
   }, [address]);
 
  const handleCopy = async () => {
-  let success = false;
-
-  try {
-    // Try the modern Clipboard API first
-    if (navigator.clipboard?.writeText) {
-      await navigator.clipboard.writeText(address);
-      success = true;
-    } else {
-      // Fallback for older browsers or insecure contexts
-      const textarea = document.createElement("textarea");
-      textarea.value = address;
-      textarea.setAttribute("readonly", "");
-      textarea.style.position = "fixed";
-      textarea.style.left = "-9999px";
-      textarea.style.opacity = "0";
-      document.body.appendChild(textarea);
-      textarea.select();
-
-      try {
-        success = document.execCommand("copy");
-      } finally {
-        document.body.removeChild(textarea);
-      }
-    }
-  } catch {
-    success = false;
-  }
+  // Copy via the shared hook (Clipboard API + execCommand fallback).
+  const success = await copy(address);
 
   if (success) {
-    setCopied(true);
     setAnnouncement("Address copied to clipboard");
-    setTimeout(() => {
-      setCopied(false);
-      setAnnouncement("");
-    }, 2000);
+    setTimeout(() => setAnnouncement(""), 2000);
   } else {
-    // Explicit failure feedback
+    // Explicit failure feedback: live-region announcement + error toast.
     setAnnouncement("Failed to copy address. Please copy manually.");
-    // Show a visual error state briefly
-    setCopied(false);
-    // Use a separate state or visual indicator for error
-    // We'll use the copied state with a different visual
-    // For now, we'll rely on the announcement
-    setTimeout(() => {
-      setAnnouncement("");
-    }, 3000);
+    toast?.addToast("Failed to copy address. Please copy manually.", "error");
+    setTimeout(() => setAnnouncement(""), 3000);
   }
 };
 
@@ -131,7 +100,7 @@ export default function WalletStatus({
 
   return (
     <div ref={ref} className="flex items-center gap-2">
-      <div className="sr-only" aria-live="polite" aria-atomic="true">
+      <div className="sr-only" role="status" aria-live="polite" aria-atomic="true">
         {announcement}
       </div>
       {/* Network Badge */}

--- a/src/components/navigation/__tests__/WalletStatus.copy.test.tsx
+++ b/src/components/navigation/__tests__/WalletStatus.copy.test.tsx
@@ -3,17 +3,24 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import WalletStatus from "../WalletStatus";
 
+// jsdom defines navigator.clipboard as a getter-only property, so it must be
+// redefined (not assigned) when stubbing. `undefined` simulates an insecure
+// context where the async Clipboard API is unavailable.
+function setClipboard(writeText?: ReturnType<typeof vi.fn>) {
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    writable: true,
+    value: writeText ? { writeText } : undefined,
+  });
+}
+
 describe("WalletStatus copy functionality", () => {
   const mockAddress = "GABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
   const mockNetwork = "TESTNET";
 
   beforeEach(() => {
     // Mock clipboard API
-    Object.assign(navigator, {
-      clipboard: {
-        writeText: vi.fn(),
-      },
-    });
+    setClipboard(vi.fn());
   });
 
   afterEach(() => {
@@ -81,9 +88,7 @@ describe("WalletStatus copy functionality", () => {
   it("uses fallback copy when clipboard API is unavailable", async () => {
     const user = userEvent.setup();
     // Remove clipboard API
-    Object.assign(navigator, {
-      clipboard: undefined,
-    });
+    setClipboard(undefined);
 
     // Mock execCommand
     document.execCommand = vi.fn().mockReturnValue(true);
@@ -113,9 +118,7 @@ describe("WalletStatus copy functionality", () => {
   it("handles fallback copy failure", async () => {
     const user = userEvent.setup();
     // Remove clipboard API
-    Object.assign(navigator, {
-      clipboard: undefined,
-    });
+    setClipboard(undefined);
 
     // Mock execCommand failure
     document.execCommand = vi.fn().mockReturnValue(false);

--- a/src/components/toast/ToastProvider.tsx
+++ b/src/components/toast/ToastProvider.tsx
@@ -104,3 +104,13 @@ export function useToast(): ToastContextValue {
   }
   return ctx;
 }
+
+/**
+ * useOptionalToast — like {@link useToast} but returns `null` instead of
+ * throwing when rendered outside a `ToastProvider`. Useful for shared widgets
+ * (e.g. copy buttons) that should still work in isolation/tests where no
+ * provider is mounted.
+ */
+export function useOptionalToast(): ToastContextValue | null {
+  return useContext(ToastContext);
+}

--- a/src/hooks/__tests__/useClipboard.test.ts
+++ b/src/hooks/__tests__/useClipboard.test.ts
@@ -1,0 +1,139 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useClipboard } from "../useClipboard";
+
+/**
+ * jsdom exposes `navigator.clipboard` as a getter-only property, so it must be
+ * redefined (not assigned) when stubbing. `undefined` simulates an insecure
+ * context where the Clipboard API is absent.
+ */
+function setClipboard(value: { writeText: ReturnType<typeof vi.fn> } | undefined) {
+  Object.defineProperty(navigator, "clipboard", {
+    value,
+    configurable: true,
+    writable: true,
+  });
+}
+
+describe("useClipboard", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("sets status to 'copied' on a successful Clipboard API write", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    setClipboard({ writeText });
+
+    const { result } = renderHook(() => useClipboard());
+
+    let returned: boolean | undefined;
+    await act(async () => {
+      returned = await result.current.copy("GABC");
+    });
+
+    expect(returned).toBe(true);
+    expect(writeText).toHaveBeenCalledWith("GABC");
+    expect(result.current.status).toBe("copied");
+  });
+
+  it("resets status to 'idle' after the reset delay", async () => {
+    setClipboard({ writeText: vi.fn().mockResolvedValue(undefined) });
+
+    const { result } = renderHook(() => useClipboard(2000));
+
+    await act(async () => {
+      await result.current.copy("GABC");
+    });
+    expect(result.current.status).toBe("copied");
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(result.current.status).toBe("idle");
+  });
+
+  it("falls back to execCommand when the Clipboard API is unavailable", async () => {
+    setClipboard(undefined);
+    const execCommand = vi.fn().mockReturnValue(true);
+    document.execCommand = execCommand;
+
+    const { result } = renderHook(() => useClipboard());
+
+    let returned: boolean | undefined;
+    await act(async () => {
+      returned = await result.current.copy("GABC");
+    });
+
+    expect(execCommand).toHaveBeenCalledWith("copy");
+    expect(returned).toBe(true);
+    expect(result.current.status).toBe("copied");
+  });
+
+  it("sets status to 'failed' when the Clipboard API rejects", async () => {
+    setClipboard({ writeText: vi.fn().mockRejectedValue(new Error("NotAllowedError")) });
+
+    const { result } = renderHook(() => useClipboard());
+
+    let returned: boolean | undefined;
+    await act(async () => {
+      returned = await result.current.copy("GABC");
+    });
+
+    expect(returned).toBe(false);
+    expect(result.current.status).toBe("failed");
+  });
+
+  it("sets status to 'failed' when both paths fail", async () => {
+    setClipboard(undefined);
+    document.execCommand = vi.fn().mockReturnValue(false);
+
+    const { result } = renderHook(() => useClipboard());
+
+    let returned: boolean | undefined;
+    await act(async () => {
+      returned = await result.current.copy("GABC");
+    });
+
+    expect(returned).toBe(false);
+    expect(result.current.status).toBe("failed");
+  });
+
+  it("reset() forces status back to idle immediately", async () => {
+    setClipboard({ writeText: vi.fn().mockResolvedValue(undefined) });
+
+    const { result } = renderHook(() => useClipboard());
+
+    await act(async () => {
+      await result.current.copy("GABC");
+    });
+    expect(result.current.status).toBe("copied");
+
+    act(() => {
+      result.current.reset();
+    });
+    expect(result.current.status).toBe("idle");
+  });
+
+  it("debounces rapid successive copies onto a single reset timer", async () => {
+    setClipboard({ writeText: vi.fn().mockResolvedValue(undefined) });
+
+    const { result } = renderHook(() => useClipboard(2000));
+
+    await act(async () => {
+      await result.current.copy("A");
+      await result.current.copy("B");
+    });
+
+    expect(result.current.status).toBe("copied");
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(result.current.status).toBe("idle");
+  });
+});

--- a/src/hooks/useClipboard.ts
+++ b/src/hooks/useClipboard.ts
@@ -1,0 +1,105 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/** Copy feedback state exposed by {@link useClipboard}. */
+export type ClipboardStatus = "idle" | "copied" | "failed";
+
+export interface UseClipboardResult {
+  /**
+   * Copy `text` to the clipboard. Uses the async Clipboard API and falls back
+   * to `document.execCommand("copy")` in insecure contexts where the API is
+   * unavailable or denied. Sets `status` to `"copied"` on success or
+   * `"failed"` otherwise, then resets to `"idle"` after `resetDelay` ms.
+   * Resolves to `true` on success and `false` on failure.
+   */
+  copy: (text: string) => Promise<boolean>;
+  /** Current feedback state. */
+  status: ClipboardStatus;
+  /** Force `status` back to `"idle"` immediately and cancel the pending reset. */
+  reset: () => void;
+}
+
+/** Legacy `execCommand` copy path for insecure contexts / old browsers. */
+function fallbackCopy(text: string): boolean {
+  if (typeof document === "undefined") return false;
+
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  textarea.style.left = "-9999px";
+  textarea.style.opacity = "0";
+  document.body.appendChild(textarea);
+  textarea.select();
+
+  try {
+    return document.execCommand("copy");
+  } catch {
+    return false;
+  } finally {
+    document.body.removeChild(textarea);
+  }
+}
+
+/**
+ * useClipboard — write-only clipboard helper with consistent success/failure
+ * feedback. It never reads from the clipboard (reading requires a separate
+ * permission and can expose other apps' data).
+ *
+ * @param resetDelay - ms before `status` auto-resets to `"idle"` (default 2000).
+ *
+ * @example
+ * ```tsx
+ * const { copy, status } = useClipboard();
+ * <button onClick={() => copy(address)}>
+ *   {status === "copied" ? "Copied" : "Copy"}
+ * </button>
+ * ```
+ */
+export function useClipboard(resetDelay = 2000): UseClipboardResult {
+  const [status, setStatus] = useState<ClipboardStatus>("idle");
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearTimer = useCallback(() => {
+    if (timer.current) {
+      clearTimeout(timer.current);
+      timer.current = null;
+    }
+  }, []);
+
+  const reset = useCallback(() => {
+    clearTimer();
+    setStatus("idle");
+  }, [clearTimer]);
+
+  const copy = useCallback(
+    async (text: string): Promise<boolean> => {
+      clearTimer();
+      let success = false;
+
+      if (navigator.clipboard?.writeText) {
+        try {
+          await navigator.clipboard.writeText(text);
+          success = true;
+        } catch {
+          // The Clipboard API can reject with NotAllowedError (e.g. permission
+          // denied / insecure context). Treat that as a failure rather than
+          // silently retrying a fallback that would likely also be blocked.
+          success = false;
+        }
+      } else {
+        // No async Clipboard API available: use the legacy execCommand path.
+        success = fallbackCopy(text);
+      }
+
+      setStatus(success ? "copied" : "failed");
+      timer.current = setTimeout(() => setStatus("idle"), resetDelay);
+      return success;
+    },
+    [clearTimer, resetDelay],
+  );
+
+  // Clear any pending timer on unmount.
+  useEffect(() => clearTimer, [clearTimer]);
+
+  return { copy, status, reset };
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -76,11 +76,14 @@ vi.mock('../components/wallet-connect/Walletcontext', () => {
 });
 
 vi.mock('../components/toast/ToastProvider', () => {
+  const ctx = {
+    addToast: vi.fn(),
+    removeToast: vi.fn(),
+    dismiss: vi.fn(),
+  };
   return {
-    useToast: () => ({
-      addToast: vi.fn(),
-      removeToast: vi.fn(),
-    }),
+    useToast: () => ctx,
+    useOptionalToast: () => ctx,
     ToastProvider: ({ children }: any) => children,
   };
 });


### PR DESCRIPTION
Adds src/hooks/useClipboard.ts exposing { copy, status, reset } where status is "idle" | "copied" | "failed". copy() uses navigator.clipboard.writeText, falls back to document.execCommand("copy") when the API is unavailable, and auto-resets to idle after 2s. Refactors TruncatedAddress and WalletStatus to consume the hook and surface an error toast on failure via a new non-throwing useOptionalToast() accessor (so isolated renders still work). Adds unit tests for the hook (both API paths, timer reset, reset()), a failure-toast test for TruncatedAddress, and fixes the WalletStatus copy tests (clipboard getter stubbing + role=status live region).

Closes #566