### PR TITLE
fix(accessibility): expose Sparkline trend direction to screen readers

### DIFF
--- a/src/components/treasuryOverviewPage/Sparkline.test.tsx
+++ b/src/components/treasuryOverviewPage/Sparkline.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import Sparkline from "./Sparkline";
+
+describe("Sparkline", () => {
+  it("returns null when data has fewer than 2 data points", () => {
+    const { container } = render(<Sparkline data={[10]} />);
+    expect(container.firstChild).toBeNull();
+
+    const { container: emptyContainer } = render(<Sparkline data={[]} />);
+    expect(emptyContainer.firstChild).toBeNull();
+  });
+
+  it("exposes accessible trend label 'Trend: up' when trend is positive", () => {
+    render(<Sparkline data={[10, 20, 30]} />);
+    const sparklineSvg = screen.getByRole("img", { name: "Trend: up" });
+    expect(sparklineSvg).toBeInTheDocument();
+    expect(sparklineSvg).not.toHaveAttribute("aria-hidden");
+    expect(sparklineSvg).toHaveAttribute("aria-label", "Trend: up");
+  });
+
+  it("exposes accessible trend label 'Trend: up' when trend is zero", () => {
+    render(<Sparkline data={[20, 20]} />);
+    const sparklineSvg = screen.getByRole("img", { name: "Trend: up" });
+    expect(sparklineSvg).toBeInTheDocument();
+    expect(sparklineSvg).not.toHaveAttribute("aria-hidden");
+    expect(sparklineSvg).toHaveAttribute("aria-label", "Trend: up");
+  });
+
+  it("exposes accessible trend label 'Trend: down' when trend is negative", () => {
+    render(<Sparkline data={[30, 20, 10]} />);
+    const sparklineSvg = screen.getByRole("img", { name: "Trend: down" });
+    expect(sparklineSvg).toBeInTheDocument();
+    expect(sparklineSvg).not.toHaveAttribute("aria-hidden");
+    expect(sparklineSvg).toHaveAttribute("aria-label", "Trend: down");
+  });
+
+  it("renders polyline points with custom dimensions and color", () => {
+    const { container } = render(
+      <Sparkline data={[0, 100]} width={100} height={50} color="rgb(255, 0, 0)" />
+    );
+    const svg = container.querySelector("svg");
+    expect(svg).toHaveAttribute("width", "100");
+    expect(svg).toHaveAttribute("height", "50");
+
+    const polyline = container.querySelector("polyline");
+    expect(polyline).toHaveAttribute("stroke", "rgb(255, 0, 0)");
+    expect(polyline).toHaveAttribute("points", "0,50 100,0");
+  });
+
+  it("handles identical values with range fallback", () => {
+    const { container } = render(<Sparkline data={[50, 50, 50]} />);
+    const polyline = container.querySelector("polyline");
+    expect(polyline).toBeInTheDocument();
+    // Points should be calculated properly without NaN
+    const points = polyline?.getAttribute("points");
+    expect(points).not.toContain("NaN");
+  });
+});

--- a/src/components/treasuryOverviewPage/Sparkline.tsx
+++ b/src/components/treasuryOverviewPage/Sparkline.tsx
@@ -24,7 +24,7 @@ export default function Sparkline({ data, width = 80, height = 32, color = "var(
     <svg
       width={width}
       height={height}
-      aria-hidden="true"
+      role="img"
       aria-label={`Trend: ${trend >= 0 ? "up" : "down"}`}
       style={{ display: "block" }}
     >

--- a/src/components/treasuryOverviewPage/__tests__/Sparkline.test.tsx
+++ b/src/components/treasuryOverviewPage/__tests__/Sparkline.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import Sparkline from "../Sparkline";
+
+describe("Sparkline", () => {
+  it("returns null when data has fewer than 2 data points", () => {
+    const { container } = render(<Sparkline data={[10]} />);
+    expect(container.firstChild).toBeNull();
+
+    const { container: emptyContainer } = render(<Sparkline data={[]} />);
+    expect(emptyContainer.firstChild).toBeNull();
+  });
+
+  it("exposes accessible trend label 'Trend: up' when trend is positive", () => {
+    render(<Sparkline data={[10, 20, 30]} />);
+    const sparklineSvg = screen.getByRole("img", { name: "Trend: up" });
+    expect(sparklineSvg).toBeInTheDocument();
+    expect(sparklineSvg).not.toHaveAttribute("aria-hidden");
+    expect(sparklineSvg).toHaveAttribute("aria-label", "Trend: up");
+  });
+
+  it("exposes accessible trend label 'Trend: up' when trend is zero", () => {
+    render(<Sparkline data={[20, 20]} />);
+    const sparklineSvg = screen.getByRole("img", { name: "Trend: up" });
+    expect(sparklineSvg).toBeInTheDocument();
+    expect(sparklineSvg).not.toHaveAttribute("aria-hidden");
+    expect(sparklineSvg).toHaveAttribute("aria-label", "Trend: up");
+  });
+
+  it("exposes accessible trend label 'Trend: down' when trend is negative", () => {
+    render(<Sparkline data={[30, 20, 10]} />);
+    const sparklineSvg = screen.getByRole("img", { name: "Trend: down" });
+    expect(sparklineSvg).toBeInTheDocument();
+    expect(sparklineSvg).not.toHaveAttribute("aria-hidden");
+    expect(sparklineSvg).toHaveAttribute("aria-label", "Trend: down");
+  });
+
+  it("renders polyline points with custom dimensions and color", () => {
+    const { container } = render(
+      <Sparkline data={[0, 100]} width={100} height={50} color="rgb(255, 0, 0)" />
+    );
+    const svg = container.querySelector("svg");
+    expect(svg).toHaveAttribute("width", "100");
+    expect(svg).toHaveAttribute("height", "50");
+
+    const polyline = container.querySelector("polyline");
+    expect(polyline).toHaveAttribute("stroke", "rgb(255, 0, 0)");
+    expect(polyline).toHaveAttribute("points", "0,50 100,0");
+  });
+
+  it("handles identical values with range fallback", () => {
+    const { container } = render(<Sparkline data={[50, 50, 50]} />);
+    const polyline = container.querySelector("polyline");
+    expect(polyline).toBeInTheDocument();
+    const points = polyline?.getAttribute("points");
+    expect(points).not.toContain("NaN");
+  });
+});


### PR DESCRIPTION
Closes #724 
fix(accessibility): expose Sparkline trend direction to assistive technology
Description
Fixes an accessibility issue where src/components/treasuryOverviewPage/Sparkline.tsx had aria-hidden="true" set on the <svg> element. This removed the element—and its dynamically calculated aria-label={Trend: ${trend >= 0 ? "up" : "down"}}—from the accessibility tree, leaving screen reader users without trend direction context.
Key Changes
:
Removed aria-hidden="true".
Added role="img" so screen readers correctly identify the SVG graphic with its calculated aria-label (Trend: up or Trend: down).
:
Added unit test suite asserting accessible name presence without aria-hidden across positive, zero, and negative trends.
Verification & Git Operations
Created commit fix(accessibility): expose Sparkline trend direction to screen readers.
Configured current branch upstream and pushed to origin/main.
The push operation has completed successfully and set main to track origin/main.
Summary of Completed Work
Code Fix: Modified  to remove aria-hidden="true" and add role="img", exposing the trend direction (Trend: up / Trend: down) to assistive technology.
Unit Tests: Added  to verify accessible names across up, down, and flat trends.
Git Push: Pushed commit fe3fbe8 to origin/main with upstream tracking configured.