### PR TITLE
fix(#355): enforce configurable minimum stream duration in validateDuration

### DIFF
--- a/src/components/CreateStreamModal.tsx
+++ b/src/components/CreateStreamModal.tsx
@@ -35,6 +35,7 @@ export function sanitizeDepositAmountInput(value: string): string {
 
 // Keep demo stream math below JS safe-integer territory while still allowing large institutional schedules.
 export const MAX_ACCRUAL_RATE = 100_000;
+export const MIN_DURATION_DAYS = 1;
 export const MAX_DURATION_DAYS = 3_650;
 export const MAX_REQUIRED_DEPOSIT = MAX_ACCRUAL_RATE * MAX_DURATION_DAYS;
 
@@ -92,6 +93,10 @@ function validateDuration(value: string, t: any): string | undefined {
 
   if (!value.trim() || isNaN(numericValue) || numericValue <= 0) {
     return t("createStream.validation.durationPositive");
+  }
+
+  if (numericValue < MIN_DURATION_DAYS) {
+    return t("createStream.validation.durationMin", { min: MIN_DURATION_DAYS });
   }
 
   if (numericValue > MAX_DURATION_DAYS) {

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -99,6 +99,7 @@ export const en = {
   "createStream.validation.ratePositive": "Stream rate must be a positive number.",
   "createStream.validation.rateMax": "Stream rate must be {max} USDC/day or less.",
   "createStream.validation.durationPositive": "Duration must be a positive number.",
+  "createStream.validation.durationMin": "Duration must be at least {min} day.",
   "createStream.validation.durationMax": "Duration must be {max} days or less.",
   "createStream.validation.recipientRequired": "Recipient is required.",
   "createStream.validation.recipientInvalid": "Please enter a valid Stellar address (starts with G, 56 characters).",


### PR DESCRIPTION
## Summary

Closes #355

`validateDuration` in `CreateStreamModal.tsx` accepted any positive value including sub-day fractions, which produce streams that complete almost instantly.

## Changes

- Added `MIN_DURATION_DAYS = 1` constant (exported, easy to tune) alongside `MAX_DURATION_DAYS`
- Added a minimum check in `validateDuration` that returns the new `durationMin` i18n key when the value is below the minimum
- Added `createStream.validation.durationMin` key to `src/i18n/en.ts`

## Testing

Existing bounds tests (`CreateStreamModal.bounds.test.tsx`) continue to pass. The minimum is enforced at field validation so the step-2 "Next" button is blocked until the value is ≥ 1 day.