### PR TITLE
fix(#358): distinguish transient RPC errors from permanent failures

### DIFF
--- a/src/hooks/useTransactionStatus.test.ts
+++ b/src/hooks/useTransactionStatus.test.ts
@@ -1,0 +1,328 @@
+/**
+ * Tests for useTransactionStatus – GitHub issue #358
+ *
+ * Verifies that:
+ *   • Transient RPC errors are retried within the existing attempt budget
+ *     (with exponential back-off) and do not surface an error prematurely.
+ *   • Permanent errors fail fast without consuming further retries.
+ *   • classifyRpcError() correctly categorises known error patterns.
+ *   • Terminal statuses (success / failed) resolve correctly.
+ *   • The hook cleans up on unmount without causing state updates.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import {
+  useTransactionStatus,
+  classifyRpcError,
+} from './useTransactionStatus';
+
+// ---------------------------------------------------------------------------
+// Fake timers
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+// ---------------------------------------------------------------------------
+// classifyRpcError unit tests
+// ---------------------------------------------------------------------------
+
+describe('classifyRpcError', () => {
+  it('returns permanent for null / undefined', () => {
+    expect(classifyRpcError(null)).toBe('permanent');
+    expect(classifyRpcError(undefined)).toBe('permanent');
+  });
+
+  it('classifies network-related errors as transient', () => {
+    expect(classifyRpcError(new Error('network error'))).toBe('transient');
+    expect(classifyRpcError(new Error('connection refused'))).toBe('transient');
+    expect(classifyRpcError(new Error('fetch failed'))).toBe('transient');
+    expect(classifyRpcError(new Error('Request timed out'))).toBe('transient');
+    expect(classifyRpcError(new Error('ECONNREFUSED'))).toBe('transient');
+    expect(classifyRpcError(new Error('ENOTFOUND rpc.stellar.org'))).toBe('transient');
+    expect(classifyRpcError(new Error('load failed'))).toBe('transient');
+  });
+
+  it('classifies HTTP 429 / 503 / 504 / 408 as transient via .status', () => {
+    const makeErr = (status: number) => Object.assign(new Error('err'), { status });
+    expect(classifyRpcError(makeErr(429))).toBe('transient');
+    expect(classifyRpcError(makeErr(503))).toBe('transient');
+    expect(classifyRpcError(makeErr(504))).toBe('transient');
+    expect(classifyRpcError(makeErr(408))).toBe('transient');
+  });
+
+  it('classifies 400 / 401 / 403 / 500 as permanent', () => {
+    const makeErr = (status: number) => Object.assign(new Error('err'), { status });
+    expect(classifyRpcError(makeErr(400))).toBe('permanent');
+    expect(classifyRpcError(makeErr(401))).toBe('permanent');
+    expect(classifyRpcError(makeErr(403))).toBe('permanent');
+    expect(classifyRpcError(makeErr(500))).toBe('permanent');
+  });
+
+  it('classifies auth / validation errors as permanent', () => {
+    expect(classifyRpcError(new Error('Unauthorized'))).toBe('permanent');
+    expect(classifyRpcError(new Error('Forbidden'))).toBe('permanent');
+    expect(classifyRpcError(new Error('Invalid transaction'))).toBe('permanent');
+    expect(classifyRpcError(new Error('malformed XDR'))).toBe('permanent');
+    expect(classifyRpcError(new Error('bad request'))).toBe('permanent');
+    expect(classifyRpcError(new Error('account not found'))).toBe('permanent');
+    expect(classifyRpcError(new Error('sequence number mismatch'))).toBe('permanent');
+  });
+
+  it('classifies rate-limit messages as transient', () => {
+    expect(classifyRpcError(new Error('too many requests'))).toBe('transient');
+    expect(classifyRpcError(new Error('rate limit exceeded'))).toBe('transient');
+    expect(classifyRpcError(new Error('service unavailable'))).toBe('transient');
+  });
+
+  it('classifies unknown errors (no pattern match, no status code) as permanent', () => {
+    expect(classifyRpcError(new Error('something completely unknown'))).toBe('permanent');
+    expect(classifyRpcError('plain string error')).toBe('permanent');
+    expect(classifyRpcError({ code: 999 })).toBe('permanent');
+  });
+
+  it('permanent patterns take priority over transient patterns', () => {
+    // "not authorized" contains both "not" (neutral) and "authorized" (permanent)
+    expect(classifyRpcError(new Error('not authorized due to network policy'))).toBe(
+      'permanent',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// useTransactionStatus integration tests
+// ---------------------------------------------------------------------------
+
+/** Advance all pending microtasks + fake timers in lockstep. */
+async function flushAll(ms = 0) {
+  await act(async () => {
+    vi.advanceTimersByTime(ms);
+    await Promise.resolve();
+  });
+}
+
+describe('useTransactionStatus – success path', () => {
+  it('resolves to success when fetchStatus returns "success"', async () => {
+    const fetchStatus = vi.fn().mockResolvedValue('success');
+
+    const { result } = renderHook(() =>
+      useTransactionStatus({ fetchStatus, pollIntervalMs: 100 }),
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.status).toBe('success');
+    expect(result.current.isPolling).toBe(false);
+    expect(result.current.errorMessage).toBeNull();
+  });
+
+  it('resolves to failed when fetchStatus returns "failed"', async () => {
+    const fetchStatus = vi.fn().mockResolvedValue('failed');
+
+    const { result } = renderHook(() =>
+      useTransactionStatus({ fetchStatus, pollIntervalMs: 100 }),
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.status).toBe('failed');
+    expect(result.current.isPolling).toBe(false);
+  });
+});
+
+describe('useTransactionStatus – permanent errors fail fast', () => {
+  it('immediately sets status=error on a permanent error without retrying', async () => {
+    const fetchStatus = vi
+      .fn()
+      .mockRejectedValue(new Error('Invalid transaction XDR'));
+
+    const { result } = renderHook(() =>
+      useTransactionStatus({ fetchStatus, maxAttempts: 10, pollIntervalMs: 100 }),
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Should have only been called once (fail fast — no retries).
+    expect(fetchStatus).toHaveBeenCalledTimes(1);
+    expect(result.current.status).toBe('error');
+    expect(result.current.errorMessage).toMatch(/invalid transaction/i);
+    expect(result.current.isPolling).toBe(false);
+  });
+
+  it('surfaces the original error message on permanent failure', async () => {
+    const fetchStatus = vi
+      .fn()
+      .mockRejectedValue(new Error('Unauthorized: missing signature'));
+
+    const { result } = renderHook(() =>
+      useTransactionStatus({ fetchStatus, pollIntervalMs: 100 }),
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.errorMessage).toBe('Unauthorized: missing signature');
+  });
+});
+
+describe('useTransactionStatus – transient errors are retried', () => {
+  it('retries on a transient error and eventually succeeds', async () => {
+    // Fail twice with a transient error, then succeed.
+    const fetchStatus = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error('network error'), { status: 503 }))
+      .mockRejectedValueOnce(new Error('connection refused'))
+      .mockResolvedValue('success');
+
+    const { result } = renderHook(() =>
+      useTransactionStatus({ fetchStatus, maxAttempts: 10, pollIntervalMs: 100, backOffBase: 2, maxBackOffMs: 1_000 }),
+    );
+
+    // First call throws (transient) → back-off sleep
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Advance past first back-off (100 * 2^1 = 200 ms)
+    await act(async () => {
+      vi.advanceTimersByTime(300);
+      await Promise.resolve();
+    });
+
+    // Advance past second back-off (100 * 2^2 = 400 ms)
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+      await Promise.resolve();
+    });
+
+    // Third call resolves with 'success'
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(fetchStatus).toHaveBeenCalledTimes(3);
+    expect(result.current.status).toBe('success');
+    expect(result.current.isPolling).toBe(false);
+  });
+
+  it('exhausts max attempts if all are transient errors', async () => {
+    const fetchStatus = vi
+      .fn()
+      .mockRejectedValue(new Error('network error'));
+
+    const { result } = renderHook(() =>
+      useTransactionStatus({
+        fetchStatus,
+        maxAttempts: 3,
+        pollIntervalMs: 10,
+        backOffBase: 2,
+        maxBackOffMs: 100,
+      }),
+    );
+
+    // Flush all retries
+    for (let i = 0; i < 5; i++) {
+      await act(async () => {
+        vi.advanceTimersByTime(200);
+        await Promise.resolve();
+      });
+    }
+
+    expect(result.current.status).toBe('error');
+    expect(result.current.errorMessage).toMatch(/maximum retries/i);
+    expect(result.current.isPolling).toBe(false);
+  });
+});
+
+describe('useTransactionStatus – disabled flag', () => {
+  it('does not start polling when disabled=true', async () => {
+    const fetchStatus = vi.fn().mockResolvedValue('success');
+
+    const { result } = renderHook(() =>
+      useTransactionStatus({ fetchStatus, disabled: true }),
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(fetchStatus).not.toHaveBeenCalled();
+    expect(result.current.status).toBe('idle');
+  });
+});
+
+describe('useTransactionStatus – pending transitions', () => {
+  it('remains pending while fetchStatus returns "pending"', async () => {
+    let callCount = 0;
+    const fetchStatus = vi.fn().mockImplementation(() => {
+      callCount++;
+      if (callCount < 3) return Promise.resolve('pending');
+      return Promise.resolve('success');
+    });
+
+    const { result } = renderHook(() =>
+      useTransactionStatus({ fetchStatus, pollIntervalMs: 50 }),
+    );
+
+    // After first call returns 'pending'
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.status).toBe('pending');
+
+    // Advance past first poll interval
+    await act(async () => {
+      vi.advanceTimersByTime(60);
+      await Promise.resolve();
+    });
+
+    // Still pending after second call
+    expect(['pending', 'success']).toContain(result.current.status);
+
+    // Advance to trigger third call → success
+    await act(async () => {
+      vi.advanceTimersByTime(60);
+      await Promise.resolve();
+    });
+
+    expect(result.current.status).toBe('success');
+  });
+});
+
+describe('useTransactionStatus – cleanup on unmount', () => {
+  it('does not update state after unmount', async () => {
+    const fetchStatus = vi
+      .fn()
+      .mockImplementation(() => new Promise((resolve) => setTimeout(() => resolve('success'), 500)));
+
+    const { result, unmount } = renderHook(() =>
+      useTransactionStatus({ fetchStatus, pollIntervalMs: 100 }),
+    );
+
+    // Unmount before the fetch resolves
+    unmount();
+
+    await act(async () => {
+      vi.advanceTimersByTime(600);
+      await Promise.resolve();
+    });
+
+    // Status should still be 'pending' (set at mount) — no post-unmount update.
+    expect(['idle', 'pending']).toContain(result.current.status);
+  });
+});

--- a/src/hooks/useTransactionStatus.ts
+++ b/src/hooks/useTransactionStatus.ts
@@ -1,0 +1,297 @@
+/**
+ * useTransactionStatus
+ *
+ * Polls for a Stellar/Soroban transaction status and exposes a typed status
+ * value together with error details.
+ *
+ * Fix for GitHub issue #358:
+ *   The original poll() loop treated every error identically, burning through
+ *   the full attempt budget even for transient network hiccups.  The hook now
+ *   classifies errors before deciding what to do:
+ *
+ *   • Transient errors  – increment a dedicated retry counter, sleep with
+ *     exponential back-off, then continue polling within the existing attempt
+ *     budget.
+ *   • Permanent errors  – fail fast by throwing immediately so the parent
+ *     component can surface a meaningful message without waiting for all
+ *     retries to expire.
+ */
+
+import { useState, useEffect, useRef, useCallback } from 'react';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export type TransactionStatusValue =
+  | 'idle'
+  | 'pending'
+  | 'success'
+  | 'failed'
+  | 'not_found'
+  | 'error';
+
+export interface TransactionStatusState {
+  /** Current lifecycle status of the transaction. */
+  status: TransactionStatusValue;
+  /** Human-readable description when status === 'error'. */
+  errorMessage: string | null;
+  /** Whether the hook is actively polling. */
+  isPolling: boolean;
+  /** Number of poll attempts made so far. */
+  attempts: number;
+}
+
+export interface UseTransactionStatusOptions {
+  /**
+   * Async function that fetches the current transaction status string from the
+   * RPC layer.  Must resolve to one of: 'pending' | 'success' | 'failed' |
+   * 'not_found', or throw on error.
+   */
+  fetchStatus: () => Promise<string>;
+  /** Maximum number of poll attempts before giving up.  Default: 10 */
+  maxAttempts?: number;
+  /** Base interval in ms between polls.  Default: 3000 */
+  pollIntervalMs?: number;
+  /** Exponent base for transient-error back-off.  Default: 2 */
+  backOffBase?: number;
+  /** Cap for back-off delay in ms.  Default: 30 000 */
+  maxBackOffMs?: number;
+  /** Skip polling entirely (e.g. no txHash yet).  Default: false */
+  disabled?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Error classification
+// ---------------------------------------------------------------------------
+
+/**
+ * HTTP / network status codes considered transient.
+ * 408 Request Timeout, 429 Too Many Requests, 503 Service Unavailable,
+ * 504 Gateway Timeout.
+ */
+const TRANSIENT_HTTP_CODES = new Set([408, 429, 503, 504]);
+
+/**
+ * Substrings matched (case-insensitively) against error messages to identify
+ * transient RPC failures.
+ */
+const TRANSIENT_MESSAGE_PATTERNS = [
+  'network',
+  'timeout',
+  'timed out',
+  'too many requests',
+  'rate limit',
+  'service unavailable',
+  'connection',
+  'econnrefused',
+  'enotfound',
+  'etimedout',
+  'fetch failed',
+  'load failed',
+];
+
+/**
+ * Substrings that indicate a permanent, non-retryable failure even when the
+ * HTTP status code would otherwise look transient.
+ */
+const PERMANENT_MESSAGE_PATTERNS = [
+  'invalid transaction',
+  'unauthorized',
+  'forbidden',
+  'not authorized',
+  'malformed',
+  'bad request',
+  'account not found',
+  'sequence number',
+];
+
+/**
+ * Classifies an error thrown by `fetchStatus()`.
+ *
+ * Returns `'transient'` when the error is likely temporary (network blip,
+ * rate-limit, gateway hiccup) so the caller should retry.
+ * Returns `'permanent'` for all other errors (auth failures, invalid requests,
+ * unknown errors) so the caller should fail fast.
+ */
+export function classifyRpcError(error: unknown): 'transient' | 'permanent' {
+  if (!error) return 'permanent';
+
+  const message =
+    error instanceof Error
+      ? error.message.toLowerCase()
+      : String(error).toLowerCase();
+
+  // Permanent patterns take priority — check them first.
+  if (PERMANENT_MESSAGE_PATTERNS.some((p) => message.includes(p))) {
+    return 'permanent';
+  }
+
+  // HTTP status code on the error object (some fetch wrappers expose `.status`).
+  const status = (error as { status?: number }).status;
+  if (typeof status === 'number' && TRANSIENT_HTTP_CODES.has(status)) {
+    return 'transient';
+  }
+
+  // Transient message patterns.
+  if (TRANSIENT_MESSAGE_PATTERNS.some((p) => message.includes(p))) {
+    return 'transient';
+  }
+
+  return 'permanent';
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function computeBackOff(
+  attempt: number,
+  base: number,
+  pollIntervalMs: number,
+  maxBackOffMs: number,
+): number {
+  const delay = pollIntervalMs * Math.pow(base, attempt);
+  return Math.min(delay, maxBackOffMs);
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useTransactionStatus({
+  fetchStatus,
+  maxAttempts = 10,
+  pollIntervalMs = 3_000,
+  backOffBase = 2,
+  maxBackOffMs = 30_000,
+  disabled = false,
+}: UseTransactionStatusOptions): TransactionStatusState {
+  const [state, setState] = useState<TransactionStatusState>({
+    status: 'idle',
+    errorMessage: null,
+    isPolling: false,
+    attempts: 0,
+  });
+
+  // Keep a stable ref to the latest fetchStatus so the effect closure never
+  // goes stale without re-mounting.
+  const fetchStatusRef = useRef(fetchStatus);
+  useEffect(() => {
+    fetchStatusRef.current = fetchStatus;
+  });
+
+  // Abort flag — set to true when the effect tears down so in-flight promises
+  // do not update state after unmount.
+  const abortedRef = useRef(false);
+
+  const poll = useCallback(async () => {
+    abortedRef.current = false;
+
+    setState({
+      status: 'pending',
+      errorMessage: null,
+      isPolling: true,
+      attempts: 0,
+    });
+
+    let transientRetries = 0;
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      if (abortedRef.current) return;
+
+      try {
+        const raw = await fetchStatusRef.current();
+
+        if (abortedRef.current) return;
+
+        const resolved = raw?.toLowerCase?.() ?? '';
+
+        if (resolved === 'success') {
+          setState({
+            status: 'success',
+            errorMessage: null,
+            isPolling: false,
+            attempts: attempt,
+          });
+          return;
+        }
+
+        if (resolved === 'failed') {
+          setState({
+            status: 'failed',
+            errorMessage: null,
+            isPolling: false,
+            attempts: attempt,
+          });
+          return;
+        }
+
+        // 'pending' or 'not_found' — keep polling.
+        setState((prev) => ({
+          ...prev,
+          status: resolved === 'not_found' ? 'not_found' : 'pending',
+          attempts: attempt,
+        }));
+
+        await sleep(pollIntervalMs);
+      } catch (err) {
+        if (abortedRef.current) return;
+
+        const kind = classifyRpcError(err);
+
+        if (kind === 'permanent') {
+          // Fail fast — do not consume more of the attempt budget.
+          setState({
+            status: 'error',
+            errorMessage:
+              err instanceof Error
+                ? err.message
+                : 'A permanent RPC error occurred.',
+            isPolling: false,
+            attempts: attempt,
+          });
+          return;
+        }
+
+        // Transient — back off and retry within the existing budget.
+        transientRetries += 1;
+        const backOff = computeBackOff(
+          transientRetries,
+          backOffBase,
+          pollIntervalMs,
+          maxBackOffMs,
+        );
+
+        setState((prev) => ({ ...prev, attempts: attempt }));
+        await sleep(backOff);
+      }
+    }
+
+    // Exhausted all attempts.
+    if (!abortedRef.current) {
+      setState((prev) => ({
+        ...prev,
+        status: 'error',
+        errorMessage: 'Transaction status could not be confirmed after maximum retries.',
+        isPolling: false,
+      }));
+    }
+  }, [maxAttempts, pollIntervalMs, backOffBase, maxBackOffMs]);
+
+  useEffect(() => {
+    if (disabled) return;
+
+    poll();
+
+    return () => {
+      abortedRef.current = true;
+    };
+  }, [disabled, poll]);
+
+  return state;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: './src/test/setup.ts',
+  },
+});


### PR DESCRIPTION
## Summary

Closes #358

The `poll()` loop in `useTransactionStatus` was catching all errors uniformly, burning through the full attempt budget on transient network hiccups and surfacing a generic failure. This PR introduces error classification:

- **Transient errors** (network blips, timeouts, HTTP 408/429/503/504, rate-limits) are retried within the existing attempt budget using **exponential back-off**.
- **Permanent errors** (auth failures, invalid transactions, malformed requests) **fail fast** on the first occurrence without wasting retries.

## Changes

### `src/hooks/useTransactionStatus.ts` (new)
- `classifyRpcError(error)` — exported helper that checks HTTP status codes and message substrings, returns `'transient'` or `'permanent'`.
- `useTransactionStatus()` — polling hook:
  - Transient → exponential back-off (`pollIntervalMs × base^n`, capped at `maxBackOffMs`), retries within budget.
  - Permanent → sets `status: 'error'` immediately with the original message.
  - Budget exhausted → surfaces a clear max-retries message.
  - `disabled` flag, abort-on-unmount guard, stable `fetchStatus` ref.

### `src/hooks/useTransactionStatus.test.ts` (new)
17 tests covering classification logic, success/failed paths, transient retry flow, permanent fail-fast, disabled flag, pending transitions, and cleanup on unmount.

### `vitest.config.ts` (new)
Minimal Vitest config without the Tailwind native binding so tests run cleanly in CI.

## Test output
```
Test Files  1 passed (1)
      Tests  17 passed (17)
```