### PR TITLE
fix(i18n): escape regex metacharacters in translate() param keys

### DIFF
--- a/src/i18n/__tests__/i18n.test.tsx
+++ b/src/i18n/__tests__/i18n.test.tsx
@@ -60,3 +60,58 @@ describe("escapeHtml utility", () => {
     expect(escapeHtml("hello & welcome <user>")).toBe("hello &amp; welcome &lt;user&gt;");
   });
 });
+
+describe("translate() with regex-metacharacter param keys", () => {
+  // Use a catalog entry that contains an interpolation placeholder.
+  // "createStream.step3.rateValue" -> "{accrualRate} USDC per day"
+  // We'll build a minimal ad-hoc catalog so tests are not coupled to en.ts wording.
+
+  const fakeCatalog = {
+    ...en,
+    // Override with a key whose placeholder uses a dot in the param name so we
+    // can exercise the fix without depending on a real catalog entry that uses dots.
+    "createStream.step3.rateValue": "{amount.usd} USDC per day",
+  } as typeof en;
+
+  it("interpolates a param key containing a dot (.) without throwing", () => {
+    // Without the fix, new RegExp(`\\{amount.usd\\}`) would treat the dot as
+    // "any character", so "{amountXusd}" would also match (over-matching).
+    // With the fix it only replaces the literal placeholder {amount.usd}.
+    const result = translate(fakeCatalog, en, "createStream.step3.rateValue", {
+      "amount.usd": "42.00",
+    });
+    expect(result).toBe("42.00 USDC per day");
+  });
+
+  it("does NOT over-match when the param key contains a dot", () => {
+    // Confirm the dot is treated as a literal: a placeholder spelled with
+    // a different character in the same position should NOT be replaced.
+    const template = { ...en, "createStream.step3.rateValue": "{amountXusd} vs {amount.usd}" } as typeof en;
+    const result = translate(template, en, "createStream.step3.rateValue", {
+      "amount.usd": "99.00",
+    });
+    // {amountXusd} should remain unreplaced; only the exact literal {amount.usd} is substituted.
+    expect(result).toBe("{amountXusd} vs 99.00");
+  });
+
+  it("interpolates a param key containing other regex metacharacters without throwing", () => {
+    const metacharKeys: Array<[string, string]> = [
+      ["amount*total", "100"],
+      ["amount+total", "200"],
+      ["amount(total)", "300"],
+      ["amount[0]", "400"],
+      ["amount$value", "500"],
+      ["amount^value", "600"],
+    ];
+
+    for (const [paramKey, paramValue] of metacharKeys) {
+      const template = { ...en, "createStream.step3.rateValue": `{${paramKey}} USDC per day` } as typeof en;
+      expect(() =>
+        translate(template, en, "createStream.step3.rateValue", { [paramKey]: paramValue })
+      ).not.toThrow();
+
+      const result = translate(template, en, "createStream.step3.rateValue", { [paramKey]: paramValue });
+      expect(result).toBe(`${paramValue} USDC per day`);
+    }
+  });
+});

--- a/src/i18n/index.tsx
+++ b/src/i18n/index.tsx
@@ -48,6 +48,17 @@ export interface I18nContextType {
 const I18nContext = createContext<I18nContextType | undefined>(undefined);
 
 /**
+ * Escapes all regex-special characters in a string so it can be used safely
+ * as a literal pattern inside `new RegExp(...)`.
+ *
+ * @param value The raw string to escape.
+ * @returns The regex-escaped string.
+ */
+export function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
  * Helper function to escape HTML characters in user-provided values
  * to prevent XSS vulnerabilities if translations are rendered unsafely.
  *
@@ -113,7 +124,10 @@ export function translate(
     let result = value;
     for (const [paramKey, paramValue] of Object.entries(params)) {
       const escapedValue = escapeHtml(String(paramValue));
-      result = result.replace(new RegExp(`\\{${paramKey}\\}`, "g"), escapedValue);
+      // Escape regex-metacharacters in the param key so a caller-controlled key
+      // such as "amount.usd" cannot widen the match or throw an invalid-pattern error.
+      const escapedKey = escapeRegExp(paramKey);
+      result = result.replace(new RegExp(`\\{${escapedKey}\\}`, "g"), escapedValue);
     }
     return result;
   }


### PR DESCRIPTION
paramKey was interpolated directly into new RegExp(...) without escaping, allowing keys with regex-special characters (e.g. '.', '*', '+') to either throw an invalid-pattern error or silently over-match.

- Add escapeRegExp() helper that applies the standard /[.*+?^${}()|[\]\]/g replacement before the key is embedded in the RegExp literal.
- Use escapeRegExp(paramKey) in translate() so all param keys are treated as literal strings.
- Add regression tests covering dot ('.') and six other metacharacters, asserting correct substitution and no over-matching.

## Summary

<!-- What does this PR change and why? -->

## Changes

<!-- List the key changes made. -->

## Test plan

- [ ] `npm run build` passes (type-check + production build)
- [ ] `npm run test` passes (all unit tests green)
- [ ] `npm run test:coverage` passes (statements/branches/functions/lines ≥ 95%)
- [ ] New code is covered by tests; the coverage include list in `vitest.config.ts` is expanded if new production modules are added

## Coverage gate

CI enforces **95% coverage thresholds** (statements, branches, functions, lines) via
the `coverage` job in `.github/workflows/ci.yml`. The job runs `npm run test:coverage`
and fails the PR check when any threshold is missed. The coverage report is uploaded
as a build artifact for every run.

To add a new production file to the coverage baseline, append it to the `include`
array in `vitest.config.ts` and ensure tests cover it before opening the PR.

closes #739