### PR TITLE
test(CreateStreamModal): add failure-path test for useTransactionStat…

### DIFF
--- a/src/components/__tests__/CreateStreamModal.failure.test.tsx
+++ b/src/components/__tests__/CreateStreamModal.failure.test.tsx
@@ -169,4 +169,37 @@ describe('CreateStreamModal submit failure handling', () => {
 
     expect(mockedCreateStream).toHaveBeenCalledTimes(1);
   });
+
+  it('does not call onStreamCreated or close modal when transaction status polling fails on-chain', async () => {
+    mockedCreateStream.mockResolvedValue({
+      status: 'SUCCESS',
+      txHash: 'tx-failed-hash-123',
+    } as any);
+    mockedGetTransactionStatus.mockResolvedValue('failed');
+
+    const onClose = vi.fn();
+    const onStreamCreated = vi.fn();
+
+    const { container } = render(
+      <CreateStreamModal
+        isOpen={true}
+        onClose={onClose}
+        onStreamCreated={onStreamCreated}
+      />,
+    );
+
+    advanceToStep3(container);
+    fireEvent.click(
+      within(container).getByRole('button', { name: /^create stream$/i }),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Transaction failed before confirmation.'),
+      ).toBeInTheDocument();
+    });
+
+    expect(onStreamCreated).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
Closes #645 

## Description
Trace and verify `CreateStreamModal.tsx` submission behavior regarding optimistic updates and add failure-path test coverage for on-chain transaction failure via `useTransactionStatus`.

## Analysis Findings
- `CreateStreamModal.tsx` does **not** perform any optimistic list updates on submission.
- On submit, `CreateStreamModal` sends the creation transaction on-chain via `createStream()` and sets `submittedTxHash`.
- Status polling is driven by `useTransactionStatus`.
- The completion callback `onStreamCreated` (and closing of the modal) is **only** triggered when `transactionStatus.status === "confirmed"`.
- If submission fails or `useTransactionStatus` reports `"failed"`, `onStreamCreated` is never called, ensuring no phantom stream entries persist in `RecentStreams` or UI state.

## Changes Included
- Added automated failure-path unit test in `src/components/__tests__/CreateStreamModal.failure.test.tsx` simulating transaction failure reported via `useTransactionStatus` polling (`getTransactionStatus` returning `"failed"`).
- Verified that `onStreamCreated` and `onClose` are not invoked during failure, keeping the modal open with the failure alert displayed.

## Acceptance Criteria
- [x] Optimistic-update behavior (if any) is identified and documented.
- [x] Failure-path rollback is tested.
- [x] No phantom UI state persists after a failed submission.

## Test Verification
- All 59 unit tests across 8 `CreateStreamModal` test files (`CreateStreamModal.failure.test.tsx`, `CreateStreamModal.transaction.test.tsx`, `CreateStreamModal.dates.test.tsx`, etc.) pass cleanly.