### PR TITLE
feat: add rate-of-change sparkline visualization to MetricCard

### DIFF
--- a/src/components/treasuryOverviewPage/Metric.ts
+++ b/src/components/treasuryOverviewPage/Metric.ts
@@ -6,4 +6,6 @@ export interface Metric {
   label: string;
   value: string;
   desc: string;
+  /** Optional trend data for the rate-of-change sparkline (e.g. last N data points). */
+  trend?: number[];
 }

--- a/src/components/treasuryOverviewPage/MetricCard.tsx
+++ b/src/components/treasuryOverviewPage/MetricCard.tsx
@@ -7,8 +7,9 @@
  */
 
 import { Metric } from "./Metric";
+import Sparkline from "./Sparkline";
 
-export default function MetricCard({ icon, label, value, desc }: Metric) {
+export default function MetricCard({ icon, label, value, desc, trend }: Metric) {
   return (
     <div
       className="flex flex-col rounded-xl p-6 h-full"
@@ -35,6 +36,12 @@ export default function MetricCard({ icon, label, value, desc }: Metric) {
       <div className="text-2xl font-semibold leading-8 mb-2" style={{ color: "var(--color-text-vivid)" }}>
         {value}
       </div>
+
+      {trend && trend.length >= 2 && (
+        <div style={{ marginBottom: "var(--space-sm)" }} aria-label="Rate of change sparkline">
+          <Sparkline data={trend} />
+        </div>
+      )}
 
       <p className="text-sm leading-5 mt-auto" style={{ color: "var(--color-text-secondary)" }}>
         {desc}

--- a/src/components/treasuryOverviewPage/Sparkline.tsx
+++ b/src/components/treasuryOverviewPage/Sparkline.tsx
@@ -1,0 +1,41 @@
+interface SparklineProps {
+  data: number[];
+  width?: number;
+  height?: number;
+  color?: string;
+}
+
+export default function Sparkline({ data, width = 80, height = 32, color = "var(--color-accent-primary)" }: SparklineProps) {
+  if (data.length < 2) return null;
+
+  const min = Math.min(...data);
+  const max = Math.max(...data);
+  const range = max - min || 1;
+
+  const points = data.map((v, i) => {
+    const x = (i / (data.length - 1)) * width;
+    const y = height - ((v - min) / range) * height;
+    return `${x},${y}`;
+  }).join(" ");
+
+  const trend = data[data.length - 1] - data[0];
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      aria-hidden="true"
+      aria-label={`Trend: ${trend >= 0 ? "up" : "down"}`}
+      style={{ display: "block" }}
+    >
+      <polyline
+        points={points}
+        fill="none"
+        stroke={color}
+        strokeWidth={1.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}


### PR DESCRIPTION
Closes #552

Adds an optional trend?: number[] field to the Metric interface and renders an SVG Sparkline component below the value when trend data is provided. The sparkline uses design token colors and is accessible via aria-label.