### PR TITLE
fix(stellar): reject non-zero trailing padding bits in decodeBase32

### DIFF
--- a/src/lib/__tests__/stellar.test.ts
+++ b/src/lib/__tests__/stellar.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isValidStellarAddress, maskAddress, stellarExplorerUrl } from "../stellar";
+import { decodeBase32, isValidStellarAddress, maskAddress, stellarExplorerUrl } from "../stellar";
 
 const BASE32_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
 const ED25519_PUBLIC_KEY_VERSION_BYTE = 6 << 3;
@@ -108,5 +108,71 @@ describe("stellarExplorerUrl", () => {
     expect(stellarExplorerUrl("GABC/unsafe value", "PUBLIC")).toBe(
       "https://stellar.expert/explorer/public/account/GABC%2Funsafe%20value",
     );
+  });
+});
+
+describe("decodeBase32 — non-canonical (non-zero trailing padding bits)", () => {
+  // A 7-character base32 string encodes 7 × 5 = 35 bits, which yields
+  // 4 full bytes (32 bits) with 3 leftover padding bits.  Per RFC 4648 §3.5
+  // and the Stellar StrKey spec those padding bits MUST be zero.  If they
+  // are non-zero, multiple distinct base32 strings would decode to the same
+  // 4-byte payload — a non-canonical re-encoding.
+  //
+  // "AAAAAAA"  → index sequence [0,0,0,0,0,0,0] → 35 zero bits
+  //             → 4 bytes [0,0,0,0], trailing 3 bits = 0b000 (canonical ✓)
+  // "AAAAAAB"  → last index = 1 → trailing 3 bits = 0b001 (non-zero  ✗)
+  // "AAAAAAC"  → last index = 2 → trailing 3 bits = 0b010 (non-zero  ✗)
+  //
+  // Both "AAAAAAB" and "AAAAAAC" decode to the same 4 bytes as "AAAAAAA",
+  // which is exactly the non-canonical collision that must be rejected.
+
+  it("accepts a canonical encoding whose trailing padding bits are zero", () => {
+    const result = decodeBase32("AAAAAAA");
+    expect(result).not.toBeNull();
+    expect(Array.from(result!)).toEqual([0, 0, 0, 0]);
+  });
+
+  it("rejects a non-canonical encoding with non-zero trailing padding bits (last char B)", () => {
+    // "AAAAAAB" has trailing 3 bits = 0b001 — same 4-byte payload as "AAAAAAA"
+    expect(decodeBase32("AAAAAAB")).toBeNull();
+  });
+
+  it("rejects a non-canonical encoding with non-zero trailing padding bits (last char C)", () => {
+    // "AAAAAAC" has trailing 3 bits = 0b010 — same 4-byte payload as "AAAAAAA"
+    expect(decodeBase32("AAAAAAC")).toBeNull();
+  });
+
+  it("confirms the canonical and non-canonical strings would otherwise share a byte payload", () => {
+    // Temporarily decode without the trailing-bit check to show both strings
+    // map to identical bytes, proving we are testing a real non-canonical pair.
+    const ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+    function decodeIgnoringPadding(value: string): number[] {
+      let bits = 0;
+      let bitCount = 0;
+      const bytes: number[] = [];
+      for (const char of value) {
+        const index = ALPHABET.indexOf(char);
+        bits = (bits << 5) | index;
+        bitCount += 5;
+        while (bitCount >= 8) {
+          bitCount -= 8;
+          bytes.push((bits >> bitCount) & 0xff);
+        }
+      }
+      return bytes;
+    }
+
+    expect(decodeIgnoringPadding("AAAAAAA")).toEqual([0, 0, 0, 0]);
+    expect(decodeIgnoringPadding("AAAAAAB")).toEqual([0, 0, 0, 0]);
+    expect(decodeIgnoringPadding("AAAAAAC")).toEqual([0, 0, 0, 0]);
+  });
+
+  it("still accepts all valid 56-character Stellar addresses (zero remainder for 56×5=280 bits)", () => {
+    // 56 chars × 5 bits = 280 bits = 35 bytes exactly; bitCount is always 0
+    // at end, so the padding check is a no-op and valid addresses keep passing.
+    const address = createValidAddress(277);
+    expect(isValidStellarAddress(address)).toBe(true);
+    // A different seed produces a different valid address — both should pass.
+    expect(isValidStellarAddress(createValidAddress(42))).toBe(true);
   });
 });

--- a/src/lib/stellar.ts
+++ b/src/lib/stellar.ts
@@ -3,7 +3,7 @@ const STRKEY_BASE32_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
 const ED25519_PUBLIC_KEY_VERSION_BYTE = 6 << 3;
 const ED25519_PUBLIC_KEY_BYTE_LENGTH = 35;
 
-function decodeBase32(value: string): Uint8Array | null {
+export function decodeBase32(value: string): Uint8Array | null {
   let bits = 0;
   let bitCount = 0;
   const bytes: number[] = [];
@@ -20,6 +20,12 @@ function decodeBase32(value: string): Uint8Array | null {
       bytes.push((bits >> bitCount) & 0xff);
     }
   }
+
+  // Per RFC 4648, any leftover sub-byte bits after the last full byte must be
+  // zero. Non-zero trailing padding bits mean this is a non-canonical encoding
+  // of the same byte payload — reject it so that exactly one base32 string maps
+  // to each byte sequence.
+  if (bitCount > 0 && (bits & ((1 << bitCount) - 1)) !== 0) return null;
 
   return new Uint8Array(bytes);
 }


### PR DESCRIPTION
Per RFC 4648 §3.5, leftover sub-byte bits after the last full byte must be zero. Without this check, multiple distinct base32 strings decode to the same byte payload, making isValidStellarAddress accept non-canonical encodings.

Add the guard after the accumulation loop and export decodeBase32 so it can be tested directly. Add a regression test suite that:
- confirms canonical inputs (trailing bits = 0) are accepted
- rejects two non-canonical re-encodings of the same 4-byte payload
- proves the collision via a padding-ignoring decode helper
- verifies valid 56-char Stellar addresses still pass

## Summary

<!-- What does this PR change and why? -->

## Changes

<!-- List the key changes made. -->

## Test plan

- [ ] `npm run build` passes (type-check + production build)
- [ ] `npm run test` passes (all unit tests green)
- [ ] `npm run test:coverage` passes (statements/branches/functions/lines ≥ 95%)
- [ ] New code is covered by tests; the coverage include list in `vitest.config.ts` is expanded if new production modules are added

## Coverage gate

CI enforces **95% coverage thresholds** (statements, branches, functions, lines) via
the `coverage` job in `.github/workflows/ci.yml`. The job runs `npm run test:coverage`
and fails the PR check when any threshold is missed. The coverage report is uploaded
as a build artifact for every run.

To add a new production file to the coverage baseline, append it to the `include`
array in `vitest.config.ts` and ensure tests cover it before opening the PR.

closes #734