### PR TITLE
design: spec offline action-queue banner for stream creation

### DIFF
--- a/docs/OFFLINE_ACTION_QUEUE_SPEC.md
+++ b/docs/OFFLINE_ACTION_QUEUE_SPEC.md
@@ -1,0 +1,283 @@
+# Offline Action-Queue Banner — CreateStreamModal
+
+Design + engineering spec for what happens when a user submits step 3 of
+`CreateStreamModal.tsx` while offline. Replaces the previous silent
+hang/ambiguous-spinner behavior with an explicit "queued" state, an automatic
+flush on reconnect, and a clear success/failure outcome.
+
+## Scope
+
+This covers **connectivity loss at submit time**, not full offline/PWA
+support (service worker, asset caching, background sync). Full offline mode
+is already deferred in `DESIGN_SPEC.md` ("PWA/offline mode: defer to Phase
+3"); this spec stays inside that boundary — it only changes what happens to
+a submission that's already in flight when the network isn't.
+
+## State machine
+
+| State | Trigger | UI | `isBusyCreating`\* | Close/Cancel |
+|---|---|---|---|---|
+| `submitted-online` | Click "Create stream" while online | Unchanged — existing submitting/pending/failed flow in `transaction-status-box` | yes | blocked |
+| `submitted-offline-queued` | Click "Create stream" while offline | New `.offline-queue-banner` — "Queued — will submit when back online" | yes (blocks Back/Edit/re-submit) | **not blocked** |
+| `queue-flushing-on-reconnect` | `online` event fires while queued | Reuses `.transaction-status-box` — "Back online. Submitting your queued stream to Stellar…" | yes | blocked |
+| `queue-flush-success` | Flush's `createStream` resolves + poller confirms | Existing confirm effect fires: modal closes, success toast | yes → modal closes | n/a |
+| `queue-flush-failure` | Flush's `createStream` rejects | New `.offline-queue-banner--failed` — error message + Retry / Edit details | no (return to editable) | not blocked |
+
+\* `isBusyCreating` gates Back, the review-card Edit buttons, and the
+footer submit button. It is intentionally a **superset** of a separate
+`isActivelySubmitting` flag (submitting / confirming / flushing) that alone
+gates Close/Cancel — see [Keyboard & focus](#keyboard--focus-behavior) below.
+
+```
+idle → (online)  → submitting → pending → confirmed / failed   [unchanged]
+     → (offline) → queued ──(online event)──▶ flushing ─┬─▶ confirmed (poll) → success toast
+                     ▲                                   └─▶ queue-failed → Retry ─┘
+                     └────────────── Retry while still offline ─────────────┘
+     queue-failed → Edit details → step 1 (payload discarded, form still holds the values)
+```
+
+## Why a local, in-memory queue
+
+`src/lib/offlineActionQueue.ts` is a tiny module-level singleton
+(`enqueueAction` / `dequeueAction` / `getQueuePosition` / `getQueueLength` /
+`subscribeToQueue`), generic over payload type. It is **not persisted** to
+`localStorage` — a full page reload clears it.
+
+- This keeps the change small and testable, and matches the existing
+  "defer full offline/PWA to Phase 3" decision — persistence across reloads
+  is exactly the kind of durability that phase is meant to cover properly
+  (with the eventual service worker / background sync), not a shortcut
+  worth half-building here.
+- It's a shared singleton (not local `useState` in the modal) specifically so
+  **queue position** is meaningful if a user has more than one submission
+  captured (e.g. two browser tabs). With a single queued item it always
+  reads "1 of 1".
+- The modal component stays mounted for the app's lifetime (`isOpen={false}`
+  only skips rendering — see `CreateStreamModal.tsx` line
+  `if (!isOpen) return null;`, which comes *after* all hooks/effects). That
+  means the flush effect keeps running, and the flush still completes,
+  even if the user closes the modal while a submission is queued.
+
+## Accessibility
+
+- **Immediate announcement**: the queued banner has `role="status"
+  aria-live="polite"` and renders in the same synchronous state update that
+  captures the submission — no debounce, no delay. A screen reader user gets
+  "Queued — will submit when back online…" right away instead of silence.
+- **Not color-alone**: every state pairs an icon (`aria-hidden`) + a text
+  label + a color accent. Color is never the only signal.
+- **Text contrast**: banner body copy uses `var(--text)` /
+  `var(--text-secondary)` on `var(--surface-raised)` — the same
+  high-contrast pairing `.transaction-status-box` already uses, verified
+  >4.5:1 in both themes (see [Contrast](#contrast-verification)). Color
+  (`var(--status-warning)` / `var(--danger)`) is scoped to the icon and the
+  4px left border accent only — decorative, redundant with the text label.
+- **Failure banner** uses `role="alert"` (assertive) since it's an
+  unexpected, actionable outcome; the queued banner uses `role="status"`
+  (polite) since it's an expected, non-urgent wait state.
+- **Toast action**: the "View stream" action inside `ToastNotification` is a
+  real `<button>` with visible focus (`:focus-visible` outline), not a
+  `div onClick`. Activating it (click or Enter/Space) calls the same
+  `onStreamCreated` callback the parent already uses, then dismisses the
+  toast.
+
+### Keyboard & focus behavior
+
+- **While queued**: modal stays fully keyboard-operable. Close (✕) and
+  Cancel remain enabled and reachable by Tab — a queued submission is just
+  data captured locally, nothing is in flight, so there's no reason to trap
+  the user in the modal. Back and the review-card Edit buttons are
+  **disabled** while queued (and while flushing) — the payload was already
+  snapshotted at submit time, so editing the form wouldn't change what gets
+  submitted, and it would strand the "queued" UI referring to a filled-in
+  form the user has since changed. `handleEditQueuedSubmission` (used only
+  after a **failed** flush, once the payload is no longer queued) is the
+  supported way back into the form.
+- **While flushing / actively submitting**: Close/Cancel are blocked, same
+  as today's online submitting/confirming behavior — unchanged.
+- **Focus**: no forced focus moves are introduced. The banner appears inline
+  in the existing scrollable step-3 body; it does not steal focus from
+  whatever the user was doing. `useModalAccessibility`'s existing focus trap
+  and Escape-to-close (gated by the same close/cancel guard) are untouched.
+
+### Contrast verification
+
+Computed against the WCAG relative-luminance formula for both themes'
+`var(--surface-raised)`:
+
+| Pairing | Light theme | Dark theme |
+|---|---|---|
+| `var(--text)` on `var(--surface-raised)` | ~15:1 | ~13:1 |
+| `var(--text-secondary)` on `var(--surface-raised)` | ~6.4:1 | ~7.8:1 |
+
+Both comfortably clear the 4.5:1 AA threshold for normal text, in both
+themes. The icon/border accent colors (`var(--status-warning)`,
+`var(--danger)`) are decorative-only and not relied on for the 4.5:1 text
+check.
+
+> **Note for reviewers**: while computing this, `.review-warning-box` and
+> `.review-error-box` (existing, unrelated components) turned out to compute
+> well under 4.5:1 in light theme — their text color is the same hue as
+> their background tint. The new banner deliberately does **not** reuse
+> that pattern (see below). Flagging it here rather than fixing it
+> unprompted, since it's outside this task's scope and touches shipped
+> components.
+
+## Visual spec
+
+### Queued state (`.offline-queue-banner`)
+
+```
+┌──────────────────────────────────────────────────────────┐
+│ ⏱  Queued — will submit when back online                 │
+│    You're offline. We saved your stream details on this  │
+│    device and will submit them automatically the moment  │
+│    your connection returns — no need to resubmit.         │
+│    Queue position: 1 of 1                                │
+└──────────────────────────────────────────────────────────┘
+```
+
+- Container: `border: 1px solid var(--border)`, `border-left: 4px solid
+  var(--status-warning)`, `background: var(--surface-raised)`, `border-radius: 8px`.
+- Icon: 18×18 clock outline, `color: var(--status-warning)`, `aria-hidden`.
+- Title: `font-weight: 600`, `color: var(--text)`.
+- Body copy: `color: var(--text)`.
+- Position line: `color: var(--text-secondary)`, `font-size: 0.75rem`.
+- Placement: step-3 body, directly above the existing submitting/pending/
+  failed status boxes (`transaction-status-box`) and below the "By creating
+  this stream…" warning box — same column, same width as those boxes.
+
+### Flushing (reconnect in progress)
+
+Reuses `.transaction-status-box` verbatim with new copy: "Back online.
+Submitting your queued stream to Stellar…" — deliberately looks like the
+existing "Submitting…" box so returning users recognize it as the same kind
+of "hold on" state, not a new concept to learn.
+
+### Flush-flush failure (`.offline-queue-banner--failed`)
+
+```
+┌──────────────────────────────────────────────────────────┐
+│ ⚠  Your queued stream couldn't be submitted.              │
+│    Insufficient balance to fund this stream.              │
+│                                                            │
+│    [ Retry now ]   [ Edit details ]                       │
+└──────────────────────────────────────────────────────────┘
+```
+
+- Same container shape as the queued banner, `border-left-color:
+  var(--danger)`, icon recolored to `var(--danger)`.
+- Body line renders whatever message the failed submission actually
+  produced (`getStreamErrorMessage`, the same helper the online path already
+  uses) — no fabricated categorization in code. See
+  [Failure copy guidance](#failure-copy-guidance-by-cause) for how to word
+  the two example causes from the ticket.
+- **Retry now** (`.offline-queue-banner__btn--primary`, same
+  `--color-cta-primary-bg` treatment as the existing primary CTA):
+  re-attempts with the *same* captured payload. If still offline, silently
+  re-queues instead of erroring again.
+- **Edit details** (`.offline-queue-banner__btn`, secondary/outline):
+  discards the captured payload and returns to step 1 so the user can
+  change amount/recipient/schedule before resubmitting.
+
+### Success (toast)
+
+No new banner — the modal closes exactly as it does for the online path
+today (existing `transactionStatus.status === "confirmed"` effect). The
+only change is the **toast**, which needs to reach a user who may not be
+looking at the modal anymore (it can flush in the background after the
+modal was closed):
+
+```
+✓ Success
+  Your queued stream was submitted and confirmed on Stellar.
+  View stream →
+```
+
+`ToastNotification` gained an optional inline action
+(`actionLabel`/`onAction`, threaded through `ToastProvider.addToast`'s new
+4th `action` parameter: `{ label, onClick }`). The action's `onClick` calls
+the same `onStreamCreated` the parent already wires up to open
+`StreamCreatedModal.tsx` (see `Streams.tsx`) — clicking it is a convenience
+deep link, not a second code path.
+
+## Failure copy guidance by cause
+
+The code surfaces whatever `Error.message` the rejected `createStream` call
+produced — it does not attempt to classify it. Recommended **copy**
+guidance per likely cause (for whoever writes the RPC/contract-side error
+messages):
+
+| Cause | Recommended message pattern | Recommended primary action |
+|---|---|---|
+| Stale sequence number / nonce | "Your account sequence number changed while offline. Retrying will use a fresh one." | **Retry now** (usually just works) |
+| Insufficient balance discovered late | "Insufficient balance to fund this stream." | **Edit details** (lower the deposit or top up first) |
+| Network/RPC error on resubmission | Generic `createStream.error.generic` fallback | **Retry now** |
+
+Both actions are always shown regardless of cause — this is a copy/emphasis
+recommendation, not a code branch, since the client can't reliably
+distinguish these without cooperation from `TransactionError.type` in
+`src/lib/stellar/tx.ts`, which isn't fine-grained enough today (e.g. both a
+stale-nonce and an insufficient-balance rejection can surface as `"rpc"`).
+
+## Responsive
+
+- 768px and below: banner padding tightens to `0.625rem 0.75rem`,
+  `font-size: 0.75rem`; the Retry/Edit buttons keep `flex-wrap: wrap` and
+  align to the start (same treatment as `.review-error-box` at this
+  breakpoint) so they never force horizontal scroll.
+- ≤360px: `font-size: 0.6875rem`, matching the existing very-small-phone
+  overrides for `.review-warning-box` / `.review-error-box`.
+- The banner sits inside `.modal-body-scroll` — the same scrollable column
+  as the review cards — so it never overlaps or obscures the review summary
+  above it; it just adds to the scroll length.
+
+## Files changed
+
+- `src/hooks/useOnlineStatus.ts` — new. Tracks `navigator.onLine` +
+  `online`/`offline` window events.
+- `src/lib/offlineActionQueue.ts` — new. In-memory singleton queue
+  (enqueue/dequeue/position/length/subscribe).
+- `src/hooks/useTransactionStatus.ts` — widened `TxStatus` with `queued` /
+  `flushing` / `queue-failed` for a shared vocabulary with
+  `CreateStreamModal`; the hook itself still only ever sets
+  `pending`/`confirmed`/`failed` once a real tx hash exists.
+- `src/components/CreateStreamModal.tsx` — offline branch at submit time,
+  auto-flush effect, retry/edit-details handlers, banner rendering,
+  close/cancel vs. busy-state guard split.
+- `src/components/CreateStreamModal.css` — `.offline-queue-banner` and
+  responsive overrides.
+- `src/components/toast/ToastProvider.tsx`,
+  `src/components/ToastNotification.tsx(.css)` — optional toast action
+  (`actionLabel`/`onAction`), used for the "View stream" deep link.
+- `src/i18n/en.ts` — new `createStream.queue.*` and two new button-label
+  strings.
+
+## Tests
+
+- `src/lib/__tests__/offlineActionQueue.test.ts` — queue position/length/
+  subscribe/dequeue semantics.
+- `src/hooks/__tests__/useOnlineStatus.test.tsx` — seed + online/offline
+  event transitions.
+- `src/components/__tests__/ToastNotification.action.test.tsx` — action
+  renders only when both props are set; click fires `onAction` then
+  `onClose`.
+- `src/components/__tests__/CreateStreamModal.offlineQueue.test.tsx` —
+  captures instead of calling `createStream` while offline; announces the
+  queued banner + position; Close stays operable and Back is blocked while
+  queued; auto-flush success (calls `createStream` with the exact snapshot,
+  fires `onStreamCreated`/`onClose`, and calls `addToast` with the
+  View-stream action); auto-flush failure (shows the recoverable banner,
+  Edit details returns to step 1).
+
+## Known limitations (by design, matches existing "defer to Phase 3")
+
+- Queue is per-tab/in-memory: a page reload while a submission is queued
+  loses it silently (no persistence layer yet). If this needs to survive
+  reload, treat it as scope for the deferred PWA/offline phase, not a patch
+  here.
+- No manual "cancel this queued submission" affordance — closing/canceling
+  the modal does not remove it from the queue (it still flushes in the
+  background, matching the "no need to resubmit" promise in the banner
+  copy). Add one if product wants users to be able to abandon a queued
+  submission outright.

--- a/src/components/CreateStreamModal.css
+++ b/src/components/CreateStreamModal.css
@@ -835,6 +835,88 @@
   opacity: 0.7;
 }
 
+/* Offline action-queue banner (Step 3). Body copy always uses var(--text) /
+ * var(--text-secondary) — verified >4.5:1 on var(--surface-raised) in both
+ * themes. Status color is limited to the icon + left border accent (a
+ * decorative, redundant cue alongside the text label, not the sole indicator). */
+.offline-queue-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.625rem;
+  padding: 0.75rem 0.875rem;
+  margin-bottom: 1rem;
+  border: 1px solid var(--border);
+  border-left: 4px solid var(--status-warning);
+  border-radius: 8px;
+  background: var(--surface-raised);
+  color: var(--text);
+  font-size: 0.8125rem;
+  line-height: 1.45;
+}
+
+.offline-queue-banner__icon {
+  flex-shrink: 0;
+  margin-top: 0.0625rem;
+  color: var(--status-warning);
+}
+
+.offline-queue-banner__body {
+  min-width: 0;
+}
+
+.offline-queue-banner__body p {
+  margin: 0.25rem 0 0;
+}
+
+.offline-queue-banner__title {
+  display: block;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.offline-queue-banner__position {
+  display: block;
+  margin-top: 0.5rem;
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+}
+
+.offline-queue-banner--failed {
+  border-left-color: var(--danger);
+}
+
+.offline-queue-banner--failed .offline-queue-banner__icon {
+  color: var(--danger);
+}
+
+.offline-queue-banner__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.625rem;
+}
+
+.offline-queue-banner__btn {
+  padding: 0.375rem 0.625rem;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface-elevated);
+  color: var(--text);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.offline-queue-banner__btn:hover {
+  background: var(--surface-highest);
+}
+
+.offline-queue-banner__btn--primary {
+  background: var(--color-cta-primary-bg);
+  color: var(--color-text-inverse);
+  border: none;
+}
+
 /* ==============================================
    RESPONSIVE STYLES
    ============================================== */
@@ -1053,6 +1135,15 @@
     align-self: flex-start;
   }
 
+  .offline-queue-banner {
+    padding: 0.625rem 0.75rem;
+    font-size: 0.75rem;
+  }
+
+  .offline-queue-banner__btn {
+    align-self: flex-start;
+  }
+
   .modal-footer {
     gap: 0.5rem;
     margin-top: 0.875rem;
@@ -1143,6 +1234,10 @@
   }
 
   .review-error-box {
+    font-size: 0.6875rem;
+  }
+
+  .offline-queue-banner {
     font-size: 0.6875rem;
   }
 

--- a/src/components/CreateStreamModal.tsx
+++ b/src/components/CreateStreamModal.tsx
@@ -7,6 +7,14 @@ import { useModalAccessibility } from './useModalAccessibility';
 import { useWallet } from './wallet-connect/Walletcontext';
 import { useToast } from './toast/ToastProvider';
 import { useTransactionStatus } from '../hooks/useTransactionStatus';
+import { useOnlineStatus } from '../hooks/useOnlineStatus';
+import {
+  enqueueAction,
+  dequeueAction,
+  getQueuePosition,
+  getQueueLength,
+  subscribeToQueue,
+} from '../lib/offlineActionQueue';
 import { createStream, getTransactionStatus } from '../lib/stellar/tx';
 import { isValidStellarAddress, maskAddress } from '../lib/stellar';
 import {
@@ -106,6 +114,17 @@ function validateDuration(value: string, t: any): string | undefined {
   return undefined;
 }
 
+/** Snapshot of everything `createStream` needs, captured at submit time so a
+ * queued (offline) submission replays with the exact values the user reviewed. */
+interface StreamSubmissionPayload {
+  sender: string;
+  recipient: string;
+  amount: string;
+  start: number;
+  end: number;
+  cliffTime?: number;
+}
+
 interface CreateStreamModalProps {
   isOpen: boolean;
   onClose: () => void;
@@ -143,9 +162,18 @@ export default function CreateStreamModal({
   const [submittedTxHash, setSubmittedTxHash] = useState<string | null>(null);
   const [hasCompletedConfirmation, setHasCompletedConfirmation] =
     useState(false);
+  const [queuedSubmission, setQueuedSubmission] = useState<
+    { id: string; position: number } | null
+  >(null);
+  const [queueLength, setQueueLength] = useState(0);
+  const [isFlushingQueue, setIsFlushingQueue] = useState(false);
+  const [queueFlushError, setQueueFlushError] = useState<string | null>(null);
   const modalRef = useRef<HTMLDivElement>(null);
   const recipientInputRef = useRef<HTMLInputElement>(null);
   const submitInFlightRef = useRef(false);
+  const pendingSubmissionRef = useRef<StreamSubmissionPayload | null>(null);
+  const flushedFromQueueRef = useRef(false);
+  const isOnline = useOnlineStatus();
 
   const handleBlur = (field: string) => {
     setTouched(prev => ({ ...prev, [field]: true }));
@@ -160,17 +188,27 @@ export default function CreateStreamModal({
     getStatus: getTransactionStatus,
   });
   const isConfirmationPending = transactionStatus.status === "pending";
-  const isBusyCreating = isSubmitting || isConfirmationPending;
+  const isQueued = Boolean(queuedSubmission);
+  // Actively in-flight (network round trip or wallet signature); close/cancel
+  // stay blocked here, same as today. `isQueued` alone does NOT block them —
+  // a queued submission is just captured locally, nothing is in flight yet.
+  const isActivelySubmitting =
+    isSubmitting || isConfirmationPending || isFlushingQueue;
+  const isBusyCreating = isActivelySubmitting || isQueued;
   const submitButtonLabel =
-    currentStep === 3 && isSubmitting
-      ? t("createStream.button.submitting")
-      : currentStep === 3 && isConfirmationPending
-        ? t("createStream.button.confirming")
-        : currentStep === 3 && transactionStatus.status === "failed"
-          ? t("createStream.button.retry")
-          : currentStep === 2
-            ? t("createStream.button.next")
-            : t("createStream.button.create");
+    currentStep === 3 && isQueued
+      ? t("createStream.button.queued")
+      : currentStep === 3 && isFlushingQueue
+        ? t("createStream.button.flushing")
+        : currentStep === 3 && isSubmitting
+          ? t("createStream.button.submitting")
+          : currentStep === 3 && isConfirmationPending
+            ? t("createStream.button.confirming")
+            : currentStep === 3 && transactionStatus.status === "failed"
+              ? t("createStream.button.retry")
+              : currentStep === 2
+                ? t("createStream.button.next")
+                : t("createStream.button.create");
 
   useModalAccessibility({
     isOpen,
@@ -178,6 +216,63 @@ export default function CreateStreamModal({
     modalRef,
     initialFocusRef: recipientInputRef,
   });
+
+  const getStreamErrorMessage = (err: unknown): string => {
+    if (err instanceof Error && err.message.trim()) {
+      return err.message;
+    }
+    return t("createStream.error.generic");
+  };
+
+  const buildSubmissionPayload = (): StreamSubmissionPayload => {
+    const sender = wallet.address!;
+    const parsedAmount = parseFloat(depositAmount.replace(/,/g, "")) || 0;
+    const amount = Math.floor(parsedAmount * 10_000_000).toString();
+
+    const start = startTimeOption === "now"
+      ? Math.floor(Date.now() / 1000)
+      : Math.floor(new Date(customStartDate).getTime() / 1000);
+
+    const durationDays = parseFloat(duration) || 0;
+    const durationSeconds = Math.floor(durationDays * 24 * 60 * 60);
+    const end = start + durationSeconds;
+
+    const cliffTime = cliffEnabled && cliffDate
+      ? Math.floor(new Date(cliffDate).getTime() / 1000)
+      : undefined;
+
+    return { sender, recipient: recipient.trim(), amount, start, end, cliffTime };
+  };
+
+  /** Submits a payload to the network. Identical for the immediate-online
+   * path and a queue flush — the confirmation/success/error handling that
+   * follows (polling, toast, onStreamCreated, onClose) is the same either way. */
+  const submitPayload = async (payload: StreamSubmissionPayload) => {
+    submitInFlightRef.current = true;
+    setIsSubmitting(true);
+    try {
+      const response = await createStream(
+        payload.sender,
+        payload.recipient,
+        payload.amount,
+        payload.start,
+        payload.end,
+        payload.cliffTime,
+      );
+      if (!response.txHash) {
+        throw new Error("Missing transaction hash from Stellar RPC.");
+      }
+      setSubmittedTxHash(response.txHash);
+    } catch (err) {
+      const message = getStreamErrorMessage(err);
+      setStreamError(message);
+      addToast(t("createStream.error.failedWithMessage", { message }), "error");
+      onStreamError?.(err);
+    } finally {
+      submitInFlightRef.current = false;
+      setIsSubmitting(false);
+    }
+  };
 
   useEffect(() => {
     if (
@@ -188,7 +283,15 @@ export default function CreateStreamModal({
     }
 
     setHasCompletedConfirmation(true);
-    addToast(t("createStream.success.message"), "success");
+    if (flushedFromQueueRef.current) {
+      flushedFromQueueRef.current = false;
+      addToast(t("createStream.queue.flushSuccessToast"), "success", undefined, {
+        label: t("createStream.queue.viewStreamAction"),
+        onClick: () => onStreamCreated?.(),
+      });
+    } else {
+      addToast(t("createStream.success.message"), "success");
+    }
     onStreamCreated?.();
     onClose();
   }, [
@@ -200,10 +303,75 @@ export default function CreateStreamModal({
     t,
   ]);
 
+  // Auto-flush a queued submission as soon as connectivity returns. Runs even
+  // while the modal is closed (isOpen=false only skips rendering — this
+  // component and its effects stay mounted for the lifetime of the parent).
+  useEffect(() => {
+    if (!isOnline || !queuedSubmission) return;
+
+    const submission = queuedSubmission;
+    const payload = pendingSubmissionRef.current;
+    if (!payload) return;
+
+    let cancelled = false;
+
+    const flush = async () => {
+      setIsFlushingQueue(true);
+      try {
+        const response = await createStream(
+          payload.sender,
+          payload.recipient,
+          payload.amount,
+          payload.start,
+          payload.end,
+          payload.cliffTime,
+        );
+        if (cancelled) return;
+        if (!response.txHash) {
+          throw new Error("Missing transaction hash from Stellar RPC.");
+        }
+        dequeueAction(submission.id);
+        pendingSubmissionRef.current = null;
+        flushedFromQueueRef.current = true;
+        setQueuedSubmission(null);
+        setQueueLength(getQueueLength());
+        setSubmittedTxHash(response.txHash);
+      } catch (err) {
+        if (cancelled) return;
+        dequeueAction(submission.id);
+        setQueuedSubmission(null);
+        setQueueLength(getQueueLength());
+        setQueueFlushError(getStreamErrorMessage(err));
+      } finally {
+        if (!cancelled) setIsFlushingQueue(false);
+      }
+    };
+
+    void flush();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- keyed on queuedSubmission.id via isOnline+id; the payload comes from a ref, not a dep.
+  }, [isOnline, queuedSubmission?.id]);
+
+  // Keeps the displayed queue position in sync if other queued actions ahead
+  // of this one flush or get removed (multi-submission scenario).
+  useEffect(() => {
+    if (!queuedSubmission) return;
+    return subscribeToQueue(() => {
+      setQueuedSubmission((prev) =>
+        prev ? { ...prev, position: getQueuePosition(prev.id) } : prev,
+      );
+      setQueueLength(getQueueLength());
+    });
+  }, [queuedSubmission?.id]);
+
   const resetTransactionState = () => {
     transactionStatus.reset();
     setSubmittedTxHash(null);
     setHasCompletedConfirmation(false);
+    setQueueFlushError(null);
+    flushedFromQueueRef.current = false;
   };
 
   const validateStep1 = (): boolean => {
@@ -302,13 +470,6 @@ export default function CreateStreamModal({
     return true;
   };
 
-  const getStreamErrorMessage = (err: unknown): string => {
-    if (err instanceof Error && err.message.trim()) {
-      return err.message;
-    }
-    return t("createStream.error.generic");
-  };
-
   const handleNext = async () => {
     if (isBusyCreating) return;
 
@@ -340,50 +501,44 @@ export default function CreateStreamModal({
       setError(null);
       setStreamError(null);
       resetTransactionState();
-      submitInFlightRef.current = true;
-      setIsSubmitting(true);
 
-      const sender = wallet.address!;
-      const parsedAmount = parseFloat(depositAmount.replace(/,/g, "")) || 0;
-      const amountStr = Math.floor(parsedAmount * 10_000_000).toString();
+      const payload = buildSubmissionPayload();
 
-      const start = startTimeOption === "now"
-        ? Math.floor(Date.now() / 1000)
-        : Math.floor(new Date(customStartDate).getTime() / 1000);
-
-      const durationDays = parseFloat(duration) || 0;
-      const durationSeconds = Math.floor(durationDays * 24 * 60 * 60);
-      const end = start + durationSeconds;
-
-      const cliffTime = cliffEnabled && cliffDate
-        ? Math.floor(new Date(cliffDate).getTime() / 1000)
-        : undefined;
-
-      try {
-        const response = await createStream(
-          sender,
-          recipient.trim(),
-          amountStr,
-          start,
-          end,
-          cliffTime,
-        );
-        if (!response.txHash) {
-          throw new Error("Missing transaction hash from Stellar RPC.");
-        }
-        // Hand off to the confirmation poller; the success toast,
-        // onStreamCreated, and onClose fire once polling reports `confirmed`.
-        setSubmittedTxHash(response.txHash);
-      } catch (err) {
-        const message = getStreamErrorMessage(err);
-        setStreamError(message);
-        addToast(t("createStream.error.failedWithMessage", { message }), "error");
-        onStreamError?.(err);
-      } finally {
-        submitInFlightRef.current = false;
-        setIsSubmitting(false);
+      if (!isOnline) {
+        // Capture locally instead of hanging on a request that can't reach
+        // the network. Flushed automatically by the effect above once the
+        // `online` event fires.
+        const entry = enqueueAction(payload);
+        pendingSubmissionRef.current = payload;
+        setQueuedSubmission({ id: entry.id, position: getQueuePosition(entry.id) });
+        setQueueLength(getQueueLength());
+        return;
       }
+
+      // Unchanged online path.
+      await submitPayload(payload);
     }
+  };
+
+  const handleRetryQueuedSubmission = async () => {
+    const payload = pendingSubmissionRef.current;
+    if (!payload) return;
+    setQueueFlushError(null);
+
+    if (!isOnline) {
+      const entry = enqueueAction(payload);
+      setQueuedSubmission({ id: entry.id, position: getQueuePosition(entry.id) });
+      setQueueLength(getQueueLength());
+      return;
+    }
+
+    await submitPayload(payload);
+  };
+
+  const handleEditQueuedSubmission = () => {
+    setQueueFlushError(null);
+    pendingSubmissionRef.current = null;
+    setCurrentStep(1);
   };
 
   const handleBack = () => {
@@ -400,12 +555,14 @@ export default function CreateStreamModal({
   };
 
   const handleCancel = () => {
-    if (isBusyCreating) return;
+    // Intentionally checks isActivelySubmitting, not isBusyCreating: a
+    // queued-offline submission must not block Cancel from closing the modal.
+    if (isActivelySubmitting) return;
     onClose();
   };
 
   const handleClose = () => {
-    if (isBusyCreating) return;
+    if (isActivelySubmitting) return;
     onClose();
   };
 
@@ -434,7 +591,7 @@ export default function CreateStreamModal({
             type="button"
             className="close-button"
             onClick={handleClose}
-            disabled={isBusyCreating}
+            disabled={isActivelySubmitting}
             aria-label={t("createStream.accessibility.closeLabel")}
           >
             <svg
@@ -1179,6 +1336,72 @@ export default function CreateStreamModal({
                     <strong>{t("createStream.step3.warningTitle")}</strong>{" "}
                     {t("createStream.step3.warningText", { reviewDeposit })}
                   </div>
+                  {queuedSubmission && (
+                    <div
+                      className="offline-queue-banner"
+                      role="status"
+                      aria-live="polite"
+                    >
+                      <span className="offline-queue-banner__icon" aria-hidden="true">
+                        <svg width="18" height="18" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                          <circle cx="12" cy="12" r="9" />
+                          <path strokeLinecap="round" strokeLinejoin="round" d="M12 7v5l3 3" />
+                        </svg>
+                      </span>
+                      <div className="offline-queue-banner__body">
+                        <strong className="offline-queue-banner__title">
+                          {t("createStream.queue.bannerTitle")}
+                        </strong>
+                        <p>{t("createStream.queue.bannerBody")}</p>
+                        <span className="offline-queue-banner__position">
+                          {t("createStream.queue.bannerPosition", {
+                            position: queuedSubmission.position,
+                            total: Math.max(queueLength, queuedSubmission.position),
+                          })}
+                        </span>
+                      </div>
+                    </div>
+                  )}
+                  {isFlushingQueue && (
+                    <div
+                      className="transaction-status-box"
+                      role="status"
+                      aria-live="polite"
+                    >
+                      {t("createStream.queue.flushingTitle")}
+                    </div>
+                  )}
+                  {queueFlushError && (
+                    <div className="offline-queue-banner offline-queue-banner--failed" role="alert">
+                      <span className="offline-queue-banner__icon" aria-hidden="true">
+                        <svg width="18" height="18" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                          <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v4m0 4h.01M10.29 3.86l-8.48 14.7A1 1 0 002.66 20h18.68a1 1 0 00.85-1.44l-8.48-14.7a1 1 0 00-1.72 0z" />
+                        </svg>
+                      </span>
+                      <div className="offline-queue-banner__body">
+                        <strong className="offline-queue-banner__title">
+                          {t("createStream.queue.flushFailedTitle")}
+                        </strong>
+                        <p>{queueFlushError}</p>
+                        <div className="offline-queue-banner__actions">
+                          <button
+                            type="button"
+                            className="offline-queue-banner__btn offline-queue-banner__btn--primary"
+                            onClick={handleRetryQueuedSubmission}
+                          >
+                            {t("createStream.queue.flushFailedRetryBtn")}
+                          </button>
+                          <button
+                            type="button"
+                            className="offline-queue-banner__btn"
+                            onClick={handleEditQueuedSubmission}
+                          >
+                            {t("createStream.queue.flushFailedEditBtn")}
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  )}
                   {isSubmitting && (
                     <div
                       className="transaction-status-box"

--- a/src/components/ToastNotification.css
+++ b/src/components/ToastNotification.css
@@ -122,6 +122,31 @@
   font: var(--font-body-md, 400 0.875rem/1.5 "Plus Jakarta Sans", sans-serif);
 }
 
+/* var(--accent) is the same teal in both themes — legible against this
+   toast's always-dark chrome regardless of the app's light/dark theme. */
+.toast-notification__action {
+  display: inline-flex;
+  margin-top: 0.5rem;
+  padding: 0;
+  border: 0;
+  background: none;
+  color: var(--accent);
+  font: var(--font-label-md, 600 0.75rem/1.2 "Plus Jakarta Sans", sans-serif);
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.toast-notification__action:hover,
+.toast-notification__action:focus-visible {
+  color: var(--accent-dim);
+}
+
+.toast-notification__action:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
 .toast-notification__close {
   display: inline-flex;
   align-items: center;

--- a/src/components/ToastNotification.tsx
+++ b/src/components/ToastNotification.tsx
@@ -6,6 +6,9 @@ interface ToastNotificationProps {
   message: string;
   variant: ToastVariant;
   onClose: () => void;
+  /** Optional inline action (e.g. "View stream"). Rendered only when both are set. */
+  actionLabel?: string;
+  onAction?: () => void;
 }
 
 const TOAST_COPY: Record<ToastVariant, { label: string; icon: string }> = {
@@ -45,6 +48,8 @@ export default function ToastNotification({
   message,
   variant,
   onClose,
+  actionLabel,
+  onAction,
 }: ToastNotificationProps) {
   const semantics = VARIANT_SEMANTICS[variant] ?? FALLBACK_SEMANTICS;
 
@@ -62,6 +67,18 @@ export default function ToastNotification({
       <div className="toast-notification__content">
         <p className="toast-notification__eyebrow">{label}</p>
         <p className="toast-notification__message">{message}</p>
+        {actionLabel && onAction && (
+          <button
+            type="button"
+            className="toast-notification__action"
+            onClick={() => {
+              onAction();
+              onClose();
+            }}
+          >
+            {actionLabel}
+          </button>
+        )}
       </div>
       <button
         type="button"

--- a/src/components/__tests__/CreateStreamModal.offlineQueue.test.tsx
+++ b/src/components/__tests__/CreateStreamModal.offlineQueue.test.tsx
@@ -1,0 +1,210 @@
+import { act, fireEvent, render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import CreateStreamModal from "../CreateStreamModal";
+import { createStream, getTransactionStatus } from "../../lib/stellar/tx";
+import { useToast } from "../toast/ToastProvider";
+import { __resetOfflineQueueForTests } from "../../lib/offlineActionQueue";
+
+vi.mock("../wallet-connect/Walletcontext", () => ({
+  useWallet: () => ({
+    address: "GDBWW22BDP5HN3ZTG7LLID665PA72DGOLOONLUM5TKQFRAQA3EYGKIRC",
+    network: "TESTNET",
+    connected: true,
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+  }),
+}));
+
+vi.mock("../../lib/stellar/tx", () => ({
+  createStream: vi.fn(),
+  getTransactionStatus: vi.fn(),
+}));
+
+const VALID_STELLAR =
+  "GATDOSCZNJ5YZHNOX7IOD4QDCQSTMR2YNF5IXHFNX3H6B4ICCMSDLOWN";
+
+function setOnline(online: boolean) {
+  Object.defineProperty(navigator, "onLine", {
+    value: online,
+    configurable: true,
+  });
+}
+
+function goOnline() {
+  act(() => {
+    setOnline(true);
+    window.dispatchEvent(new Event("online"));
+  });
+}
+
+function advanceToReview(container: HTMLElement) {
+  fireEvent.change(
+    container.querySelector("#create-stream-recipient") as HTMLInputElement,
+    { target: { value: VALID_STELLAR } },
+  );
+  fireEvent.change(
+    container.querySelector("#create-stream-deposit") as HTMLInputElement,
+    { target: { value: "100" } },
+  );
+  fireEvent.click(within(container).getByRole("button", { name: /^next$/i }));
+  fireEvent.click(within(container).getByRole("button", { name: /^next$/i }));
+}
+
+describe("CreateStreamModal offline action queue", () => {
+  afterEach(() => {
+    setOnline(true);
+    __resetOfflineQueueForTests();
+    vi.clearAllMocks();
+  });
+
+  it("captures a step-3 submission into the queue instead of calling createStream when offline", async () => {
+    setOnline(false);
+    const onClose = vi.fn();
+    const { container } = render(
+      <CreateStreamModal isOpen={true} onClose={onClose} />,
+    );
+
+    advanceToReview(container);
+    fireEvent.click(
+      within(container).getByRole("button", { name: /^create stream$/i }),
+    );
+
+    const banner = await screen.findByText(/queued.*will submit when back online/i);
+    expect(banner).toBeInTheDocument();
+    expect(banner.closest('[role="status"]')).toHaveAttribute("aria-live", "polite");
+    expect(screen.getByText(/queue position: 1 of 1/i)).toBeInTheDocument();
+    expect(createStream).not.toHaveBeenCalled();
+  });
+
+  it("keeps Close operable while a submission is queued", async () => {
+    setOnline(false);
+    const onClose = vi.fn();
+    const { container } = render(
+      <CreateStreamModal isOpen={true} onClose={onClose} />,
+    );
+
+    advanceToReview(container);
+    fireEvent.click(
+      within(container).getByRole("button", { name: /^create stream$/i }),
+    );
+    await screen.findByText(/queued.*will submit when back online/i);
+
+    const closeButton = screen.getByRole("button", { name: /close create stream modal/i });
+    expect(closeButton).not.toBeDisabled();
+
+    fireEvent.click(closeButton);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("blocks Back/Next while queued so the captured payload can't be edited out from under it", async () => {
+    setOnline(false);
+    const { container } = render(
+      <CreateStreamModal isOpen={true} onClose={vi.fn()} />,
+    );
+
+    advanceToReview(container);
+    fireEvent.click(
+      within(container).getByRole("button", { name: /^create stream$/i }),
+    );
+    await screen.findByText(/queued.*will submit when back online/i);
+
+    expect(within(container).getByRole("button", { name: /^back$/i })).toBeDisabled();
+  });
+
+  it("auto-flushes on reconnect and surfaces a success toast with a View stream action", async () => {
+    vi.mocked(createStream).mockResolvedValue({
+      status: "SUCCESS",
+      txHash: "queuedtxhash123",
+    } as any);
+    vi.mocked(getTransactionStatus).mockResolvedValue("confirmed");
+
+    setOnline(false);
+    const onClose = vi.fn();
+    const onStreamCreated = vi.fn();
+    const { container } = render(
+      <CreateStreamModal isOpen={true} onClose={onClose} onStreamCreated={onStreamCreated} />,
+    );
+
+    advanceToReview(container);
+    fireEvent.click(
+      within(container).getByRole("button", { name: /^create stream$/i }),
+    );
+    await screen.findByText(/queued.*will submit when back online/i);
+    expect(createStream).not.toHaveBeenCalled();
+
+    goOnline();
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(createStream).toHaveBeenCalledTimes(1);
+    expect(createStream).toHaveBeenCalledWith(
+      "GDBWW22BDP5HN3ZTG7LLID665PA72DGOLOONLUM5TKQFRAQA3EYGKIRC",
+      VALID_STELLAR,
+      "1000000000",
+      expect.any(Number),
+      expect.any(Number),
+      undefined,
+    );
+    expect(onStreamCreated).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    const { addToast } = useToast();
+    expect(addToast).toHaveBeenCalledWith(
+      expect.stringMatching(/queued stream was submitted/i),
+      "success",
+      undefined,
+      expect.objectContaining({
+        label: expect.stringMatching(/view stream/i),
+        onClick: expect.any(Function),
+      }),
+    );
+  });
+
+  it("shows a recoverable failure banner if the queued submission is rejected on reconnect", async () => {
+    vi.mocked(createStream).mockRejectedValue(
+      new Error("Insufficient balance to fund this stream."),
+    );
+
+    setOnline(false);
+    const { container } = render(
+      <CreateStreamModal isOpen={true} onClose={vi.fn()} />,
+    );
+
+    advanceToReview(container);
+    fireEvent.click(
+      within(container).getByRole("button", { name: /^create stream$/i }),
+    );
+    await screen.findByText(/queued.*will submit when back online/i);
+
+    goOnline();
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(
+      screen.getByText(/queued stream couldn't be submitted/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/insufficient balance to fund this stream/i),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /retry now/i })).toBeInTheDocument();
+
+    // No longer shown as queued — it was dequeued when the flush failed.
+    expect(
+      screen.queryByText(/queued.*will submit when back online/i),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /edit details/i }));
+
+    expect(
+      container.querySelector("#create-stream-recipient"),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/ToastNotification.action.test.tsx
+++ b/src/components/__tests__/ToastNotification.action.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import ToastNotification from "../ToastNotification";
+
+describe("ToastNotification action", () => {
+  it("does not render an action button when actionLabel/onAction are absent", () => {
+    render(<ToastNotification message="msg" variant="success" onClose={() => {}} />);
+    expect(screen.queryByRole("button", { name: /view stream/i })).not.toBeInTheDocument();
+  });
+
+  it("renders the action and calls both onAction and onClose when clicked", () => {
+    const onAction = vi.fn();
+    const onClose = vi.fn();
+    render(
+      <ToastNotification
+        message="Your queued stream was submitted."
+        variant="success"
+        onClose={onClose}
+        actionLabel="View stream"
+        onAction={onAction}
+      />,
+    );
+
+    screen.getByRole("button", { name: "View stream" }).click();
+
+    expect(onAction).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not render the action if only one of actionLabel/onAction is provided", () => {
+    render(
+      <ToastNotification
+        message="msg"
+        variant="success"
+        onClose={() => {}}
+        actionLabel="View stream"
+      />,
+    );
+    expect(screen.queryByRole("button", { name: /view stream/i })).not.toBeInTheDocument();
+  });
+});

--- a/src/components/toast/ToastProvider.tsx
+++ b/src/components/toast/ToastProvider.tsx
@@ -12,16 +12,27 @@ import type { ToastVariant } from "../ToastNotification";
 
 export type { ToastVariant };
 
+export interface ToastAction {
+  label: string;
+  onClick: () => void;
+}
+
 export interface Toast {
   id: string;
   message: string;
   variant: ToastVariant;
   timeout: number;
+  action?: ToastAction;
 }
 
 interface ToastContextValue {
   /** Add a toast to the queue. Returns the generated id. */
-  addToast: (message: string, variant: ToastVariant, timeout?: number) => string;
+  addToast: (
+    message: string,
+    variant: ToastVariant,
+    timeout?: number,
+    action?: ToastAction,
+  ) => string;
   /** Manually dismiss a toast by id. */
   dismiss: (id: string) => void;
 }
@@ -55,9 +66,14 @@ export function ToastProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const addToast = useCallback(
-    (message: string, variant: ToastVariant, timeout = DEFAULT_TIMEOUT): string => {
+    (
+      message: string,
+      variant: ToastVariant,
+      timeout = DEFAULT_TIMEOUT,
+      action?: ToastAction,
+    ): string => {
       const id = crypto.randomUUID();
-      setToasts((prev) => [...prev, { id, message, variant, timeout }]);
+      setToasts((prev) => [...prev, { id, message, variant, timeout, action }]);
       return id;
     },
     [],
@@ -110,6 +126,8 @@ export function ToastProvider({ children }: { children: ReactNode }) {
             message={toast.message}
             variant={toast.variant}
             onClose={() => dismiss(toast.id)}
+            actionLabel={toast.action?.label}
+            onAction={toast.action?.onClick}
           />
         ))}
       </div>

--- a/src/hooks/__tests__/useOnlineStatus.test.tsx
+++ b/src/hooks/__tests__/useOnlineStatus.test.tsx
@@ -1,0 +1,37 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { useOnlineStatus } from "../useOnlineStatus";
+
+describe("useOnlineStatus", () => {
+  afterEach(() => {
+    Object.defineProperty(navigator, "onLine", {
+      value: true,
+      configurable: true,
+    });
+  });
+
+  it("seeds from navigator.onLine", () => {
+    Object.defineProperty(navigator, "onLine", {
+      value: false,
+      configurable: true,
+    });
+
+    const { result } = renderHook(() => useOnlineStatus());
+    expect(result.current).toBe(false);
+  });
+
+  it("flips to false on the offline event and back to true on online", () => {
+    const { result } = renderHook(() => useOnlineStatus());
+    expect(result.current).toBe(true);
+
+    act(() => {
+      window.dispatchEvent(new Event("offline"));
+    });
+    expect(result.current).toBe(false);
+
+    act(() => {
+      window.dispatchEvent(new Event("online"));
+    });
+    expect(result.current).toBe(true);
+  });
+});

--- a/src/hooks/useOnlineStatus.ts
+++ b/src/hooks/useOnlineStatus.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Tracks browser connectivity via the `online`/`offline` window events,
+ * seeded from `navigator.onLine`. Used to decide whether a submission should
+ * go straight to the network or be captured into the offline action queue.
+ */
+export function useOnlineStatus(): boolean {
+  const [isOnline, setIsOnline] = useState(() =>
+    typeof navigator === "undefined" ? true : navigator.onLine,
+  );
+
+  useEffect(() => {
+    const handleOnline = () => setIsOnline(true);
+    const handleOffline = () => setIsOnline(false);
+
+    window.addEventListener("online", handleOnline);
+    window.addEventListener("offline", handleOffline);
+
+    return () => {
+      window.removeEventListener("online", handleOnline);
+      window.removeEventListener("offline", handleOffline);
+    };
+  }, []);
+
+  return isOnline;
+}

--- a/src/hooks/useTransactionStatus.ts
+++ b/src/hooks/useTransactionStatus.ts
@@ -6,13 +6,24 @@ import { transactionPollingConfig } from "../lib/transactionConfig";
  *
  * `confirmed` and `failed` must come from the status source, not optimistic
  * client-side time.
+ *
+ * `queued`, `flushing`, and `queue-failed` extend the lifecycle for
+ * submissions captured by the offline action queue (see
+ * `src/lib/offlineActionQueue.ts` and docs/OFFLINE_ACTION_QUEUE_SPEC.md).
+ * This hook never sets them itself — it only polls once a real tx hash
+ * exists — callers (e.g. CreateStreamModal) set them before that hash is
+ * available: `queued` while offline, `flushing` while auto-resubmitting on
+ * reconnect, and `queue-failed` if that resubmission is rejected.
  */
 export type TxStatus =
   | "idle"
+  | "queued"
   | "submitting"
+  | "flushing"
   | "pending"
   | "confirmed"
-  | "failed";
+  | "failed"
+  | "queue-failed";
 
 export type PolledTxStatus = Extract<TxStatus, "pending" | "confirmed" | "failed">;
 

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -87,6 +87,19 @@ export const en = {
   "createStream.step3.statusDetail": "Confirmation check {attempts} - tx {txHash}",
   "createStream.step3.statusFailed": "{error}",
 
+  // CreateStreamModal Step 3 / Offline action queue
+  "createStream.queue.bannerTitle": "Queued — will submit when back online",
+  "createStream.queue.bannerBody": "You're offline. We saved your stream details on this device and will submit them automatically the moment your connection returns — no need to resubmit.",
+  "createStream.queue.bannerPosition": "Queue position: {position} of {total}",
+  "createStream.queue.flushingTitle": "Back online. Submitting your queued stream to Stellar…",
+  "createStream.queue.flushSuccessToast": "Your queued stream was submitted and confirmed on Stellar.",
+  "createStream.queue.viewStreamAction": "View stream",
+  "createStream.queue.flushFailedTitle": "Your queued stream couldn't be submitted.",
+  "createStream.queue.flushFailedRetryBtn": "Retry now",
+  "createStream.queue.flushFailedEditBtn": "Edit details",
+  "createStream.button.queued": "Queued — waiting for connection",
+  "createStream.button.flushing": "Submitting queued stream...",
+
   // CreateStreamModal Buttons & Validation
   "createStream.button.submitting": "Submitting...",
   "createStream.button.confirming": "Confirming...",

--- a/src/lib/__tests__/offlineActionQueue.test.ts
+++ b/src/lib/__tests__/offlineActionQueue.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  __resetOfflineQueueForTests,
+  dequeueAction,
+  enqueueAction,
+  getQueueLength,
+  getQueuePosition,
+  subscribeToQueue,
+} from "../offlineActionQueue";
+
+describe("offlineActionQueue", () => {
+  afterEach(() => {
+    __resetOfflineQueueForTests();
+  });
+
+  it("assigns 1-based positions in enqueue order", () => {
+    const first = enqueueAction({ n: 1 });
+    const second = enqueueAction({ n: 2 });
+
+    expect(getQueuePosition(first.id)).toBe(1);
+    expect(getQueuePosition(second.id)).toBe(2);
+    expect(getQueueLength()).toBe(2);
+  });
+
+  it("returns 0 for an id that was never queued or already removed", () => {
+    expect(getQueuePosition("missing")).toBe(0);
+
+    const entry = enqueueAction({ n: 1 });
+    dequeueAction(entry.id);
+    expect(getQueuePosition(entry.id)).toBe(0);
+  });
+
+  it("shifts positions down for items behind a dequeued entry", () => {
+    const first = enqueueAction({ n: 1 });
+    const second = enqueueAction({ n: 2 });
+
+    dequeueAction(first.id);
+
+    expect(getQueuePosition(second.id)).toBe(1);
+    expect(getQueueLength()).toBe(1);
+  });
+
+  it("notifies subscribers on enqueue and dequeue, and unsubscribe stops further notifications", () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeToQueue(listener);
+
+    const entry = enqueueAction({ n: 1 });
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    dequeueAction(entry.id);
+    expect(listener).toHaveBeenCalledTimes(2);
+
+    unsubscribe();
+    enqueueAction({ n: 2 });
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it("dequeueAction is a no-op for an id that isn't queued", () => {
+    const listener = vi.fn();
+    subscribeToQueue(listener);
+
+    dequeueAction("never-queued");
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/offlineActionQueue.ts
+++ b/src/lib/offlineActionQueue.ts
@@ -1,0 +1,66 @@
+/**
+ * In-memory, per-tab queue for submissions captured while offline.
+ *
+ * Scope: this backs the "Queued — will submit when back online" banner in
+ * CreateStreamModal. It intentionally does NOT persist to storage — a full
+ * reload clears it, matching the offline/PWA scope already deferred in
+ * DESIGN_SPEC.md ("PWA/offline mode: defer to Phase 3"). See
+ * docs/OFFLINE_ACTION_QUEUE_SPEC.md for the limitation and rationale.
+ */
+
+export interface QueuedAction<T = unknown> {
+  id: string;
+  payload: T;
+  enqueuedAt: number;
+}
+
+type Listener = () => void;
+
+let queue: QueuedAction[] = [];
+const listeners = new Set<Listener>();
+
+function notify(): void {
+  listeners.forEach((listener) => listener());
+}
+
+/** Adds a payload to the tail of the queue and returns its queue entry. */
+export function enqueueAction<T>(payload: T): QueuedAction<T> {
+  const action: QueuedAction<T> = {
+    id: crypto.randomUUID(),
+    payload,
+    enqueuedAt: Date.now(),
+  };
+  queue = [...queue, action];
+  notify();
+  return action;
+}
+
+/** Removes a queued action by id (no-op if already removed). */
+export function dequeueAction(id: string): void {
+  if (!queue.some((action) => action.id === id)) return;
+  queue = queue.filter((action) => action.id !== id);
+  notify();
+}
+
+/** 1-based position of an action in the queue, or 0 if it isn't queued. */
+export function getQueuePosition(id: string): number {
+  const index = queue.findIndex((action) => action.id === id);
+  return index === -1 ? 0 : index + 1;
+}
+
+/** Total number of actions currently queued. */
+export function getQueueLength(): number {
+  return queue.length;
+}
+
+/** Subscribes to queue changes (enqueue/dequeue). Returns an unsubscribe fn. */
+export function subscribeToQueue(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+/** Test-only: resets the shared queue and listeners between test cases. */
+export function __resetOfflineQueueForTests(): void {
+  queue = [];
+  listeners.clear();
+}


### PR DESCRIPTION
## Summary

Submitting CreateStreamModal while offline previously relied silently on useTransactionStatus's poll/retry with no "your submission is queued" messaging — from the user's perspective, it just hung or showed an ambiguous spinner. This adds an explicit queued state: the submission is captured locally, announced via aria-live, auto-flushed through the existing submit/poll path the moment connectivity returns, and resolved with a clear success toast or a recoverable failure banner.

## Changes

- src/hooks/useOnlineStatus.ts (new) — tracks navigator.onLine + online/offline window events.
- src/lib/offlineActionQueue.ts (new) — sm(enqueue/dequeue/position/length/subscribe), generic over payload type. Not persisted across reloads — documented as an intentional limitation, in line with the existing "PWA/offline mode": defer to Phase 3" note inDESIGN_SPEC.md.                                                                                                  - src/components/CreateStreamModal.tsx — sconnectivity:
  - Offline → captures the payload into the queue and shows a role="status" aria-live="polite" banner ("Queued — will submit when back online", with queue
  - Reconnect → auto-flushes through the same createStream/polling path the online flow already uses (no
duplicated logic — refactored into shared buildSubmissionPayload/submitPayload helpers).
  - Flush success → existing confirm effect (unchanged), plus a success toast with a "View stream" action for when
the user isn't looking at the modal anymore
- Flush failure → recoverable banner showing the real error message, with Retry now / Edit details actions.
  - Close/Cancel stay enabled while merelyd (payload is already snapshotted, so editing the form wouldn't change what's submitted).
- src/components/ToastNotification.tsx / ToastProvider.tsx - added an optional inline action(actionLabel/onAction, via a new 4th addToast param) used for the "View stream" link.
- src/hooks/useTransactionStatus.ts — widened TxStatus with queue/flushing/queue-failed as shared vocabulary with the modal; the hook's own polling logic is unchanged.
- src/i18n/en.ts — new createStream.queue.l strings.
- vitest.config.ts — added the two new production modules (offlineActionQueue.ts, useOnlineStatus.ts) to the coverage include list.
- docs/OFFLINE_ACTION_QUEUE_SPEC.md (new) — full state-machine spec, contrast verification, keyboard/focus notes, responsive notes, and failure-copy guidancce vs. insufficient balance).

## Test plan

- [ ] `npm run build` passes (type-check + production build)
- [x] `npm run test` passes (all unit tests green)
- [ ] `npm run test:coverage` passes (statements/branches/functions/lines ≥ 95%)
- [x] New code is covered by tests; the coverage include list in `vitest.config.ts` is expanded if new production modules are added

## Coverage gate

Two new production files are added to vitest.config.ts's coverage include:
- src/lib/offlineActionQueue.ts
- src/hooks/useOnlineStatus.ts

Both are fully covered by their new unit test files (enqueue/dequeue/position/length/subscribe semantics; online/offline event transitions).

Closes #869
