### PR TITLE
test(sorobanTxStatus): add unit tests for soroban rpc status source

### DIFF
--- a/src/lib/__tests__/sorobanTxStatus.test.ts
+++ b/src/lib/__tests__/sorobanTxStatus.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createSorobanRpcStatusSource } from "../sorobanTxStatus";
+
+const RPC_URL = "https://rpc.example.com";
+const TX_HASH = "abcdef1234567890";
+
+/**
+ * Build a minimal fetch-compatible Response for a Soroban RPC getTransaction reply.
+ */
+function makeRpcResponse(status: string, opts?: { ok?: boolean; httpStatus?: number }) {
+  const ok = opts?.ok ?? true;
+  const httpStatus = opts?.httpStatus ?? 200;
+  return Promise.resolve(
+    new Response(
+      JSON.stringify({ jsonrpc: "2.0", id: 1, result: { status } }),
+      { status: httpStatus, headers: { "Content-Type": "application/json" } },
+    ) as Response & { ok: boolean },
+  );
+}
+
+/**
+ * Build a fetch Response with no `result` field in the body (malformed).
+ */
+function makeMissingResultResponse() {
+  return Promise.resolve(
+    new Response(
+      JSON.stringify({ jsonrpc: "2.0", id: 1 }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    ),
+  );
+}
+
+/**
+ * Build a non-OK HTTP response (e.g. 503 Service Unavailable).
+ */
+function makeErrorResponse(httpStatus = 503) {
+  return Promise.resolve(
+    new Response("Service Unavailable", { status: httpStatus }),
+  );
+}
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("createSorobanRpcStatusSource", () => {
+  describe("status mapping", () => {
+    it('maps SUCCESS → "confirmed"', async () => {
+      vi.mocked(fetch).mockReturnValueOnce(makeRpcResponse("SUCCESS"));
+
+      const source = createSorobanRpcStatusSource(RPC_URL);
+      const signal = new AbortController().signal;
+      const result = await source(TX_HASH, { attempt: 1, signal });
+
+      expect(result).toBe("confirmed");
+    });
+
+    it('maps FAILED → "failed"', async () => {
+      vi.mocked(fetch).mockReturnValueOnce(makeRpcResponse("FAILED"));
+
+      const source = createSorobanRpcStatusSource(RPC_URL);
+      const signal = new AbortController().signal;
+      const result = await source(TX_HASH, { attempt: 1, signal });
+
+      expect(result).toBe("failed");
+    });
+
+    it('maps NOT_FOUND → "pending"', async () => {
+      vi.mocked(fetch).mockReturnValueOnce(makeRpcResponse("NOT_FOUND"));
+
+      const source = createSorobanRpcStatusSource(RPC_URL);
+      const signal = new AbortController().signal;
+      const result = await source(TX_HASH, { attempt: 1, signal });
+
+      expect(result).toBe("pending");
+    });
+
+    it('maps an unrecognised/future status value → "pending" (default case)', async () => {
+      // Simulate a hypothetical future status the switch doesn't explicitly handle.
+      vi.mocked(fetch).mockReturnValueOnce(makeRpcResponse("QUEUED" as "NOT_FOUND"));
+
+      const source = createSorobanRpcStatusSource(RPC_URL);
+      const signal = new AbortController().signal;
+      const result = await source(TX_HASH, { attempt: 1, signal });
+
+      expect(result).toBe("pending");
+    });
+  });
+
+  describe("error paths", () => {
+    it("throws with a descriptive message on a non-OK HTTP response", async () => {
+      vi.mocked(fetch).mockReturnValueOnce(makeErrorResponse(503));
+
+      const source = createSorobanRpcStatusSource(RPC_URL);
+      const signal = new AbortController().signal;
+
+      await expect(source(TX_HASH, { attempt: 1, signal })).rejects.toThrow(
+        "Soroban RPC error: 503",
+      );
+    });
+
+    it("throws with a descriptive message when the response body is missing `result`", async () => {
+      vi.mocked(fetch).mockReturnValueOnce(makeMissingResultResponse());
+
+      const source = createSorobanRpcStatusSource(RPC_URL);
+      const signal = new AbortController().signal;
+
+      await expect(source(TX_HASH, { attempt: 1, signal })).rejects.toThrow(
+        "Invalid Soroban RPC response",
+      );
+    });
+  });
+
+  describe("AbortSignal forwarding", () => {
+    it("passes the AbortSignal through to fetch", async () => {
+      vi.mocked(fetch).mockReturnValueOnce(makeRpcResponse("SUCCESS"));
+
+      const controller = new AbortController();
+      const source = createSorobanRpcStatusSource(RPC_URL);
+      await source(TX_HASH, { attempt: 1, signal: controller.signal });
+
+      expect(fetch).toHaveBeenCalledOnce();
+      const [, fetchInit] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit];
+      expect(fetchInit.signal).toBe(controller.signal);
+    });
+
+    it("forwards the correct RPC URL and request body to fetch", async () => {
+      vi.mocked(fetch).mockReturnValueOnce(makeRpcResponse("SUCCESS"));
+
+      const source = createSorobanRpcStatusSource(RPC_URL);
+      const signal = new AbortController().signal;
+      await source(TX_HASH, { attempt: 1, signal });
+
+      const [url, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit];
+      expect(url).toBe(RPC_URL);
+      expect(JSON.parse(init.body as string)).toMatchObject({
+        method: "getTransaction",
+        params: { hash: TX_HASH },
+      });
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -41,6 +41,7 @@ export default defineConfig({
         "src/lib/formatters.ts",
         "src/lib/api/newsletterService.ts",
         "src/lib/recentStreamMapper.ts",
+        "src/lib/sorobanTxStatus.ts",
         "src/theme/ThemeProvider.tsx",
       ],
       exclude: ["src/components/**/*.test.tsx", "src/theme/**/__tests__/**"],


### PR DESCRIPTION
closes #686

# Summary

Adds a new Soroban RPC transaction status source module (`sorobanTxStatus.ts`) to the coverage baseline and introduces a comprehensive test suite for it. The tests verify correct status mapping from Soroban RPC responses to internal status values, proper error handling for non-OK HTTP responses and malformed payloads, and correct forwarding of `AbortSignal` and request parameters to `fetch`.

## Changes

- **`src/lib/__tests__/sorobanTxStatus.test.ts`** *(new file)*: Adds 146 lines of unit tests for `createSorobanRpcStatusSource`, covering:
  - Status mapping: `SUCCESS` → `"confirmed"`, `FAILED` → `"failed"`, `NOT_FOUND` → `"pending"`, and unrecognised/future statuses → `"pending"` (default case)
  - Error paths: non-OK HTTP responses (e.g. 503) throw a descriptive `"Soroban RPC error: <status>"` message; responses missing the `result` field throw `"Invalid Soroban RPC response"`
  - `AbortSignal` forwarding: confirms the signal is passed through to `fetch` and that the correct RPC URL and JSON-RPC request body (`method: "getTransaction"`, `params: { hash }`) are sent

- **`vitest.config.ts`**: Appends `"src/lib/sorobanTxStatus.ts"` to the coverage `include` array so the new production module is subject to the 95% coverage gate enforced in CI.

## Test plan

- [ ] `npm run build` passes (type-check + production build)
- [ ] `npm run test` passes (all unit tests green)
- [ ] `npm run test:coverage` passes (statements/branches/functions/lines ≥ 95%)
- [ ] New code is covered by tests; the coverage include list in `vitest.config.ts` is expanded if new production modules are added

## Coverage gate

CI enforces **95% coverage thresholds** (statements, branches, functions, lines) via
the `coverage` job in `.github/workflows/ci.yml`. The job runs `npm run test:coverage`
and fails the PR check when any threshold is missed. The coverage report is uploaded
as a build artifact for every run.

To add a new production file to the coverage baseline, append it to the `include`
array in `vitest.config.ts` and ensure tests cover it before opening the PR.