### PR TITLE
fix(ui): make DemoBanner reflect active state and replace hardcoded colors (#702)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -149,7 +149,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -540,7 +539,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -589,7 +587,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -2095,7 +2092,6 @@
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -2275,7 +2271,6 @@
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -2293,7 +2288,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -2305,7 +2299,6 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -2355,7 +2348,6 @@
       "integrity": "sha512-PJ5vePq5/ognBbrIcoC5+SHO5dfpeLPzP9FpLkzWrguoYQEeeSjlJpVwOpo1JRSTEi7dRcwNy4h4dzV70PqHcg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.61.1",
         "@typescript-eslint/types": "8.61.1",
@@ -2581,7 +2573,6 @@
       "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.5",
@@ -2726,7 +2717,6 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2961,7 +2951,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3387,7 +3376,6 @@
       "integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -4821,7 +4809,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4854,7 +4841,6 @@
       "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -4987,7 +4973,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5000,7 +4985,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -5421,7 +5405,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5530,7 +5513,6 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -5606,7 +5588,6 @@
       "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.5",
         "@vitest/mocker": "4.1.5",
@@ -5843,7 +5824,6 @@
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/components/treasuryOverviewPage/DemoBanner.tsx
+++ b/src/components/treasuryOverviewPage/DemoBanner.tsx
@@ -1,20 +1,65 @@
-export default function DemoBanner() {
+export type DemoState = "loaded" | "empty" | "loading";
+
+export interface DemoBannerProps {
+  state: DemoState;
+}
+
+interface BadgeConfig {
+  id: DemoState;
+  label: string;
+}
+
+const BADGES: BadgeConfig[] = [
+  { id: "loaded", label: "Loaded" },
+  { id: "empty", label: "Empty" },
+  { id: "loading", label: "Loading" },
+];
+
+export default function DemoBanner({ state }: DemoBannerProps) {
   return (
-    <div className="bg-yellow-50 border border-yellow-200 rounded-lg px-4 py-3">
+    <div
+      className="rounded-lg px-4 py-3 border"
+      style={{
+        backgroundColor: "var(--color-warning-bg)",
+        borderColor: "var(--color-warning)",
+      }}
+    >
       <div className="flex items-center gap-3 text-sm">
-        <span className="text-yellow-900 font-medium">Demo state:</span>
-
-        <span className="px-2 py-1 rounded bg-orange-900 text-white font-medium">
-          Loaded
+        <span
+          className="font-medium"
+          style={{ color: "var(--color-text-primary)" }}
+        >
+          Demo state:
         </span>
 
-        <span className="px-2 py-1 rounded bg-yellow-200 text-yellow-900 font-medium">
-          Empty
-        </span>
-
-        <span className="px-2 py-1 rounded bg-yellow-200 text-yellow-900 font-medium">
-          Loading
-        </span>
+        {BADGES.map((badge) => {
+          const isActive = badge.id === state;
+          return (
+            <span
+              key={badge.id}
+              data-testid={`badge-${badge.id}`}
+              data-active={isActive}
+              className="px-2 py-1 rounded border text-xs transition-colors"
+              style={
+                isActive
+                  ? {
+                      backgroundColor: "var(--color-warning)",
+                      color: "var(--color-text-inverse)",
+                      borderColor: "var(--color-warning)",
+                      fontWeight: 600,
+                    }
+                  : {
+                      backgroundColor: "transparent",
+                      color: "var(--color-text-muted)",
+                      borderColor: "var(--color-border-default)",
+                      fontWeight: 400,
+                    }
+              }
+            >
+              {badge.label}
+            </span>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/components/treasuryOverviewPage/__tests__/DemoBanner.test.tsx
+++ b/src/components/treasuryOverviewPage/__tests__/DemoBanner.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import DemoBanner from "../DemoBanner";
+
+describe("DemoBanner", () => {
+  it("renders loaded state correctly highlighting only Loaded badge", () => {
+    render(<DemoBanner state="loaded" />);
+
+    expect(screen.getByText("Demo state:")).toBeInTheDocument();
+
+    const loadedBadge = screen.getByTestId("badge-loaded");
+    const emptyBadge = screen.getByTestId("badge-empty");
+    const loadingBadge = screen.getByTestId("badge-loading");
+
+    expect(loadedBadge).toHaveAttribute("data-active", "true");
+    expect(emptyBadge).toHaveAttribute("data-active", "false");
+    expect(loadingBadge).toHaveAttribute("data-active", "false");
+
+    const loadedStyle = loadedBadge.getAttribute("style") || "";
+    const emptyStyle = emptyBadge.getAttribute("style") || "";
+    const loadingStyle = loadingBadge.getAttribute("style") || "";
+
+    expect(loadedStyle).toContain("var(--color-warning)");
+    expect(loadedStyle).toContain("var(--color-text-inverse)");
+
+    expect(emptyStyle).toContain("transparent");
+    expect(emptyStyle).toContain("var(--color-text-muted)");
+
+    expect(loadingStyle).toContain("transparent");
+    expect(loadingStyle).toContain("var(--color-text-muted)");
+  });
+
+  it("renders empty state correctly highlighting only Empty badge", () => {
+    render(<DemoBanner state="empty" />);
+
+    const loadedBadge = screen.getByTestId("badge-loaded");
+    const emptyBadge = screen.getByTestId("badge-empty");
+    const loadingBadge = screen.getByTestId("badge-loading");
+
+    expect(loadedBadge).toHaveAttribute("data-active", "false");
+    expect(emptyBadge).toHaveAttribute("data-active", "true");
+    expect(loadingBadge).toHaveAttribute("data-active", "false");
+
+    const loadedStyle = loadedBadge.getAttribute("style") || "";
+    const emptyStyle = emptyBadge.getAttribute("style") || "";
+    const loadingStyle = loadingBadge.getAttribute("style") || "";
+
+    expect(loadedStyle).toContain("transparent");
+    expect(loadedStyle).toContain("var(--color-text-muted)");
+
+    expect(emptyStyle).toContain("var(--color-warning)");
+    expect(emptyStyle).toContain("var(--color-text-inverse)");
+
+    expect(loadingStyle).toContain("transparent");
+    expect(loadingStyle).toContain("var(--color-text-muted)");
+  });
+
+  it("renders loading state correctly highlighting only Loading badge", () => {
+    render(<DemoBanner state="loading" />);
+
+    const loadedBadge = screen.getByTestId("badge-loaded");
+    const emptyBadge = screen.getByTestId("badge-empty");
+    const loadingBadge = screen.getByTestId("badge-loading");
+
+    expect(loadedBadge).toHaveAttribute("data-active", "false");
+    expect(emptyBadge).toHaveAttribute("data-active", "false");
+    expect(loadingBadge).toHaveAttribute("data-active", "true");
+
+    const loadedStyle = loadedBadge.getAttribute("style") || "";
+    const emptyStyle = emptyBadge.getAttribute("style") || "";
+    const loadingStyle = loadingBadge.getAttribute("style") || "";
+
+    expect(loadedStyle).toContain("transparent");
+    expect(loadedStyle).toContain("var(--color-text-muted)");
+
+    expect(emptyStyle).toContain("transparent");
+    expect(emptyStyle).toContain("var(--color-text-muted)");
+
+    expect(loadingStyle).toContain("var(--color-warning)");
+    expect(loadingStyle).toContain("var(--color-text-inverse)");
+  });
+});

--- a/src/components/treasuryOverviewPage/__tests__/demoMode.test.tsx
+++ b/src/components/treasuryOverviewPage/__tests__/demoMode.test.tsx
@@ -91,6 +91,11 @@ describe("treasury overview demo mode", () => {
     expect(screen.getByText("Demo state:")).toBeInTheDocument();
     expect(screen.getByText("Dev Grant - Alice")).toBeInTheDocument();
     expect(screen.getByText("Active Streams")).toBeInTheDocument();
+
+    // In demo mode with loaded fixture data, loaded badge must be highlighted exclusively
+    expect(screen.getByTestId("badge-loaded")).toHaveAttribute("data-active", "true");
+    expect(screen.getByTestId("badge-empty")).toHaveAttribute("data-active", "false");
+    expect(screen.getByTestId("badge-loading")).toHaveAttribute("data-active", "false");
   });
 
   it("defaults to live data and does not render fixture streams", async () => {

--- a/src/pages/TreasuryPage.tsx
+++ b/src/pages/TreasuryPage.tsx
@@ -1,5 +1,5 @@
-import DemoBanner from "../components/treasuryOverviewPage/DemoBanner";
-import Header from "../components/treasuryOverviewPage/Header"
+import DemoBanner, { type DemoState } from "../components/treasuryOverviewPage/DemoBanner";
+import Header from "../components/treasuryOverviewPage/Header";
 import Metrics from "../components/treasuryOverviewPage/Metrics";
 import RecentStreams from "../components/treasuryOverviewPage/RecentStreams";
 import { useTreasuryOverviewData } from "../components/treasuryOverviewPage/useTreasuryOverviewData";
@@ -23,10 +23,16 @@ export default function TreasuryPage() {
     useTreasuryOverviewData();
   const { connected: walletConnected } = useWallet();
 
+  const demoState: DemoState = loading
+    ? "loading"
+    : (metrics && metrics.length > 0) || (streams && streams.length > 0)
+    ? "loaded"
+    : "empty";
+
   if (loading) {
     return (
       <div className="p-6 flex flex-col gap-8 bg-gray-50 min-h-screen">
-        {isDemoMode && <DemoBanner />}
+        {isDemoMode && <DemoBanner state={demoState} />}
         <Header />
         <div role="status" className="text-sm text-gray-500">
           Loading treasury overview...
@@ -38,7 +44,7 @@ export default function TreasuryPage() {
   if (error) {
     return (
       <div className="p-6 flex flex-col gap-8 bg-gray-50 min-h-screen">
-        {isDemoMode && <DemoBanner />}
+        {isDemoMode && <DemoBanner state={demoState} />}
         <Header />
         <div role="alert" className="text-sm text-red-600">
           {error}
@@ -49,7 +55,7 @@ export default function TreasuryPage() {
 
   return (
     <div className="p-6 flex flex-col gap-8 bg-gray-50 min-h-screen">
-      {isDemoMode && <DemoBanner />}
+      {isDemoMode && <DemoBanner state={demoState} />}
       <Header />
       <Metrics metrics={metrics || []} loading={loading} error={error} />
       <RecentStreams

--- a/src/pages/__tests__/TreasuryPage.test.tsx
+++ b/src/pages/__tests__/TreasuryPage.test.tsx
@@ -106,6 +106,20 @@ describe('TreasuryPage', () => {
     expect(screen.getByTestId('streams')).toHaveTextContent(JSON.stringify(fakeStreams));
   });
 
+  it('renders DemoBanner when isDemoMode is true during loading', () => {
+    mockHook.mockReturnValue({ metrics: undefined, streams: undefined, isDemoMode: true, loading: true, error: null });
+    render(<TreasuryPage />);
+    expect(screen.getByTestId('demo-banner')).toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveTextContent('Loading treasury overview...');
+  });
+
+  it('renders DemoBanner when isDemoMode is true during error', () => {
+    mockHook.mockReturnValue({ metrics: undefined, streams: undefined, isDemoMode: true, loading: false, error: 'Error' });
+    render(<TreasuryPage />);
+    expect(screen.getByTestId('demo-banner')).toBeInTheDocument();
+    expect(screen.getByRole('alert')).toHaveTextContent('Error');
+  });
+
   it('renders Metrics/RecentStreams with empty data when undefined and not loading/error', () => {
     // The empty/loading/error states for "no data yet" now live inside
     // Metrics/RecentStreams themselves (see their own test coverage), not as


### PR DESCRIPTION
Closes #702

Summary
Refactored `DemoBanner.tsx` to dynamically highlight only the active state badge (`loaded`, `empty`, or `loading`) passed from `TreasuryPage.tsx`, instead of rendering all three badges as static elements. Replaced all hardcoded Tailwind color classes with system CSS design tokens (`var(--color-*)`) for seamless theme adaptation.

Changes
- `src/components/treasuryOverviewPage/DemoBanner.tsx`: Updated `DemoBannerProps` to require an explicit `state: "loaded" | "empty" | "loading"` prop. Rendered badges dynamically so only the active state receives filled highlight styling, while inactive badges remain outlined/muted. Replaced hardcoded Tailwind background/text color classes with `--color-*` tokens.
- `src/pages/TreasuryPage.tsx`: Derived the active demo state from `useTreasuryOverviewData` and passed it as `<DemoBanner state={demoState} />`.
- `src/components/treasuryOverviewPage/tests/DemoBanner.test.tsx`: Created unit test suite asserting correct badge highlighting for all 3 scenarios. Updated `demoMode.test.tsx` and `TreasuryPage.test.tsx`.

Test plan
- [x] `npx tsc --noEmit` passes (0 TypeScript compilation errors)
- [x] `npx eslint` passes (0 linter errors on modified files)
- [x] `npm run test:coverage` passes with 100% test coverage on `DemoBanner.tsx` and `TreasuryPage.tsx`
- [x] Verified visually that no hardcoded Tailwind color classes remain and design tokens adapt to light/dark themes