### PR TITLE
fix(ui): use design tokens for metrics loading, error, and empty states (#701)

### DIFF
--- a/src/components/treasuryOverviewPage/Metrics.tsx
+++ b/src/components/treasuryOverviewPage/Metrics.tsx
@@ -10,7 +10,7 @@ interface MetricsProps {
 export default function Metrics({ metrics, loading, error }: MetricsProps) {
   if (loading) {
     return (
-      <p role="status" className="text-sm text-gray-500">
+      <p role="status" className="text-sm" style={{ color: "var(--color-text-secondary)" }}>
         Loading treasury metrics...
       </p>
     );
@@ -18,7 +18,7 @@ export default function Metrics({ metrics, loading, error }: MetricsProps) {
 
   if (error) {
     return (
-      <p role="alert" className="text-sm text-red-600">
+      <p role="alert" className="text-sm" style={{ color: "var(--color-danger)" }}>
         {error}
       </p>
     );
@@ -32,7 +32,7 @@ export default function Metrics({ metrics, loading, error }: MetricsProps) {
       {metrics.length > 0 ? (
         metrics.map((m: Metric, i: number) => <MetricCard key={i} {...m} />)
       ) : (
-        <p className="text-sm text-gray-500">No treasury metrics available.</p>
+        <p className="text-sm" style={{ color: "var(--color-text-secondary)" }}>No treasury metrics available.</p>
       )}
     </section>
   );

--- a/src/components/treasuryOverviewPage/__tests__/Metrics.test.tsx
+++ b/src/components/treasuryOverviewPage/__tests__/Metrics.test.tsx
@@ -76,4 +76,30 @@ describe("Metrics", () => {
       });
     }
   });
+
+  describe("design token styling (no hardcoded Tailwind color classes)", () => {
+    it("uses var(--color-text-secondary) for loading state and does not use hardcoded color classes", () => {
+      render(<Metrics metrics={[]} loading={true} />);
+      const statusEl = screen.getByRole("status");
+
+      expect(statusEl).toHaveStyle({ color: "var(--color-text-secondary)" });
+      expect(statusEl.className).not.toMatch(/text-gray-500|text-red-600/);
+    });
+
+    it("uses var(--color-danger) for error state and does not use hardcoded color classes", () => {
+      render(<Metrics metrics={[]} error="Failed to fetch metrics" />);
+      const alertEl = screen.getByRole("alert");
+
+      expect(alertEl).toHaveStyle({ color: "var(--color-danger)" });
+      expect(alertEl.className).not.toMatch(/text-gray-500|text-red-600/);
+    });
+
+    it("uses var(--color-text-secondary) for empty state and does not use hardcoded color classes", () => {
+      render(<Metrics metrics={[]} />);
+      const emptyEl = screen.getByText("No treasury metrics available.");
+
+      expect(emptyEl).toHaveStyle({ color: "var(--color-text-secondary)" });
+      expect(emptyEl.className).not.toMatch(/text-gray-500|text-red-600/);
+    });
+  });
 });


### PR DESCRIPTION
Closes #701

## Summary

Replaced hardcoded Tailwind gray/red text classes (`text-gray-500`, `text-red-600`) in `Metrics.tsx` with design tokens (`var(--color-text-secondary)`, `var(--color-danger)`). This ensures the loading, error, and empty states adapt to the active theme, matching `MetricCard.tsx`.

## Changes

- **`src/components/treasuryOverviewPage/Metrics.tsx`**: Replaced raw Tailwind color classes with inline design token styles for loading, error, and empty states.
- **`src/components/treasuryOverviewPage/__tests__/Metrics.test.tsx`**: Added regression tests verifying that hardcoded Tailwind color classes are removed and design tokens are applied with 100% test coverage.

## Test plan

- [x] `npm run build` passes (type-check + production build)
- [x] `npm run test` passes (all unit tests green)
- [x] `npm run test:coverage` passes (statements/branches/functions/lines ≥ 95%)
- [x] New code is covered by tests; the coverage include list in `vitest.config.ts` is expanded if new production modules are added

## Coverage gate

CI enforces **95% coverage thresholds** (statements, branches, functions, lines) via the `coverage` job in `.github/workflows/ci.yml`.