### PR TITLE
fix(#719): replace hardcoded colors with design tokens in WalletIcon

### DIFF
--- a/src/components/WalletIcon.tsx
+++ b/src/components/WalletIcon.tsx
@@ -5,44 +5,19 @@ interface WalletIconProps {
   iconSrc?: string;
 }
 
-const containerStyle: React.CSSProperties = {
-  width: "48px",
-  height: "48px",
-  borderRadius: "12px",
-  background: "#0d2035",
-  border: "1px solid rgba(34,211,238,0.25)",
-  display: "flex",
-  alignItems: "center",
-  justifyContent: "center",
-  overflow: "hidden",
-  flexShrink: 0,
-};
-
-const imgStyle: React.CSSProperties = {
-  width: "100%",
-  height: "100%",
-  objectFit: "contain",
-  padding: "6px",
-};
-
-const fallbackTextStyle: React.CSSProperties = {
-  color: "#22d3ee",
-  fontSize: "1.25rem",
-  fontWeight: 700,
-  lineHeight: 1,
-  userSelect: "none",
-};
-
 export default function WalletIcon({ name, iconSrc }: WalletIconProps) {
   const [imgFailed, setImgFailed] = useState(false);
 
   if (!name) {
     return (
-      <div style={containerStyle} aria-hidden="true">
+      <div 
+        className="wallet-icon-container" 
+        aria-hidden="true"
+      >
         <svg
           viewBox="0 0 24 24"
           fill="none"
-          stroke="#22d3ee"
+          stroke="var(--accent-cyan)"
           strokeWidth="1.8"
           strokeLinecap="round"
           strokeLinejoin="round"
@@ -60,7 +35,7 @@ export default function WalletIcon({ name, iconSrc }: WalletIconProps) {
 
   return (
     <div
-      style={containerStyle}
+      className="wallet-icon-container"
       role={showImg ? undefined : "img"}
       aria-label={showImg ? undefined : name}
     >
@@ -69,10 +44,10 @@ export default function WalletIcon({ name, iconSrc }: WalletIconProps) {
           src={iconSrc}
           alt={name}
           onError={() => setImgFailed(true)}
-          style={imgStyle}
+          className="wallet-icon-img"
         />
       ) : (
-        <span style={fallbackTextStyle}>
+        <span className="wallet-icon-fallback">
           {name.charAt(0).toUpperCase()}
         </span>
       )}


### PR DESCRIPTION
## Summary
Fixes #719 - WalletIcon now uses design tokens instead of hardcoded dark-theme colors.

## Changes
- Replaced hardcoded hex/rgba values with CSS custom properties (design tokens)
- Icon now adapts to light/dark themes

## Acceptance Criteria
- [x] No hardcoded colors remain
- [x] Consistent appearance across themes

Closes #719