### PR TITLE
fix: guard formatLocalDate against invalid date strings and return fallback

### DIFF
--- a/src/lib/__tests__/formatters.test.ts
+++ b/src/lib/__tests__/formatters.test.ts
@@ -173,6 +173,14 @@ describe("formatLocalDate", () => {
     expect(result).toMatch(/\d/);
     expect(typeof result).toBe("string");
   });
+
+  it('returns fallback for a malformed date string instead of throwing', () => {
+    expect(formatLocalDate("not-a-date")).toBe("Not set");
+  });
+
+  it("returns custom fallback for a malformed date string when provided", () => {
+    expect(formatLocalDate("not-a-date", {}, "N/A")).toBe("N/A");
+  });
 });
 
 // ─── Locale Resilience ────────────────────────────────────────────────────────

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -139,5 +139,7 @@ export function formatLocalDate(
   fallback = "Not set",
 ): string {
   if (!dateString) return fallback;
-  return createDateTimeFormat(options).format(new Date(dateString));
+  const date = new Date(dateString);
+  if (Number.isNaN(date.getTime())) return fallback;
+  return createDateTimeFormat(options).format(date);
 }


### PR DESCRIPTION
closes #728 

Problem
formatLocalDate in src/lib/formatters.ts only checked for falsy input (!dateString). Any malformed-but-truthy date string (e.g. "not-a-date", corrupted API response) would construct a Date with NaN time, then pass it to Intl.DateTimeFormat.format(), which throws RangeError: Invalid time value and crashes the render path.
Fix
Construct the Date before formatting and check Number.isNaN(date.getTime()). If invalid, return the fallback value instead of throwing.
Before:
if (!dateString) return fallback;
return createDateTimeFormat(options).format(new Date(dateString));
After:
if (!dateString) return fallback;
const date = new Date(dateString);
if (Number.isNaN(date.getTime())) return fallback;
return createDateTimeFormat(options).format(date);
Tests added
- formatLocalDate("not-a-date") returns "Not set" (default fallback)
- formatLocalDate("not-a-date", {}, "N/A") returns "N/A" (custom fallback)
Spot-check
CreateStreamModal.tsx uses formatLocalDateTime from createStreamDates.ts, which already guards via parseLocalDateTime(). No other unguarded date-formatting paths found.