### PR TITLE
fix: mount KeyboardShortcutsModal and remove aspirational shortcuts

### DIFF
--- a/src/components/KeyboardShortcutsModal.tsx
+++ b/src/components/KeyboardShortcutsModal.tsx
@@ -19,28 +19,6 @@ const SECTIONS: ShortcutSection[] = [
       { keys: ['Escape'], description: 'Close modal / dismiss overlay' },
     ],
   },
-  {
-    heading: 'Navigation',
-    shortcuts: [
-      { keys: ['Alt', 'D'], description: 'Go to Dashboard' },
-      { keys: ['Alt', 'S'], description: 'Go to Streams' },
-      { keys: ['Alt', 'R'], description: 'Go to Recipient' },
-    ],
-  },
-  {
-    heading: 'Streams',
-    shortcuts: [
-      { keys: ['/'], description: 'Focus search / filter input' },
-      { keys: ['Alt', 'N'], description: 'Open Create Stream modal' },
-    ],
-  },
-  {
-    heading: 'Recipient',
-    shortcuts: [
-      { keys: ['Alt', 'W'], description: 'Open withdraw dialog' },
-      { keys: ['Alt', 'C'], description: 'Copy recipient address' },
-    ],
-  },
 ];
 
 export function KeyboardShortcutsModal() {

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -2,6 +2,7 @@ import { useRef, useState } from "react";
 import { NavLink, Outlet, useLocation } from "react-router-dom";
 import ConnectWalletModal from "./ConnectWalletModal";
 import Footer from "./Footer";
+import { KeyboardShortcutsModal } from "./KeyboardShortcutsModal";
 import "./Layout.css";
 
 type NavItem = { to: string; label: string; shortLabel: string };
@@ -150,6 +151,7 @@ export default function Layout() {
         onConnectAlbedo={handleCloseModal}
         onConnectWalletConnect={handleCloseModal}
       />
+      <KeyboardShortcutsModal />
     </div>
   );
 }

--- a/src/components/__tests__/KeyboardShortcutsModal.test.tsx
+++ b/src/components/__tests__/KeyboardShortcutsModal.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import { KeyboardShortcutsModal } from "../KeyboardShortcutsModal";
+
+describe("KeyboardShortcutsModal", () => {
+  it("opens when '?' is pressed and closes when 'Escape' is pressed", async () => {
+    const user = userEvent.setup();
+    render(<KeyboardShortcutsModal />);
+
+    // Initially not open
+    expect(screen.queryByRole("dialog", { name: /keyboard shortcuts/i })).not.toBeInTheDocument();
+
+    // Press '?'
+    await user.keyboard("?");
+    expect(screen.getByRole("dialog", { name: /keyboard shortcuts/i })).toBeInTheDocument();
+
+    // Press 'Escape'
+    await user.keyboard("{Escape}");
+    expect(screen.queryByRole("dialog", { name: /keyboard shortcuts/i })).not.toBeInTheDocument();
+  });
+
+  it("closes when the close button is clicked", async () => {
+    const user = userEvent.setup();
+    render(<KeyboardShortcutsModal />);
+
+    await user.keyboard("?");
+    expect(screen.getByRole("dialog", { name: /keyboard shortcuts/i })).toBeInTheDocument();
+
+    const closeButton = screen.getByRole("button", { name: /close keyboard shortcuts/i });
+    await user.click(closeButton);
+
+    expect(screen.queryByRole("dialog", { name: /keyboard shortcuts/i })).not.toBeInTheDocument();
+  });
+
+  it("closes when clicking the backdrop", async () => {
+    const user = userEvent.setup();
+    render(<KeyboardShortcutsModal />);
+
+    await user.keyboard("?");
+    const dialogContainer = screen.getByRole("dialog", { name: /keyboard shortcuts/i });
+    expect(dialogContainer).toBeInTheDocument();
+
+    // Click the dialog container itself (which is the backdrop)
+    await user.click(dialogContainer);
+
+    expect(screen.queryByRole("dialog", { name: /keyboard shortcuts/i })).not.toBeInTheDocument();
+  });
+
+  it("does not close when clicking inside the modal content", async () => {
+    const user = userEvent.setup();
+    render(<KeyboardShortcutsModal />);
+
+    await user.keyboard("?");
+    expect(screen.getByRole("dialog", { name: /keyboard shortcuts/i })).toBeInTheDocument();
+
+    // Click on the heading inside the modal
+    const heading = screen.getByRole("heading", { name: "Keyboard Shortcuts" });
+    await user.click(heading);
+
+    expect(screen.getByRole("dialog", { name: /keyboard shortcuts/i })).toBeInTheDocument();
+  });
+
+  it("does not open when '?' is pressed inside an editable element", async () => {
+    const user = userEvent.setup();
+    render(
+      <div>
+        <input type="text" aria-label="test input" />
+        <textarea aria-label="test textarea" />
+        <KeyboardShortcutsModal />
+      </div>
+    );
+
+    const input = screen.getByRole("textbox", { name: "test input" });
+    const textarea = screen.getByRole("textbox", { name: "test textarea" });
+
+    // Focus input and press '?'
+    await user.type(input, "?");
+    expect(screen.queryByRole("dialog", { name: /keyboard shortcuts/i })).not.toBeInTheDocument();
+
+    // Focus textarea and press '?'
+    await user.type(textarea, "?");
+    expect(screen.queryByRole("dialog", { name: /keyboard shortcuts/i })).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Title: fix: mount KeyboardShortcutsModal and remove aspirational shortcuts

## Context: 
The `KeyboardShortcutsModal` component was fully built but never mounted anywhere in the application, rendering its global listeners inactive. Furthermore, the component documented several shortcuts (e.g., Alt+D, Alt+S, Alt+R, /, Alt+N, Alt+W, Alt+C) that were not actually implemented elsewhere in the application, creating a confusing and misleading experience for users. 

## Implementation Details:
*   **Mounted Component:** Imported and added `<KeyboardShortcutsModal />` to `src/components/Layout.tsx` alongside other global elements like `<ConnectWalletModal />` to ensure it is always rendered as part of the app shell.
*   **Removed Unimplemented Shortcuts:** Audited the codebase and removed the aspirational sections ("Navigation", "Streams", and "Recipient") from the `SECTIONS` constant in `KeyboardShortcutsModal.tsx`. Only the actually implemented "Global" shortcuts (`?` to open, `Escape` to close) remain.
*   **Added Comprehensive Tests:** Created `src/components/__tests__/KeyboardShortcutsModal.test.tsx` to cover the opening and closing behaviors of the modal, including a check to ensure `?` does not open the modal when the user's focus is on an editable element (`input` or `textarea`).

## Verification:
*   Ran the complete Vitest test suite (`npm run test`) successfully, demonstrating the modal behaves as expected under all scenarios, and ensuring the new file contributes successfully to test coverage.
*   Verified that the unimplemented shortcut logic no longer appears on the interface, keeping documentation aligned with app functionality.

closes #706 
