### PR TITLE
#750 StreamTimeline.tsx hardcodes en-US in Intl.DateTimeFormat instea…

### DIFF
--- a/src/components/StreamTimeline.tsx
+++ b/src/components/StreamTimeline.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import "./StreamTimeline.module.css";
 import { usePrefersReducedMotion } from "../hooks/usePrefersReducedMotion";
+import { createDateTimeFormat } from "../lib/formatters";
 
 export interface StreamTimelineProps {
   startDate: string;
@@ -86,18 +87,21 @@ export const StreamTimeline: React.FC<StreamTimelineProps> = ({
     Math.min(100, ((currentTime - start.getTime()) / totalDuration) * 100),
   );
 
-  // Format date for display (handle long Stellar addresses)
+  // Format date for display. Resolves user locale via navigator.language
+  // (with a validated "en-US" fallback) consistent with src/lib/formatters.ts.
+  // This mirrors the fix for issue #388 applied elsewhere in the app.
   const formatDate = (date: Date): string => {
-    return new Intl.DateTimeFormat("en-US", {
+    return createDateTimeFormat({
       month: "short",
       day: "numeric",
       year: "2-digit",
     }).format(date);
   };
 
-  // Format long dates with ellipsis for overflow
+  // Format short numeric month/day for the inline segment labels.
+  // Locale-aware so ordering and separators match the visitor's locale.
   const formatShortDate = (date: Date): string => {
-    return new Intl.DateTimeFormat("en-US", {
+    return createDateTimeFormat({
       month: "numeric",
       day: "numeric",
     }).format(date);

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -46,8 +46,11 @@ function createNumberFormat(options?: Intl.NumberFormatOptions): Intl.NumberForm
 /**
  * Create an `Intl.DateTimeFormat` using the resolved locale.
  * Falls back to `"en-US"` if the locale causes an error.
+ *
+ * Exported so components (e.g. StreamTimeline) can reuse the same locale
+ * resolution / fallback logic instead of hardcoding `"en-US"`.
  */
-function createDateTimeFormat(options?: Intl.DateTimeFormatOptions): Intl.DateTimeFormat {
+export function createDateTimeFormat(options?: Intl.DateTimeFormatOptions): Intl.DateTimeFormat {
   try {
     return new Intl.DateTimeFormat(resolveLocale(), options);
   } catch {


### PR DESCRIPTION
## Summary

StreamTimeline.tsx's internal `formatDate` and `formatShortDate` helpers were constructing `Intl.DateTimeFormat` with a hardcoded `"en-US"` locale, even though the rest of the stream detail page (and the app-wide fix in #388) already resolves the user's locale from `navigator.language` with a safe validated `"en-US"` fallback. This caused the timeline visualization to always render US-style `M/D/YY` ordering regardless of the visitor's locale, while the surrounding dates (from `formatDateWithTimezone`/`getRelativeTime` in `src/lib/timePresentation.ts`) were correctly localized.

This PR finishes the #388 sweep by making StreamTimeline's two date helpers reuse the existing shared `createDateTimeFormat` helper from `src/lib/formatters.ts`, so the entire stream detail page is now locale-aware. It also adds a test suite that pins the locale-aware behavior, SSR/non-browser fallback, and malformed-locale resilience.

## Changes

- **`src/lib/formatters.ts`**
  - Exported the previously module-private `createDateTimeFormat` helper so components can reuse the canonical locale-resolution + fallback logic instead of duplicating it (or hardcoding `"en-US"`). Behavior unchanged: it still calls `resolveLocale()` (reads `navigator.language`, validates via `Intl.NumberFormat`, falls back to `"en-US"`) and wraps the constructor in a try/catch that falls back to `Intl.DateTimeFormat("en-US", …)` if anything throws.
- **`src/components/StreamTimeline.tsx`**
  - Imported `createDateTimeFormat` from `../lib/formatters`.
  - Replaced both `new Intl.DateTimeFormat("en-US", …)` calls in `formatDate` and `formatShortDate` with `createDateTimeFormat(…)`.
  - The original options objects are preserved exactly (`{ month: "short", day: "numeric", year: "2-digit" }` and `{ month: "numeric", day: "numeric" }`) — only the locale source changes, so en-US output is byte-identical.
  - Updated inline comments to reference the #388 consistency fix.
  - The screen-reader summary list, visible date labels (Start/Cliff/End), aria-labels on segments, and the inline cliff segment short-date label all now localize automatically because they all flow through the same two helpers.
- **`src/components/__tests__/StreamTimeline.locale.test.tsx`** (new)
  - Asserts en-US default output (`"Jan"` month, `M/D` short-date pattern).
  - Stubs `navigator.language = "de-DE"` and asserts the rendered short-date **changes** away from the US `M/D` slash pattern and the SR summary's start-date line differs from the hardcoded `"Jan 1, 24"` string — proving the locale is actually read from `navigator.language` rather than hardcoded behind an indirection.
  - Simulates a non-browser SSR/test environment by deleting `globalThis.navigator` and asserts the component renders without throwing.
  - Stubs `navigator.language` to a malformed value (`"not-a-valid-locale!"`) and asserts graceful fallback to non-NaN output.
- **No new production modules were added**, so no changes to the coverage `include` list in `vitest.config.ts` are required (the `createDateTimeFormat` addition is a visibility change on an already-covered file, and StreamTimeline's component tests already sit under `src/components/**/*.test.tsx`, which is excluded from the coverage thresholds per the existing config).

## Test plan

- [ ] `npm run build` passes (type-check + production build)
  - **Note (pre-existing):** The clean `main` branch currently fails `tsc -b` with three pre-existing syntax errors in `src/components/Layout.tsx` (lines 37, 44) and `src/components/treasuryOverviewPage/__tests__/StreamsTable.test.tsx` (line 167). These reproduce on an unmodified checkout and are unrelated to this PR; my changes introduce **no new** TypeScript errors (verified by Vite/esbuild successfully compiling the touched files in every Vitest run).
- [x] `npm run test` passes (all StreamTimeline + formatters tests green)
  - StreamTimeline test suites: **15/15 passing** (9 segments + 2 duration + 4 new locale tests).
  - formatters test suite: **41/41 passing** (including all pre-existing resolveLocale/non-default-locale/constructor-fallback tests).
  - **Note (pre-existing):** Four other test files fail on the clean `main` branch as well (`ZeroAccrualBanner.test.tsx` references an undefined `formatEventDate`; `Input.test.tsx` ARIA assertions; `RecipientStreams.states.test.tsx` imports an undefined component; one `ConnectWalletModal.test.tsx` focus-trap test). These failures reproduce without my changes and are not regressions from this PR.
- [ ] `npm run test:coverage` passes (statements/branches/functions/lines ≥ 95%)
  - Expected to remain green: `src/lib/formatters.ts` was already in the coverage include list and continues to be covered by its existing 41 tests; no new production modules were added to the include list; the new locale tests add coverage for the locale-dependent paths inside StreamTimeline without changing the threshold surface (component files are already excluded from the v8 coverage gate by `exclude: ["src/components/**/*.test.tsx", "src/theme/**/__tests__/**"]`).
- [x] New code is covered by tests; the coverage include list in `vitest.config.ts` is expanded if new production modules are added
  - The only production-code changes are (a) exporting an existing function from `formatters.ts` (already listed and covered), and (b) switching StreamTimeline's internal calls to that exported helper (covered by the new locale test file). No new production modules were introduced, so no addition to the `include` array is needed.

## Coverage gate

CI enforces **95% coverage thresholds** (statements, branches, functions, lines) via the `coverage` job in `.github/workflows/ci.yml`. This PR does not add new entries to the coverage `include` list, and the only change to a covered file (`src/lib/formatters.ts`) is a visibility modifier (`function` → `export function`) on already-tested code, so the threshold surface is unchanged. The new locale tests exercise the previously-hardcoded en-US path, the dynamic-locale path (de-DE), the SSR/undefined-navigator path, and the malformed-locale fallback path for StreamTimeline.

CLOSE #750 