### PR TITLE
test(#382): add unit tests for StreamTimeline segments and reduced-motion path

### DIFF
--- a/src/components/StreamTimeline.tsx
+++ b/src/components/StreamTimeline.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import "./StreamTimeline.module.css";
+import { usePrefersReducedMotion } from "../hooks/usePrefersReducedMotion";
 
 export interface StreamTimelineProps {
   startDate: string;
@@ -45,6 +46,8 @@ export const StreamTimeline: React.FC<StreamTimelineProps> = ({
   const cliff = cliffDate ? new Date(cliffDate) : null;
   const current = new Date(currentDate);
   const end = new Date(endDate);
+
+  const prefersReducedMotion = usePrefersReducedMotion();
 
   // Validate dates
   const totalDuration = end.getTime() - start.getTime();
@@ -129,6 +132,7 @@ export const StreamTimeline: React.FC<StreamTimelineProps> = ({
         aria-valuemin={0}
         aria-valuemax={100}
         aria-label="Stream accrual progress"
+        data-reduced-motion={prefersReducedMotion ? "true" : "false"}
       >
         {/* Cliff segment (hatched) */}
         {cliff && cliffPercent > 0 && (

--- a/src/components/__tests__/StreamTimeline.segments.test.tsx
+++ b/src/components/__tests__/StreamTimeline.segments.test.tsx
@@ -1,0 +1,204 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { StreamTimeline } from "../StreamTimeline";
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+function mockMatchMedia(matches: boolean) {
+  const listeners = new Set<(e: MediaQueryListEvent) => void>();
+  const mq = {
+    matches,
+    media: "(prefers-reduced-motion: reduce)",
+    addEventListener: vi.fn((_: string, fn: (e: MediaQueryListEvent) => void) => {
+      listeners.add(fn);
+    }),
+    removeEventListener: vi.fn((_: string, fn: (e: MediaQueryListEvent) => void) => {
+      listeners.delete(fn);
+    }),
+    dispatchChange(next: boolean) {
+      (mq as any).matches = next;
+      listeners.forEach((fn) => fn({ matches: next } as MediaQueryListEvent));
+    },
+  };
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    writable: true,
+    value: vi.fn().mockReturnValue(mq),
+  });
+  return mq;
+}
+
+const BASE = {
+  startDate: "2024-01-01T00:00:00Z",
+  endDate: "2024-04-10T00:00:00Z", // 100 days later
+  withdrawableAmount: 500,
+  totalAmount: 1000,
+  status: "active" as const,
+};
+
+// ── segment position tests ─────────────────────────────────────────────────
+
+describe("StreamTimeline segment rendering", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("renders the accrual segment for progress past the cliff", () => {
+    mockMatchMedia(false);
+    // start=Jan 1, cliff=Jan 11 (10%), current=Jan 21 (20%), end=Apr 10 (100%)
+    render(
+      <StreamTimeline
+        {...BASE}
+        cliffDate="2024-01-11T00:00:00Z"
+        currentDate="2024-01-21T00:00:00Z"
+      />,
+    );
+
+    const accrual = document.querySelector(
+      ".stream-timeline-bar__segment--accrual",
+    ) as HTMLElement;
+    expect(accrual).not.toBeNull();
+    // accrualPercent ≈ 20, cliffPercent ≈ 10, so accrual width ≈ 10%
+    const widthFloat = parseFloat(accrual.style.width);
+    expect(widthFloat).toBeGreaterThan(8);
+    expect(widthFloat).toBeLessThan(12);
+  });
+
+  it("renders the cliff segment with correct relative width", () => {
+    mockMatchMedia(false);
+    // cliff = 25 days into a 100-day stream → 25%
+    render(
+      <StreamTimeline
+        {...BASE}
+        cliffDate="2024-01-26T00:00:00Z"
+        currentDate="2024-01-26T00:00:00Z"
+      />,
+    );
+
+    const cliff = document.querySelector(
+      ".stream-timeline-bar__segment--cliff",
+    ) as HTMLElement;
+    expect(cliff).not.toBeNull();
+    const widthFloat = parseFloat(cliff.style.width);
+    expect(widthFloat).toBeGreaterThan(23);
+    expect(widthFloat).toBeLessThan(27);
+  });
+
+  it("renders the remaining segment when the stream is not complete", () => {
+    mockMatchMedia(false);
+    render(
+      <StreamTimeline
+        {...BASE}
+        cliffDate={null}
+        currentDate="2024-01-11T00:00:00Z" // 10% through
+      />,
+    );
+
+    const remaining = document.querySelector(
+      ".stream-timeline-bar__segment--remaining",
+    ) as HTMLElement;
+    expect(remaining).not.toBeNull();
+    const widthFloat = parseFloat(remaining.style.width);
+    expect(widthFloat).toBeGreaterThan(88);
+    expect(widthFloat).toBeLessThan(92);
+  });
+
+  it("does not render remaining segment when accrual reaches 100%", () => {
+    mockMatchMedia(false);
+    render(
+      <StreamTimeline
+        {...BASE}
+        cliffDate={null}
+        currentDate="2024-04-10T00:00:00Z" // exactly at end
+      />,
+    );
+
+    const remaining = document.querySelector(
+      ".stream-timeline-bar__segment--remaining",
+    );
+    expect(remaining).toBeNull();
+  });
+});
+
+// ── progress indicator tests ───────────────────────────────────────────────
+
+describe("StreamTimeline progress indicator", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("sets aria-valuenow to the rounded accrual percentage", () => {
+    mockMatchMedia(false);
+    // current = 50 days into 100-day stream → 50%
+    render(
+      <StreamTimeline
+        {...BASE}
+        cliffDate={null}
+        currentDate="2024-02-20T00:00:00Z"
+      />,
+    );
+
+    const bar = screen.getByRole("progressbar");
+    const value = parseInt(bar.getAttribute("aria-valuenow") ?? "-1", 10);
+    expect(value).toBeGreaterThanOrEqual(49);
+    expect(value).toBeLessThanOrEqual(51);
+  });
+
+  it("renders the current-date marker when current is between start and end", () => {
+    mockMatchMedia(false);
+    render(
+      <StreamTimeline
+        {...BASE}
+        cliffDate={null}
+        currentDate="2024-02-20T00:00:00Z"
+      />,
+    );
+
+    const marker = document.querySelector(".stream-timeline-bar__marker");
+    expect(marker).not.toBeNull();
+  });
+
+  it("omits the current-date marker when current equals end", () => {
+    mockMatchMedia(false);
+    render(
+      <StreamTimeline
+        {...BASE}
+        cliffDate={null}
+        currentDate="2024-04-10T00:00:00Z"
+      />,
+    );
+
+    const marker = document.querySelector(".stream-timeline-bar__marker");
+    expect(marker).toBeNull();
+  });
+});
+
+// ── reduced-motion path ────────────────────────────────────────────────────
+
+describe("StreamTimeline reduced-motion path", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("sets data-reduced-motion=true when OS prefers reduced motion", () => {
+    mockMatchMedia(true);
+    render(
+      <StreamTimeline
+        {...BASE}
+        cliffDate={null}
+        currentDate="2024-02-20T00:00:00Z"
+      />,
+    );
+
+    const bar = screen.getByRole("progressbar");
+    expect(bar.getAttribute("data-reduced-motion")).toBe("true");
+  });
+
+  it("sets data-reduced-motion=false when OS does not prefer reduced motion", () => {
+    mockMatchMedia(false);
+    render(
+      <StreamTimeline
+        {...BASE}
+        cliffDate={null}
+        currentDate="2024-02-20T00:00:00Z"
+      />,
+    );
+
+    const bar = screen.getByRole("progressbar");
+    expect(bar.getAttribute("data-reduced-motion")).toBe("false");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #382

`StreamTimeline.tsx` had no dedicated tests for segment rendering, the progress indicator, or the reduced-motion path.

## Changes

**`src/components/StreamTimeline.tsx`**
- Imported `usePrefersReducedMotion` hook and exposed its current value as `data-reduced-motion` on the `progressbar` element so tests can assert the hook is wired correctly

**`src/components/__tests__/StreamTimeline.segments.test.tsx`** (new, 9 tests)

| Suite | Tests |
|---|---|
| Segment rendering | cliff width ≈ 25%, accrual width beyond cliff, remaining segment width, no remaining when complete |
| Progress indicator | `aria-valuenow` at ~50%, marker present between start/end, marker absent at end |
| Reduced-motion | `data-reduced-motion=true` when OS prefers it, `false` otherwise |

## Testing

All 9 new tests pass. The 4 pre-existing failures in `WalletStatus.copy`, `Recipient`, `useTreasuryOverviewData`, and `tx.test.ts` are unrelated to this PR and exist on `main`.