### PR TITLE
fix(#372): return focus to Connect Wallet trigger after disconnect

### DIFF
--- a/src/components/wallet-connect/Walletbutton.tsx
+++ b/src/components/wallet-connect/Walletbutton.tsx
@@ -16,6 +16,7 @@ export default function WalletButton() {
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [copied, setCopied] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
+  const connectTriggerRef = useRef<HTMLButtonElement>(null);
 
   // The canonical ConnectWalletModal performs the Freighter connection and
   // error handling internally; WalletButton just closes once it succeeds.
@@ -43,6 +44,8 @@ export default function WalletButton() {
   function handleDisconnect() {
     disconnect();
     setDropdownOpen(false);
+    // Defer focus until the connected UI is replaced by the "Connect wallet" button
+    requestAnimationFrame(() => connectTriggerRef.current?.focus());
   }
 
   function handleDropdownKey(e: React.KeyboardEvent) {
@@ -54,6 +57,7 @@ export default function WalletButton() {
     return (
       <>
         <button
+          ref={connectTriggerRef}
           onClick={handleOpenModal}
           className="px-4 py-3 text-base font-medium text-white rounded-lg transition-all duration-200 ease-in-out cursor-pointer"
           style={{


### PR DESCRIPTION
## Summary

Closes #372

When a user disconnected via `WalletButton`, focus was lost rather than returning to the logical anchor, stranding keyboard and screen-reader users.

## Changes

**`src/components/wallet-connect/Walletbutton.tsx`**
- Added `connectTriggerRef` attached to the "Connect wallet" `<button>`
- `handleDisconnect` now calls `requestAnimationFrame(() => connectTriggerRef.current?.focus())` so focus moves to the trigger after the connected UI is torn down and the connect button is rendered

`WalletStatus.tsx` already implements focus return via `triggerRef` / `closeMenu()` and needed no changes.

## Testing

Existing `Walletbutton.test.tsx` suite (3 tests) passes. The `requestAnimationFrame` deferred focus lands on the correct element once React re-renders the disconnected state.