### PR TITLE
Fix/landing Closes #756

### DIFF
--- a/src/components/landing-page/HeroSection.tsx
+++ b/src/components/landing-page/HeroSection.tsx
@@ -42,11 +42,11 @@ export default function HeroSection({ theme = "light" }: HeroSectionProps) {
     >
       {/* Background Decorative Elements */}
       <div className="absolute inset-0 overflow-hidden pointer-events-none">
-        <div 
+        <div
           className={`absolute -top-24 -left-24 w-96 h-96 rounded-full blur-[120px] opacity-20 ${isDark ? "bg-cyan-500" : "bg-cyan-300"}`}
           style={{ animation: "pulse 10s infinite alternate" }}
         />
-        <div 
+        <div
           className={`absolute top-1/2 -right-24 w-80 h-80 rounded-full blur-[100px] opacity-10 ${isDark ? "bg-emerald-500" : "bg-emerald-300"}`}
           style={{ animation: "pulse 8s infinite alternate-reverse" }}
         />
@@ -55,7 +55,9 @@ export default function HeroSection({ theme = "light" }: HeroSectionProps) {
       <div className="relative z-10 mx-auto max-w-7xl px-6 lg:px-12 py-20">
         <div className="grid lg:grid-cols-2 gap-16 items-center">
           {/* ─── LEFT: Marketing Content ─── */}
-          <div className={`flex flex-col gap-8 transition-all duration-1000 ${mounted ? 'opacity-100 translate-x-0' : 'opacity-0 -translate-x-8'}`}>
+          <div
+            className={`flex flex-col gap-8 transition-all duration-1000 ${mounted ? "opacity-100 translate-x-0" : "opacity-0 -translate-x-8"}`}
+          >
             {/* Built on Stellar Tag */}
             <div className="flex items-center gap-2 self-start animate-fade-in">
               <div
@@ -85,14 +87,16 @@ export default function HeroSection({ theme = "light" }: HeroSectionProps) {
                   ${isDark ? "text-white" : "text-slate-900"}
                 `}
               >
-                The future of <br/>
+                The future of <br />
                 <span className="bg-gradient-to-r from-cyan-400 to-emerald-400 bg-clip-text text-transparent">
                   Treasury Streaming
                 </span>
               </h1>
-              <p className={`text-heading-3 max-w-xl ${isDark ? "text-slate-400" : "text-slate-600"}`}>
-                Real-time USDC infrastructure for DAOs, grants, and ecosystem funds. 
-                Automate your payouts with second-by-second precision.
+              <p
+                className={`text-heading-3 max-w-xl ${isDark ? "text-slate-400" : "text-slate-600"}`}
+              >
+                Real-time USDC infrastructure for DAOs, grants, and ecosystem
+                funds. Automate your payouts with second-by-second precision.
               </p>
             </div>
 
@@ -103,15 +107,16 @@ export default function HeroSection({ theme = "light" }: HeroSectionProps) {
                 ${isDark ? "text-slate-500" : "text-slate-500"}
               `}
             >
-              Move beyond manual monthly transfers. Fluxora provides high-integrity 
-              streaming that builds trust through transparency and predictable liquidity.
+              Move beyond manual monthly transfers. Fluxora provides
+              high-integrity streaming that builds trust through transparency
+              and predictable liquidity.
             </p>
 
             {/* Primary CTA Flow */}
             <div className="flex flex-wrap items-center gap-5 mt-4">
               <button
                 className="ui-primary-cta group relative overflow-hidden rounded-2xl px-8 py-4 text-lg font-bold shadow-[0_10px_30px_-10px_rgba(6,182,212,0.5)] transition-all duration-300 hover:scale-[1.02] active:scale-95"
-                onClick={() => window.location.href = "/connect-wallet"}
+                onClick={() => (window.location.href = "/connect-wallet")}
               >
                 <span className="relative z-10 flex items-center gap-2">
                   Launch App
@@ -134,41 +139,23 @@ export default function HeroSection({ theme = "light" }: HeroSectionProps) {
                 <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/20 to-transparent -translate-x-full group-hover:translate-x-full transition-transform duration-1000" />
               </button>
 
-              <button
-                className="flex cursor-pointer items-center gap-3 rounded-2xl border px-8 py-4 text-lg font-bold transition-all duration-300 active:scale-95"
-                style={{
-                  borderColor: "var(--color-border-default)",
-                  background: "var(--color-surface-default)",
-                  color: "var(--color-text-secondary)",
-                  boxShadow: "var(--shadow-sm)",
-                }}
-                onMouseEnter={(e) => {
-                  (e.currentTarget as HTMLButtonElement).style.borderColor = "var(--color-border-secondary)";
-                }}
-                onMouseLeave={(e) => {
-                  (e.currentTarget as HTMLButtonElement).style.borderColor = "var(--color-border-default)";
-                }}
-                onClick={() => alert("Watch demo clicked")}
-              >
-                <div className="flex h-6 w-6 items-center justify-center rounded-full bg-cyan-500/10 text-cyan-500">
-                  <svg
-                    aria-hidden="true"
-                    xmlns="http://www.w3.org/2000/svg"
-                    width="14"
-                    height="14"
-                    viewBox="0 0 24 24"
-                    fill="currentColor"
-                  >
-                    <polygon points="5 3 19 12 5 21 5 3" />
-                  </svg>
-                </div>
-                Watch Demo
-              </button>
+              {/*
+               * A "Watch Demo" CTA previously lived here but only triggered
+               * window.alert("Watch demo clicked") — a shipped development
+               * placeholder with no real demo content behind it. Per the
+               * fix for that issue, it was removed rather than replaced with
+               * another placeholder. Re-add it once a real demo asset
+               * (video, walkthrough, or dedicated section) exists to link to,
+               * and never wire it to alert()/confirm() — see
+               * HeroSection.test.tsx's regression test guarding against that.
+               */}
             </div>
 
             {/* Social Proof / Metrics */}
             {HERO_METRICS.length > 0 && (
-              <div className={`flex flex-wrap gap-12 mt-8 pt-8 border-t ${isDark ? 'border-slate-800/50' : 'border-slate-200/50'}`}>
+              <div
+                className={`flex flex-wrap gap-12 mt-8 pt-8 border-t ${isDark ? "border-slate-800/50" : "border-slate-200/50"}`}
+              >
                 {HERO_METRICS.map(({ value, label }) => (
                   <div key={label} className="flex flex-col gap-1 group">
                     <span
@@ -179,7 +166,9 @@ export default function HeroSection({ theme = "light" }: HeroSectionProps) {
                     >
                       {value}
                     </span>
-                    <span className={`text-label-sm uppercase tracking-widest ${isDark ? "text-slate-500" : "text-slate-400"}`}>
+                    <span
+                      className={`text-label-sm uppercase tracking-widest ${isDark ? "text-slate-500" : "text-slate-400"}`}
+                    >
                       {label}
                     </span>
                   </div>
@@ -189,7 +178,9 @@ export default function HeroSection({ theme = "light" }: HeroSectionProps) {
           </div>
 
           {/* ─── RIGHT: Glassmorphic Stream Card ─── */}
-          <div className={`relative flex justify-center lg:justify-end transition-all duration-1000 delay-300 ${mounted ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-12'}`}>
+          <div
+            className={`relative flex justify-center lg:justify-end transition-all duration-1000 delay-300 ${mounted ? "opacity-100 translate-y-0" : "opacity-0 translate-y-12"}`}
+          >
             {/* Animated Glow Rings */}
             <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
               <div className="w-[120%] h-[120%] rounded-full opacity-[0.03] border border-cyan-500 animate-spin-slow" />
@@ -232,35 +223,51 @@ export default function HeroSection({ theme = "light" }: HeroSectionProps) {
                     </svg>
                   </div>
                   <div className="flex flex-col">
-                    <p className={`text-heading-4 leading-none mb-1.5 ${isDark ? "text-white" : "text-slate-800"}`}>
+                    <p
+                      className={`text-heading-4 leading-none mb-1.5 ${isDark ? "text-white" : "text-slate-800"}`}
+                    >
                       Stellar Growth Grant
                     </p>
                     <div className="flex items-center gap-2">
-                       <span className={`text-sm font-medium ${isDark ? "text-slate-400" : "text-slate-500"}`}>from SCF Treasury</span>
-                       <span className="h-1 w-1 rounded-full bg-slate-500" />
-                       <span className="text-xs font-bold text-cyan-500 uppercase tracking-tighter">Verified</span>
+                      <span
+                        className={`text-sm font-medium ${isDark ? "text-slate-400" : "text-slate-500"}`}
+                      >
+                        from SCF Treasury
+                      </span>
+                      <span className="h-1 w-1 rounded-full bg-slate-500" />
+                      <span className="text-xs font-bold text-cyan-500 uppercase tracking-tighter">
+                        Verified
+                      </span>
                     </div>
                   </div>
                 </div>
                 <div className="flex flex-col items-end">
-                   <div className="inline-flex items-center gap-1.5 rounded-full bg-emerald-500/10 px-3 py-1 text-[10px] font-black uppercase tracking-widest text-emerald-500 border border-emerald-500/20">
-                      <span className="h-1.5 w-1.5 rounded-full bg-emerald-500 animate-pulse" />
-                      Live
-                   </div>
+                  <div className="inline-flex items-center gap-1.5 rounded-full bg-emerald-500/10 px-3 py-1 text-[10px] font-black uppercase tracking-widest text-emerald-500 border border-emerald-500/20">
+                    <span className="h-1.5 w-1.5 rounded-full bg-emerald-500 animate-pulse" />
+                    Live
+                  </div>
                 </div>
               </div>
 
               {/* Stream Visualizer */}
-              <div className={`rounded-3xl p-6 mb-8 ${isDark ? "bg-black/20" : "bg-slate-50/50"}`}>
+              <div
+                className={`rounded-3xl p-6 mb-8 ${isDark ? "bg-black/20" : "bg-slate-50/50"}`}
+              >
                 <div className="flex flex-col gap-1 mb-6">
-                  <span className={`text-xs font-bold uppercase tracking-widest ${isDark ? "text-slate-500" : "text-slate-400"}`}>
+                  <span
+                    className={`text-xs font-bold uppercase tracking-widest ${isDark ? "text-slate-500" : "text-slate-400"}`}
+                  >
                     Streaming to you
                   </span>
                   <div className="flex items-baseline gap-2">
-                    <span className={`text-5xl font-black tabular-nums tracking-tighter ${isDark ? "text-white" : "text-slate-900"}`}>
+                    <span
+                      className={`text-5xl font-black tabular-nums tracking-tighter ${isDark ? "text-white" : "text-slate-900"}`}
+                    >
                       24,812<span className="opacity-30">.42</span>
                     </span>
-                    <span className={`text-xl font-bold uppercase ${isDark ? "text-slate-500" : "text-slate-400"}`}>
+                    <span
+                      className={`text-xl font-bold uppercase ${isDark ? "text-slate-500" : "text-slate-400"}`}
+                    >
                       USDC
                     </span>
                   </div>
@@ -269,11 +276,21 @@ export default function HeroSection({ theme = "light" }: HeroSectionProps) {
                 {/* Progress Visual */}
                 <div className="space-y-3">
                   <div className="flex justify-between items-end">
-                    <span className={`text-xs font-bold ${isDark ? "text-slate-400" : "text-slate-500"}`}>Progress to Milestone</span>
-                    <span className={`text-xs font-black ${isDark ? "text-white" : "text-slate-900"}`}>67.4%</span>
+                    <span
+                      className={`text-xs font-bold ${isDark ? "text-slate-400" : "text-slate-500"}`}
+                    >
+                      Progress to Milestone
+                    </span>
+                    <span
+                      className={`text-xs font-black ${isDark ? "text-white" : "text-slate-900"}`}
+                    >
+                      67.4%
+                    </span>
                   </div>
-                  <div className={`h-3 w-full rounded-full overflow-hidden p-1 ${isDark ? "bg-white/5" : "bg-slate-200/50"}`}>
-                    <div 
+                  <div
+                    className={`h-3 w-full rounded-full overflow-hidden p-1 ${isDark ? "bg-white/5" : "bg-slate-200/50"}`}
+                  >
+                    <div
                       className="h-full rounded-full bg-gradient-to-r from-cyan-500 to-emerald-500 relative"
                       style={{ width: "67.4%" }}
                     >
@@ -281,21 +298,59 @@ export default function HeroSection({ theme = "light" }: HeroSectionProps) {
                     </div>
                   </div>
                   <div className="flex justify-between mt-2">
-                    <span className={`text-[10px] font-bold ${isDark ? "text-slate-600" : "text-slate-400"}`}>EST. BALANCE</span>
-                    <span className={`text-[10px] font-bold ${isDark ? "text-slate-600" : "text-slate-400"}`}>36,800.00 USDC</span>
+                    <span
+                      className={`text-[10px] font-bold ${isDark ? "text-slate-600" : "text-slate-400"}`}
+                    >
+                      EST. BALANCE
+                    </span>
+                    <span
+                      className={`text-[10px] font-bold ${isDark ? "text-slate-600" : "text-slate-400"}`}
+                    >
+                      36,800.00 USDC
+                    </span>
                   </div>
                 </div>
               </div>
 
               {/* Action Cards Grid */}
               <div className="grid grid-cols-2 gap-4">
-                <div className={`group cursor-pointer rounded-2xl border p-4 transition-all duration-300 hover:scale-[1.02] ${isDark ? "bg-white/[0.03] border-white/5 hover:bg-white/[0.06]" : "bg-white border-slate-100 hover:border-cyan-200"}`}>
-                  <p className={`text-[10px] font-bold uppercase tracking-widest mb-1 ${isDark ? "text-slate-500" : "text-slate-400"}`}>Rate</p>
-                  <p className={`text-xl font-black ${isDark ? "text-white" : "text-slate-900"}`}>12.5 <span className={`text-xs font-bold ${isDark ? "text-slate-400" : "text-slate-500"}`}>USDC/hr</span></p>
+                <div
+                  className={`group cursor-pointer rounded-2xl border p-4 transition-all duration-300 hover:scale-[1.02] ${isDark ? "bg-white/[0.03] border-white/5 hover:bg-white/[0.06]" : "bg-white border-slate-100 hover:border-cyan-200"}`}
+                >
+                  <p
+                    className={`text-[10px] font-bold uppercase tracking-widest mb-1 ${isDark ? "text-slate-500" : "text-slate-400"}`}
+                  >
+                    Rate
+                  </p>
+                  <p
+                    className={`text-xl font-black ${isDark ? "text-white" : "text-slate-900"}`}
+                  >
+                    12.5{" "}
+                    <span
+                      className={`text-xs font-bold ${isDark ? "text-slate-400" : "text-slate-500"}`}
+                    >
+                      USDC/hr
+                    </span>
+                  </p>
                 </div>
-                <div className={`group cursor-pointer rounded-2xl border p-4 transition-all duration-300 hover:scale-[1.02] ${isDark ? "bg-white/[0.03] border-white/5 hover:bg-white/[0.06]" : "bg-white border-slate-100 hover:border-emerald-200"}`}>
-                  <p className={`text-[10px] font-bold uppercase tracking-widest mb-1 ${isDark ? "text-slate-500" : "text-slate-400"}`}>Ends In</p>
-                  <p className={`text-xl font-black ${isDark ? "text-white" : "text-slate-900"}`}>14 <span className={`text-xs font-bold ${isDark ? "text-slate-400" : "text-slate-500"}`}>days</span></p>
+                <div
+                  className={`group cursor-pointer rounded-2xl border p-4 transition-all duration-300 hover:scale-[1.02] ${isDark ? "bg-white/[0.03] border-white/5 hover:bg-white/[0.06]" : "bg-white border-slate-100 hover:border-emerald-200"}`}
+                >
+                  <p
+                    className={`text-[10px] font-bold uppercase tracking-widest mb-1 ${isDark ? "text-slate-500" : "text-slate-400"}`}
+                  >
+                    Ends In
+                  </p>
+                  <p
+                    className={`text-xl font-black ${isDark ? "text-white" : "text-slate-900"}`}
+                  >
+                    14{" "}
+                    <span
+                      className={`text-xs font-bold ${isDark ? "text-slate-400" : "text-slate-500"}`}
+                    >
+                      days
+                    </span>
+                  </p>
                 </div>
               </div>
 

--- a/src/components/landing-page/__tests__/HeroSection.test.tsx
+++ b/src/components/landing-page/__tests__/HeroSection.test.tsx
@@ -82,7 +82,9 @@ describe("HeroSection CTAs — no placeholder alert()/confirm() dialogs", () => 
 
   it('does not render a "Watch Demo" button', () => {
     render(<HeroSection />);
-    expect(screen.queryByRole("button", { name: /watch demo/i })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /watch demo/i }),
+    ).not.toBeInTheDocument();
   });
 
   it("never calls window.alert or window.confirm when every button in the hero is clicked", async () => {

--- a/src/components/landing-page/__tests__/HeroSection.test.tsx
+++ b/src/components/landing-page/__tests__/HeroSection.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it, beforeEach } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, beforeEach, vi, afterEach } from "vitest";
 import HeroSection, { HERO_METRICS } from "../HeroSection";
 
 describe("HeroSection metrics rendering", () => {
@@ -55,5 +56,49 @@ describe("HeroSection metrics rendering", () => {
     expect(screen.queryByText("Streamed")).not.toBeInTheDocument();
     expect(screen.queryByText("Active Streams")).not.toBeInTheDocument();
     expect(screen.queryByText("Verified DAOs")).not.toBeInTheDocument();
+  });
+});
+
+describe("HeroSection CTAs — no placeholder alert()/confirm() dialogs", () => {
+  // Regression coverage for a shipped placeholder bug: the "Watch Demo" CTA
+  // used to call window.alert("Watch demo clicked") instead of doing
+  // anything real. The button has been removed until a real demo asset
+  // exists. These tests guard against either (a) the placeholder button
+  // coming back, or (b) any future CTA in this section being wired to a
+  // bare alert()/confirm() call instead of real behavior.
+
+  let alertSpy: ReturnType<typeof vi.spyOn>;
+  let confirmSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
+    confirmSpy = vi.spyOn(window, "confirm").mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    alertSpy.mockRestore();
+    confirmSpy.mockRestore();
+  });
+
+  it('does not render a "Watch Demo" button', () => {
+    render(<HeroSection />);
+    expect(screen.queryByRole("button", { name: /watch demo/i })).not.toBeInTheDocument();
+  });
+
+  it("never calls window.alert or window.confirm when every button in the hero is clicked", async () => {
+    const user = userEvent.setup();
+
+    render(<HeroSection />);
+
+    const buttons = screen.getAllByRole("button");
+    expect(buttons.length).toBeGreaterThan(0);
+
+    for (const button of buttons) {
+      // eslint-disable-next-line no-await-in-loop
+      await user.click(button);
+    }
+
+    expect(alertSpy).not.toHaveBeenCalled();
+    expect(confirmSpy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
Removes a shipped development placeholder from the public landing page: the "Watch Demo" button in HeroSection.tsx called window.alert("Watch demo clicked") instead of showing any real demo content. It sat right next to the primary "Launch App" CTA with equal visual weight, so visitors clicking it got a jarring native popup instead of a working feature — undermining trust on the app's first-impression surface.

No demo video, walkthrough, or dedicated demo section exists anywhere in the codebase to link or scroll to instead, so per the issue's own fallback guidance, the button is removed rather than replaced with another placeholder.
<!-- What does this PR change and why? -->

## Changes
Removed the "Watch Demo" <button> and its onClick={() => alert("Watch demo clicked")} handler from src/components/landing-page/HeroSection.tsx
Left an inline comment explaining why it was removed and noting it should be re-added once real demo content exists (video, walkthrough, or dedicated section)
Added two regression tests to HeroSection.test.tsx:
Asserts no "Watch Demo" button is rendered
Clicks every button in the rendered hero section and asserts window.alert/window.confirm are never called — deliberately generic so it catches any future CTA in this section shipping with a bare alert()/confirm() placeholder, not just a re-added "Watch Demo" button specifically
No changes to the "Launch App" button or its navigation behavior
<!-- List the key changes made. -->

## Test plan

- [✔ ] `npm run build` passes (type-check + production build)
- [ ] `npm run test` passes (all unit tests green)
- [✔ ] `npm run test:coverage` passes (statements/branches/functions/lines ≥ 95%)
- [✔ ] New code is covered by tests; the coverage include list in `vitest.config.ts` is expanded if new production modules are added

## Coverage gate

CI enforces **95% coverage thresholds** (statements, branches, functions, lines) via
the `coverage` job in `.github/workflows/ci.yml`. The job runs `npm run test:coverage`
and fails the PR check when any threshold is missed. The coverage report is uploaded
as a build artifact for every run.

To add a new production file to the coverage baseline, append it to the `include`
array in `vitest.config.ts` and ensure tests cover it before opening the PR.
