### PR TITLE
test(breakpoints): add boundary-condition unit tests for isMobileViewport

### DIFF
--- a/src/lib/__tests__/breakpoints.test.ts
+++ b/src/lib/__tests__/breakpoints.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { isMobileViewport, BREAKPOINT_MD } from '../breakpoints';
+
+describe('isMobileViewport', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe('boundary values around BREAKPOINT_MD', () => {
+    it('returns true just below the breakpoint (767)', () => {
+      expect(isMobileViewport(767)).toBe(true);
+    });
+
+    it('returns false exactly at the breakpoint (768)', () => {
+      expect(isMobileViewport(BREAKPOINT_MD)).toBe(false);
+    });
+
+    it('returns false just above the breakpoint (769)', () => {
+      expect(isMobileViewport(769)).toBe(false);
+    });
+  });
+
+  describe('unusual widths', () => {
+    it('treats 0 as mobile', () => {
+      expect(isMobileViewport(0)).toBe(true);
+    });
+
+    it('treats a very large width as desktop', () => {
+      expect(isMobileViewport(10000)).toBe(false);
+    });
+  });
+
+  describe('default parameter behavior', () => {
+    it('falls back to window.innerWidth when no argument is passed', () => {
+      vi.stubGlobal('innerWidth', 500);
+      expect(isMobileViewport()).toBe(true);
+    });
+
+    it('reflects a desktop-sized window.innerWidth by default', () => {
+      vi.stubGlobal('innerWidth', 1024);
+      expect(isMobileViewport()).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Closes #714

## Summary
Adds a dedicated test file for `src/lib/breakpoints.ts`, closing the coverage
gap called out in #714. `isMobileViewport` had no unit tests despite being a
shared, foundational utility used by `Sidebar.tsx` (and pending `Navbar.tsx`).

## Changes
- Added `src/lib/__tests__/breakpoints.test.ts`
- Tested the exact boundary against the documented contract:
  - `767` → `true`
  - `768` → `false`
  - `769` → `false`
- Added unusual-width cases: `0` and a very large width
- Tested default-parameter behavior by stubbing `window.innerWidth` and
  calling `isMobileViewport()` with no argument

## Testing
- `npx vitest run src/lib/__tests__/breakpoints.test.ts --coverage`
- Coverage on `breakpoints.ts`: <fill in actual % after running>

## Related
Closes #714
<!-- What does this PR change and why? -->

## Changes

<!-- List the key changes made. -->

## Test plan

- [ ] `npm run build` passes (type-check + production build)
- [ ] `npm run test` passes (all unit tests green)
- [ ] `npm run test:coverage` passes (statements/branches/functions/lines ≥ 95%)
- [ ] New code is covered by tests; the coverage include list in `vitest.config.ts` is expanded if new production modules are added

## Coverage gate

CI enforces **95% coverage thresholds** (statements, branches, functions, lines) via
the `coverage` job in `.github/workflows/ci.yml`. The job runs `npm run test:coverage`
and fails the PR check when any threshold is missed. The coverage report is uploaded
as a build artifact for every run.

To add a new production file to the coverage baseline, append it to the `include`
array in `vitest.config.ts` and ensure tests cover it before opening the PR.
