### PR TITLE
feat: add keyboard shortcut overlay triggered by ? key

### DIFF
--- a/src/components/KeyboardShortcutsModal.tsx
+++ b/src/components/KeyboardShortcutsModal.tsx
@@ -1,0 +1,133 @@
+import { useEffect, useRef, useState } from 'react';
+import { useModalAccessibility } from './useModalAccessibility';
+
+interface ShortcutEntry {
+  keys: string[];
+  description: string;
+}
+
+interface ShortcutSection {
+  heading: string;
+  shortcuts: ShortcutEntry[];
+}
+
+const SECTIONS: ShortcutSection[] = [
+  {
+    heading: 'Global',
+    shortcuts: [
+      { keys: ['?'], description: 'Open keyboard shortcuts' },
+      { keys: ['Escape'], description: 'Close modal / dismiss overlay' },
+    ],
+  },
+  {
+    heading: 'Navigation',
+    shortcuts: [
+      { keys: ['Alt', 'D'], description: 'Go to Dashboard' },
+      { keys: ['Alt', 'S'], description: 'Go to Streams' },
+      { keys: ['Alt', 'R'], description: 'Go to Recipient' },
+    ],
+  },
+  {
+    heading: 'Streams',
+    shortcuts: [
+      { keys: ['/'], description: 'Focus search / filter input' },
+      { keys: ['Alt', 'N'], description: 'Open Create Stream modal' },
+    ],
+  },
+  {
+    heading: 'Recipient',
+    shortcuts: [
+      { keys: ['Alt', 'W'], description: 'Open withdraw dialog' },
+      { keys: ['Alt', 'C'], description: 'Copy recipient address' },
+    ],
+  },
+];
+
+export function KeyboardShortcutsModal() {
+  const [open, setOpen] = useState(false);
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  useModalAccessibility({ isOpen: open, containerRef: dialogRef });
+
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      const tag = (e.target as HTMLElement).tagName;
+      const isEditable =
+        tag === 'INPUT' ||
+        tag === 'TEXTAREA' ||
+        (e.target as HTMLElement).isContentEditable;
+
+      if (e.key === '?' && !isEditable) {
+        e.preventDefault();
+        setOpen((prev) => !prev);
+      }
+      if (e.key === 'Escape') {
+        setOpen(false);
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, []);
+
+  if (!open) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Keyboard shortcuts"
+      style={{
+        position: 'fixed', inset: 0, zIndex: 9999,
+        background: 'rgba(0,0,0,0.55)', display: 'flex',
+        alignItems: 'center', justifyContent: 'center',
+      }}
+      onClick={() => setOpen(false)}
+    >
+      <div
+        ref={dialogRef}
+        style={{
+          background: '#1a1a2e', color: '#e2e8f0', borderRadius: 12,
+          padding: '1.5rem', maxWidth: 520, width: '90%',
+          maxHeight: '80vh', overflowY: 'auto',
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1rem' }}>
+          <h2 style={{ margin: 0, fontSize: '1.1rem' }}>Keyboard Shortcuts</h2>
+          <button
+            aria-label="Close keyboard shortcuts"
+            onClick={() => setOpen(false)}
+            style={{ background: 'none', border: 'none', color: '#94a3b8', fontSize: '1.25rem', cursor: 'pointer' }}
+          >
+            ✕
+          </button>
+        </div>
+
+        {SECTIONS.map((section) => (
+          <section key={section.heading} style={{ marginBottom: '1.25rem' }}>
+            <h3 style={{ fontSize: '0.75rem', textTransform: 'uppercase', letterSpacing: '0.05em', color: '#94a3b8', marginBottom: '0.5rem' }}>
+              {section.heading}
+            </h3>
+            <dl style={{ margin: 0, display: 'flex', flexDirection: 'column', gap: '0.4rem' }}>
+              {section.shortcuts.map((s) => (
+                <div key={s.description} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                  <dt style={{ display: 'flex', gap: '0.25rem' }}>
+                    {s.keys.map((k) => (
+                      <kbd key={k} style={{
+                        background: '#2d3748', border: '1px solid #4a5568',
+                        borderRadius: 4, padding: '0.1rem 0.4rem',
+                        fontSize: '0.8rem', fontFamily: 'monospace',
+                      }}>{k}</kbd>
+                    ))}
+                  </dt>
+                  <dd style={{ margin: 0, fontSize: '0.875rem', color: '#cbd5e0' }}>{s.description}</dd>
+                </div>
+              ))}
+            </dl>
+          </section>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Fixes #522

- Adds `src/components/KeyboardShortcutsModal.tsx` listing Global, Navigation, Streams, and Recipient shortcuts
- Opens on `?` keypress (skips when focus is inside input/textarea/contenteditable), closes on Escape or backdrop click
- Uses `useModalAccessibility` for focus-trap; accessible with `role=dialog`, `aria-modal`, `<dl>/<dt>/<dd>` structure and `<kbd>` elements
- Zero dependencies — mount it once in AppNavbar or App root