### PR TITLE
#754 TreasuryOnboarding.tsx hardcodes "Fluxora connects to Stellar Te…

### DIFF
--- a/src/components/TreasuryOnboarding.tsx
+++ b/src/components/TreasuryOnboarding.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import { writeOnboardingDismissed } from "../lib/onboarding";
+import { useWallet } from "./wallet-connect/Walletcontext";
 import "./TreasuryOnboarding.css";
 
 interface TreasuryOnboardingProps {
@@ -32,6 +33,7 @@ export default function TreasuryOnboarding({
   onCreateStream,
   onDismiss,
 }: TreasuryOnboardingProps) {
+  const { expectedNetwork, expectedNetworkLabel } = useWallet();
   const [step, setStep] = useState(0);
   const headingRef = useRef<HTMLHeadingElement>(null);
   const regionRef = useRef<HTMLDivElement>(null);
@@ -523,8 +525,9 @@ export default function TreasuryOnboarding({
                     <path strokeLinecap="round" d="M12 16v-4M12 8h.01" />
                   </svg>
                   <p>
-                    Fluxora connects to Stellar Testnet by default. No real
-                    funds are used during exploration.
+                    {expectedNetwork === "PUBLIC"
+                      ? `Fluxora is configured for ${expectedNetworkLabel}. This wallet connection uses real funds; review requests carefully before approving.`
+                      : `Fluxora is configured for ${expectedNetworkLabel}. No real funds are used during exploration.`}
                   </p>
                 </div>
               </>

--- a/src/components/__tests__/TreasuryOnboarding.test.tsx
+++ b/src/components/__tests__/TreasuryOnboarding.test.tsx
@@ -3,6 +3,11 @@ import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import TreasuryOnboarding from "../TreasuryOnboarding";
 import { writeOnboardingDismissed } from "../../lib/onboarding";
+import { useWallet } from "../wallet-connect/Walletcontext";
+
+vi.mock("../wallet-connect/Walletcontext", () => ({
+  useWallet: vi.fn(),
+}));
 
 vi.mock("../../lib/onboarding", () => ({
   writeOnboardingDismissed: vi.fn(),
@@ -45,6 +50,18 @@ async function goToStep(user: ReturnType<typeof userEvent.setup>, step: number) 
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.mocked(useWallet).mockReturnValue({
+    address: null,
+    network: null,
+    connected: false,
+    loading: false,
+    error: null,
+    expectedNetwork: "TESTNET",
+    expectedNetworkLabel: "Testnet",
+    isNetworkMismatch: false,
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+  });
 });
 
 // ── Step content ──────────────────────────────────────────────────────────────
@@ -93,6 +110,39 @@ describe("TreasuryOnboarding — step content", () => {
     expect(walletOptions).toHaveTextContent("Recommended · Stellar browser extension");
     expect(screen.getByRole("button", { name: "Connect Freighter" })).toBeInTheDocument();
     expect(screen.getByText("Step 3 of 3")).toBeInTheDocument();
+  });
+
+  it("shows testnet reassurance only when the expected network is TESTNET", async () => {
+    const user = userEvent.setup();
+    renderOnboarding();
+    await goToStep(user, 2);
+
+    expect(screen.getByRole("note")).toHaveTextContent(
+      "Fluxora is configured for Testnet. No real funds are used during exploration.",
+    );
+  });
+
+  it("warns that real funds are used when the expected network is PUBLIC", async () => {
+    vi.mocked(useWallet).mockReturnValue({
+      address: null,
+      network: null,
+      connected: false,
+      loading: false,
+      error: null,
+      expectedNetwork: "PUBLIC",
+      expectedNetworkLabel: "Public Network (Mainnet)",
+      isNetworkMismatch: false,
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+    });
+    const user = userEvent.setup();
+    renderOnboarding();
+    await goToStep(user, 2);
+
+    const networkNotice = screen.getByRole("note");
+    expect(networkNotice).toHaveTextContent("Public Network (Mainnet)");
+    expect(networkNotice).toHaveTextContent(/uses real funds/i);
+    expect(networkNotice).not.toHaveTextContent(/no real funds are used/i);
   });
 
   it("renders the connected Get-started step content with truncated address", async () => {


### PR DESCRIPTION
## Summary

Fixes the Treasury onboarding “Get started” network notice so it no longer states that Fluxora connects to Stellar Testnet and uses no real funds regardless of the deployment configuration.

The message now derives from WalletContext’s configured expected Stellar network. Testnet users retain the exploration reassurance, while Public Network/Mainnet users are explicitly warned that the requested wallet connection uses real funds.

## Changes

- Updated `src/components/TreasuryOnboarding.tsx`
  - Consumes `useWallet()` from WalletContext.
  - Uses `expectedNetwork` to distinguish between `TESTNET` and `PUBLIC`.
  - Uses `expectedNetworkLabel` to display the configured network name.
  - Shows Testnet copy:
    - “Fluxora is configured for Testnet. No real funds are used during exploration.”
  - Shows Public/Mainnet safety copy:
    - “Fluxora is configured for Public Network (Mainnet). This wallet connection uses real funds; review requests carefully before approving.”

- Updated `src/components/__tests__/TreasuryOnboarding.test.tsx`
  - Added a TESTNET regression test confirming the existing no-real-funds reassurance is retained.
  - Added a PUBLIC regression test confirming:
    - The Mainnet/Public Network label is displayed.
    - The notice warns that real funds are used.
    - The Testnet “No real funds” reassurance is absent.
  - Existing onboarding navigation, stepper, focus, CTA, and dismissal tests continue to pass.

## Test plan

- [ ] `npm run build` passes (type-check + production build)  
  Blocked by pre-existing unrelated syntax errors in:
  - `src/components/Layout.tsx`
  - `src/components/treasuryOverviewPage/__tests__/StreamsTable.test.tsx`

- [ ] `npm run test` passes (all unit tests green)  
  Full suite is blocked by the same pre-existing malformed repository files.

- [ ] `npm run test:coverage` passes (statements/branches/functions/lines ≥ 95%)  
  Could not be completed because the repository-wide coverage run depends on the full test suite/buildable source tree. The added production change is covered by targeted regression tests.

- [x] Targeted onboarding regression tests pass:

  ```bash
  npm test -- --run src/components/__tests__/TreasuryOnboarding.test.tsx
  ```

  ```text
  Test Files: 1 passed
  Tests: 21 passed
  ```

- [x] New code is covered by tests.
  - No new production module was added.
  - Therefore, no `vitest.config.ts` coverage include-list update is required.

## Coverage gate

This change adds regression coverage for both supported runtime network configurations without adding a new production file. The existing `TreasuryOnboarding.tsx` component is not currently included in the repository’s `vitest.config.ts` coverage baseline; adding it would require broader component coverage work to meet the repository-wide 95% gate.

CLOSE #754 