### PR TITLE
fix: replace dark: Tailwind classes with CSS var() tokens in RecipientStreams

### DIFF
--- a/src/components/__tests__/RecipientStreams.test.tsx
+++ b/src/components/__tests__/RecipientStreams.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, fireEvent } from "@testing-library/react";
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { RecipientStreams, type Stream } from "../recipient/RecipientStreams";
 
 const mockData: Stream[] = [
@@ -47,5 +47,70 @@ describe("RecipientStreams Testing Engine", () => {
 
     // Initial load is in flight, so rapid clicks are blocked by the concurrency guard.
     expect(callCount).toBe(1);
+  });
+
+  describe("theme-aware styling via design tokens", () => {
+    beforeEach(() => {
+      document.documentElement.removeAttribute("data-theme");
+    });
+
+    it("renders with token-based colors independent of OS dark mode preference", async () => {
+      // Set data-theme explicitly to "dark" while jsdom matchMedia reports light
+      document.documentElement.setAttribute("data-theme", "dark");
+
+      const fetchMock = vi.fn().mockResolvedValue([
+        { id: "1", sender: "Alice", amount: "500", status: "active" },
+      ]);
+
+      render(<RecipientStreams fetchStreamsFn={fetchMock} pollIntervalMs={0} />);
+      const streams = await screen.findByText(/From:/);
+      expect(streams).toBeInTheDocument();
+
+      // Verify the outer card uses var() tokens, not Tailwind dark: classes
+      const card = streams.closest(".p-6");
+      expect(card).toBeInTheDocument();
+      expect(card?.getAttribute("style")).toContain("var(--color-bg-primary)");
+
+      // Verify heading uses theme token
+      const heading = screen.getByText("Incoming Streams");
+      expect(heading.getAttribute("style")).toContain("var(--color-text-primary)");
+    });
+
+    it("renders correctly when app theme toggle (light) disagrees with OS dark preference", async () => {
+      // Simulate OS dark preference via matchMedia
+      window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+        matches: query === "(prefers-color-scheme: dark)",
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      }));
+
+      // But app explicitly sets data-theme="light"
+      document.documentElement.setAttribute("data-theme", "light");
+
+      const fetchMock = vi.fn().mockResolvedValue([
+        { id: "1", sender: "Alice", amount: "500", status: "active" },
+      ]);
+
+      render(<RecipientStreams fetchStreamsFn={fetchMock} pollIntervalMs={0} />);
+      const streams = await screen.findByText(/From:/);
+      expect(streams).toBeInTheDocument();
+
+      // Card should show light-theme token (var(--color-bg-primary) resolves to --surface-base which is white)
+      const card = streams.closest(".p-6");
+      expect(card?.getAttribute("style")).toContain("var(--color-bg-primary)");
+
+      // Verify error uses token colors
+      const errorFetchMock = vi.fn().mockRejectedValue(new Error("fail"));
+      document.documentElement.setAttribute("data-theme", "dark");
+      render(<RecipientStreams fetchStreamsFn={errorFetchMock} pollIntervalMs={0} />);
+      const errorAlert = await screen.findByRole("status");
+      expect(errorAlert.getAttribute("style")).toContain("var(--color-error-text)");
+      expect(errorAlert.getAttribute("style")).toContain("var(--color-error-bg)");
+    });
   });
 });

--- a/src/components/recipient/RecipientStreams.tsx
+++ b/src/components/recipient/RecipientStreams.tsx
@@ -85,11 +85,11 @@ export const RecipientStreams: React.FC<RecipientStreamsProps> = ({
   };
 
   return (
-    <div className="p-6 max-w-4xl mx-auto bg-white dark:bg-gray-900 rounded-2xl shadow-sm">
+    <div className="p-6 max-w-4xl mx-auto rounded-2xl shadow-sm" style={{ backgroundColor: "var(--color-bg-primary)" }}>
       <div className="flex justify-between items-center mb-6">
         <div>
-          <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100">Incoming Streams</h2>
-          <p className="text-sm text-gray-500">Real-time contract payment records</p>
+          <h2 className="text-xl font-bold" style={{ color: "var(--color-text-primary)" }}>Incoming Streams</h2>
+          <p className="text-sm" style={{ color: "var(--color-text-tertiary)" }}>Real-time contract payment records</p>
         </div>
         <button
           onClick={handleRefresh}
@@ -101,30 +101,34 @@ export const RecipientStreams: React.FC<RecipientStreamsProps> = ({
       </div>
 
       {error && (
-        <div role="status" aria-live="polite" className="p-3 mb-4 text-sm text-red-800 bg-red-50 rounded-xl">
+        <div role="status" aria-live="polite" className="p-3 mb-4 text-sm rounded-xl" style={{ color: "var(--color-error-text)", backgroundColor: "var(--color-error-bg)" }}>
           {error}
         </div>
       )}
 
       {sortedStreams.length === 0 && !isRefreshing ? (
-        <p className="text-center text-gray-500 my-8">No incoming streams detected.</p>
+        <p className="text-center my-8" style={{ color: "var(--color-text-tertiary)" }}>No incoming streams detected.</p>
       ) : (
         <div className="space-y-3">
           {sortedStreams.map((stream) => (
-            <div key={stream.id} className="p-4 border rounded-xl flex justify-between items-center">
+            <div key={stream.id} className="p-4 rounded-xl flex justify-between items-center" style={{ border: "1px solid var(--color-border-default)" }}>
               <div>
-                <p className="font-medium text-sm text-gray-600">From: {stream.sender}</p>
+                <p className="font-medium text-sm" style={{ color: "var(--color-text-secondary)" }}>From: {stream.sender}</p>
                 <p className="text-lg font-bold">{stream.amount} XLM</p>
               </div>
               <div className="flex items-center gap-4">
                 <span className={`px-3 py-1 rounded-full text-xs font-semibold ${
-                  stream.status === "active" ? "bg-green-100 text-green-800" : "bg-yellow-100 text-yellow-800"
-                }`}>
+                  stream.status === "active" ? "status-badge--active" : "status-badge--paused"
+                }`} style={{
+                  backgroundColor: stream.status === "active" ? "var(--color-success-bg)" : "var(--color-warning-bg)",
+                  color: stream.status === "active" ? "var(--color-success)" : "var(--color-warning)",
+                }}>
                   {stream.status}
                 </span>
                 <button 
                   onClick={() => togglePin(stream.id)}
-                  className="text-gray-400 hover:text-yellow-500"
+                  className="hover:text-yellow-500"
+                  style={{ color: "var(--color-text-tertiary)" }}
                   aria-label="Pin stream"
                 >
                   {stream.isPinned ? "★" : "☆"}


### PR DESCRIPTION
Replaces all `dark:` Tailwind variant classes in `RecipientStreams.tsx` with `var(--color-*)` design tokens that respond to `[data-theme="dark"]` on `<html>`, matching the app's theme system in `ThemeProvider.tsx`.

**Changes:**
- `RecipientStreams.tsx`: Removed all `dark:` Tailwind classes; replaced with inline `style={{ ... }}` using `var(--color-*)` tokens.
- `RecipientStreams.test.tsx`: Added two tests verifying token-based styling works correctly when `data-theme` disagrees with OS preference.

**Closes #722**