### PR TITLE
test(hooks): verify hook unmount cancels active transaction polling a…

### DIFF
--- a/src/hooks/__tests__/useTransactionStatus.test.tsx
+++ b/src/hooks/__tests__/useTransactionStatus.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createDemoTransactionStatusSource,
   useTransactionStatus,
+  type PolledTxStatus,
   type TransactionStatusSource,
 } from "../useTransactionStatus";
 
@@ -118,6 +119,90 @@ describe("useTransactionStatus", () => {
     });
 
     expect(getStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it("unmounts mid-poll without state updates or leaked timers", async () => {
+    let resolveDeferred: (value: PolledTxStatus) => void;
+    const deferred = new Promise<PolledTxStatus>((resolve) => {
+      resolveDeferred = resolve;
+    });
+
+    const getStatus = vi
+      .fn<TransactionStatusSource>()
+      .mockReturnValue(deferred);
+
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const { unmount } = renderHook(() =>
+      useTransactionStatus("tx-mid-unmount", {
+        getStatus,
+        pollIntervalMs: 100,
+        maxAttempts: 5,
+        backoffFactor: 1,
+      }),
+    );
+
+    expect(getStatus).toHaveBeenCalledTimes(1);
+
+    unmount();
+
+    await act(async () => {
+      resolveDeferred("pending");
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(10000);
+      await Promise.resolve();
+    });
+
+    expect(getStatus).toHaveBeenCalledTimes(1);
+    expect(consoleSpy).not.toHaveBeenCalled();
+
+    consoleSpy.mockRestore();
+  });
+
+  it("prevents duplicate concurrent poll loops on rapid remount", async () => {
+    const getStatus = vi
+      .fn<TransactionStatusSource>()
+      .mockResolvedValue("pending");
+
+    const { unmount } = renderHook(() =>
+      useTransactionStatus("tx-rapid", {
+        getStatus,
+        pollIntervalMs: 100,
+        maxAttempts: 10,
+        backoffFactor: 1,
+      }),
+    );
+
+    await flushPromises();
+    expect(getStatus).toHaveBeenCalledTimes(1);
+
+    unmount();
+
+    const { result: result2 } = renderHook(() =>
+      useTransactionStatus("tx-rapid", {
+        getStatus,
+        pollIntervalMs: 100,
+        maxAttempts: 10,
+        backoffFactor: 1,
+      }),
+    );
+
+    await flushPromises();
+    expect(getStatus).toHaveBeenCalledTimes(2);
+
+    for (let i = 0; i < 3; i++) {
+      await act(async () => {
+        vi.advanceTimersByTime(100);
+        await Promise.resolve();
+      });
+    }
+
+    expect(getStatus).toHaveBeenCalledTimes(5);
+    expect(result2.current.status).toBe("pending");
+    expect(result2.current.attempts).toBe(4);
   });
 
   it("uses the demo status source without optimistic immediate success", async () => {


### PR DESCRIPTION
closes #655 
## Summary

Adds two tests to `useTransactionStatus.test.tsx` that confirm the poll loop is properly
cancelled on unmount (no stale state updates, no leaked timers) and that rapid
unmount–remount with the same transaction id does not create duplicate concurrent
poll loops. Complements the existing transient-vs-permanent error-classification
coverage from PR #609/#358.

No production code changes were needed — the `cancelled` flag, `AbortController.abort()`,
and `clearTimer()` in the effect cleanup already handle these cases correctly.

## Changes

- **`src/hooks/__tests__/useTransactionStatus.test.tsx`**
  - Added `PolledTxStatus` to the import block.
  - **`unmounts mid-poll without state updates or leaked timers`** — defers the
    `getStatus` promise, unmounts while it is in-flight, resolves it to
    `"pending"`, then verifies zero extra `getStatus` calls and no `console.error`
    warnings.
  - **`prevents duplicate concurrent poll loops on rapid remount`** — mounts,
    polls once, unmounts, immediately remounts with the same txHash, then
    advances three timer intervals and confirms exactly one sequential poll per
    interval (no concurrent duplicates).

## Test plan

- [x] `npm run build` passes (type-check + production build)
- [x] `npm run test` passes (all 7 unit tests green)
- [x] New code is covered by tests; no new production modules were added

## Coverage gate

CI enforces **95% coverage thresholds** (statements, branches, functions, lines) via
the `coverage` job in `.github/workflows/ci.yml`. The job runs `npm run test:coverage`
and fails the PR check when any threshold is missed. The coverage report is uploaded
as a build artifact for every run.

No new production files were added, so no change to the `include` array in
`vitest.config.ts` is required.
