### PR TITLE
Closes #700

### DIFF
--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -358,14 +358,14 @@ function iconBox(variant: EmptyStateVariant): React.CSSProperties {
 const titleStyle: React.CSSProperties = {
   fontSize: "clamp(18px, 2.5vw, 22px)",
   fontWeight: 700,
-  color: "#FFFFFF",
+  color: "var(--color-text-primary, #FFFFFF)",
   margin: "0 0 12px 0",
 };
 
 const descStyle: React.CSSProperties = {
   fontSize: 14,
   lineHeight: 1.65,
-  color: "#99A1AF",
+  color: "var(--color-text-secondary, #99A1AF)",
   margin: "0 0 28px 0",
   maxWidth: 400,
 };

--- a/src/components/__tests__/EmptyState.test.tsx
+++ b/src/components/__tests__/EmptyState.test.tsx
@@ -231,3 +231,51 @@ describe("EmptyState — error variant", () => {
     expect(screen.getByRole("region", { name: "Error state" })).toBeInTheDocument();
   });
 });
+
+// ── theme-aware text colors ─────────────────────────────────────────
+
+describe("EmptyState — theme-aware text colors", () => {
+  it("title uses the color-text-primary token, not a hardcoded hex value", () => {
+    render(<EmptyState variant="treasury" walletConnected={false} />);
+    const heading = screen.getByRole("heading", { name: /connect your wallet/i });
+    const color = heading.style.color;
+    expect(color).toContain("var(--color-text-primary");
+    expect(color).not.toMatch(/^#/);
+    
+  });
+
+  it("description uses the color-text-secondary token, not a hardcoded hex value", () => {
+    render(<EmptyState variant="treasury" walletConnected={false} />);
+    const description = screen.getByText(
+      /connect a stellar wallet to view your treasury/i
+    );
+    const color = description.style.color;
+    expect(color).toContain("var(--color-text-secondary");
+    expect(color).not.toMatch(/^#/);
+
+  });
+
+  it("title and description remain token-based across every variant", () => {
+    const variants = [
+      "treasury",
+      "streams",
+      "recipient",
+      "zero-accrual",
+      "search-no-results",
+      "error",
+    ] as const;
+
+    variants.forEach((variant) => {
+      const { container, unmount } = render(
+        <EmptyState variant={variant} walletConnected={true} />
+      );
+      const heading = container.querySelector("h2");
+      const description = container.querySelector("p");
+
+      expect(heading?.style.color).toContain("var(--color-text-primary");
+      expect(description?.style.color).toContain("var(--color-text-secondary");
+
+      unmount();
+    });
+  });
+});


### PR DESCRIPTION
Replaces the hardcoded 
#FFFFFF (title) and 
#99A1AF (description) colors in EmptyState.tsx with var(--color-text-primary, #FFFFFF) and var(--color-text-secondary, #99A1AF), matching the var(--token, fallback) pattern already used elsewhere in the same file for icon colors. Both tokens are confirmed defined for light and dark themes in design-tokens.css.

Added a new test block asserting the title and description resolve to token references (not bare hex) across all six variants, guarding against regression.

All 38 tests in EmptyState.test.tsx pass. Two pre-existing unrelated failures on main (Home.test.tsx, outOfBandDisconnect.test.tsx) remain untouched; a few additional Home.test.tsx failures appeared only under full-suite concurrent load and did not reproduce when run in isolation.