### PR TITLE
Closes #829

### DIFF
--- a/docs/TREASURY_WIDGET_DRAG_ARRANGE_SPEC.md
+++ b/docs/TREASURY_WIDGET_DRAG_ARRANGE_SPEC.md
@@ -1,0 +1,113 @@
+# Spec: Treasury Metrics Grid Drag-to-Arrange Widget System
+
+This document specifies the interaction flows, data models, keyboard controls, responsive states, and accessibility standards for the treasury metrics grid drag-and-arrange layout system.
+
+---
+
+## 1. Overview & Objectives
+
+The Treasury Metrics Grid supports customizable widget layout reordering, resizing, and visibility configuration. 
+- **Desktop (Mouse):** Drag widgets using their drag handles and drop them onto other cards to swap their positions. Right-click or use the action menu (`⋮`) to toggle size or hide a widget.
+- **Tablet / Keyboard:** Visually hidden-until-focused keyboard "Move" buttons trigger context menus to shift layout order.
+- **Mobile (Below md breakpoint):** Reorder buttons (▲/▼) render on each card to support layout modification.
+- **Persistence:** Layout states synchronize automatically with `localStorage`, scoped to active freighter wallet addresses.
+
+---
+
+## 2. Interaction Patterns & States
+
+The metrics cards render in one of five interactive layout states:
+
+### A. Idle State
+- Normal card representation with default styling.
+- Actions menu contains:
+  1. A drag handle (grip icon) that remains hidden until the card is hovered or focused.
+  2. A hidden-until-focused keyboard "Move" button.
+  3. A vertical ellipsis button (`⋮`) to trigger the context menu.
+
+### B. Dragging State (Ghost Card)
+- Triggered by dragging the grip handle. The card in the grid gets the `.widget-dragging` class.
+- Visual: `opacity: 0.6` with standard transition animations.
+
+### C. Valid Drop Target State
+- Triggered when dragging a card over another active card slot. The target container gets the `.widget-drop-valid` class.
+- Visual: 2px dashed border and a 30% opacity overlay backdrop.
+
+### D. Invalid Drop Target State
+- Triggered when dragging a card over a hidden widget placeholder in the Widget Tray. The target tray slot gets the `.widget-drop-invalid` class.
+- Visual: 2px dashed red border and 10-15% opacity red background tint.
+
+### E. Keyboard Reorder Active State
+- Triggered by focusing the keyboard "Move" button and opening the directional Move context menu.
+
+---
+
+## 3. Data Shape & Schemas
+
+The widget layouts are defined and structured using the following schemas in `widgetLayout.ts`:
+
+```typescript
+export type WidgetSize = "1x1" | "2x1";
+
+export interface WidgetConfig {
+  id: string;      // Slugified Metric.label (e.g. "Total Balance" -> "total-balance")
+  size: WidgetSize;
+  visible: boolean;
+  order: number;   // Zero-based index representing grid positions
+}
+
+export interface WidgetLayout {
+  version: 1;
+  widgets: WidgetConfig[];
+}
+```
+
+---
+
+## 4. Accessibility (WCAG 2.1 AA Audit)
+
+To meet the WCAG 1.4.11 non-text contrast requirement (minimum 3:1 contrast ratio against the background), the following token strategies are implemented and verified:
+
+### A. Drag Handle Icon (`var(--color-text-secondary)`)
+- **Light theme (`#4a5565` vs `#fafbfc` background):** **7.20:1** contrast.
+- **Dark theme (`#b0b8c9` vs `#121a2a` background):** **8.75:1** contrast.
+- Both exceed the 3:1 non-text contrast requirement.
+
+### B. Drop Target Border (Theme-aware)
+The standard accent cyan `--color-accent-primary` (`#00b8d4`) fails contrast checks against the light theme background (only 2.29:1). To resolve this, a theme-aware border token strategy is applied:
+- **Light theme (`var(--color-accent-primary-dark)` / `#0097a7`):** **3.47:1** contrast.
+- **Dark theme (`var(--color-accent-primary)` / `#00b8d4`):** **7.31:1** contrast.
+- Both exceed the 3:1 non-text contrast requirement.
+
+### C. Invalid Target Border (`var(--color-danger)` / `#ef4444`)
+- **Light theme (`#ef4444` vs `#fafbfc` background):** **3.63:1** contrast.
+- **Dark theme (`#ef4444` vs `#121a2a` background):** **4.63:1** contrast.
+- Both exceed the 3:1 non-text contrast requirement.
+
+---
+
+## 5. Keyboard Navigation & ARIA Specifications
+
+- **Move Trigger Button:**
+  - Standard focusable `<button class="keyboard-move-btn">`. Visually hidden by default, becomes visible when keyboard focused.
+  - Activating (Space / Enter) reveals the Move menu.
+- **Move Directional Menu:**
+  - Renders menu options (Move Left / Right / Up / Down) with appropriate disabled states (e.g. Move Left is disabled for the first widget).
+  - Pressing Escape closes the menu and returns focus to the trigger button.
+- **ARIA Live Announcements:**
+  - Layout changes are announced to screen readers using an `aria-live="polite"` region.
+  - Text format: `[Widget Label] moved to position [New Index] of [Total Visible Widgets]` (e.g. `"Total Balance moved to position 2 of 6"`).
+- **Roving Focus & Target Maintenance:**
+  - Focus is restored to the moved card's "Move" button immediately after layout updates.
+
+---
+
+## 6. Storage & Session Synchronization
+
+- **Scoped Keys:**
+  - When a Freighter wallet is connected, the layout is stored under the wallet-scoped key `fluxora:treasury:widget-layout:<walletAddress>`.
+  - When no wallet is connected, it falls back to the unscoped key `fluxora:treasury:widget-layout`.
+- **Parsing Fallbacks:**
+  - If parsing fails (malformed JSON or version mismatch), the hook logs a warning and falls back to the default order derived from the incoming `metrics` list.
+- **Merging Strategy:**
+  - When loading stored configs, any incoming metrics that are not in the saved configuration (e.g. from code updates) are automatically appended to the end of the visible layout. Stored configs of widgets that no longer exist in the code are filtered out.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,15 @@ importers:
       '@stellar/freighter-api':
         specifier: ^6.0.1
         version: 6.0.1
+      '@stellar/stellar-sdk':
+        specifier: ^16.0.1
+        version: 16.1.0(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)
       '@tailwindcss/vite':
         specifier: ^4.2.0
         version: 4.2.0(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1))
+      '@testing-library/dom':
+        specifier: ^10.4.1
+        version: 10.4.1
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -26,6 +32,9 @@ importers:
       react-dom:
         specifier: ^18.2.0
         version: 18.3.1(react@18.3.1)
+      react-helmet-async:
+        specifier: ^2.0.5
+        version: 2.0.5(react@18.3.1)
       react-icons:
         specifier: ^5.5.0
         version: 5.5.0(react@18.3.1)
@@ -36,6 +45,15 @@ importers:
         specifier: ^3.5.0
         version: 3.5.0
     devDependencies:
+      '@axe-core/playwright':
+        specifier: ^4.9.1
+        version: 4.12.1(playwright-core@1.61.0)
+      '@eslint/js':
+        specifier: ^10.0.1
+        version: 10.0.1(eslint@10.7.0(jiti@2.6.1)(supports-color@7.2.0))
+      '@playwright/test':
+        specifier: 1.61.0
+        version: 1.61.0
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
@@ -56,31 +74,46 @@ importers:
         version: 18.3.7(@types/react@18.3.28)
       '@vitejs/plugin-react':
         specifier: ^4.2.1
-        version: 4.7.0(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1))
+        version: 4.7.0(supports-color@7.2.0)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1))
       '@vitest/coverage-v8':
         specifier: ^4.1.5
         version: 4.1.5(vitest@4.1.5)
       axe-core:
         specifier: ^4.11.3
         version: 4.11.3
+      eslint:
+        specifier: ^10.5.0
+        version: 10.7.0(jiti@2.6.1)(supports-color@7.2.0)
+      eslint-plugin-react-hooks:
+        specifier: ^7.1.1
+        version: 7.1.1(eslint@10.7.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)
+      eslint-plugin-react-refresh:
+        specifier: ^0.5.3
+        version: 0.5.3(eslint@10.7.0(jiti@2.6.1)(supports-color@7.2.0))
       fast-check:
         specifier: ^4.8.0
         version: 4.8.0
       jsdom:
         specifier: ^29.0.2
-        version: 29.0.2
+        version: 29.0.2(@noble/hashes@2.2.0)
+      prettier:
+        specifier: ^3.8.4
+        version: 3.9.6
       tailwindcss:
         specifier: ^4.2.0
         version: 4.2.0
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
+      typescript-eslint:
+        specifier: ^8.61.1
+        version: 8.65.0(eslint@10.7.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
       vite:
         specifier: ^7.3.1
         version: 7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1))
+        version: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1))
       vitest-axe:
         specifier: ^0.1.0
         version: 0.1.0(vitest@4.1.5)
@@ -104,6 +137,11 @@ packages:
 
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
+  '@axe-core/playwright@4.12.1':
+    resolution: {integrity: sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw==}
+    peerDependencies:
+      playwright-core: '>= 1.0.0'
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -392,6 +430,45 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@eslint-community/eslint-utils@4.10.1':
+    resolution: {integrity: sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+  '@eslint-community/regexpp@4.12.2':
+    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/config-array@0.23.5':
+    resolution: {integrity: sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/config-helpers@0.6.0':
+    resolution: {integrity: sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/core@1.2.1':
+    resolution: {integrity: sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/js@10.0.1':
+    resolution: {integrity: sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    peerDependencies:
+      eslint: ^10.0.0
+    peerDependenciesMeta:
+      eslint:
+        optional: true
+
+  '@eslint/object-schema@3.0.5':
+    resolution: {integrity: sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/plugin-kit@0.7.2':
+    resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
   '@exodus/bytes@1.15.0':
     resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -400,6 +477,26 @@ packages:
     peerDependenciesMeta:
       '@noble/hashes':
         optional: true
+
+  '@humanfs/core@0.19.2':
+    resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/node@0.16.8':
+    resolution: {integrity: sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/types@0.15.0':
+    resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanwhocodes/module-importer@1.0.1':
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
+
+  '@humanwhocodes/retry@0.4.3':
+    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
+    engines: {node: '>=18.18'}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -416,6 +513,18 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@noble/ed25519@3.1.0':
+    resolution: {integrity: sha512-pfcObRY3CtvwfaG9Mt5XqZdKmAQppl37tHUeuBhDUbiwJBCVY4/A4lbMvb1xKhMDx96AqAqZpMWuBX1HulhX4g==}
+
+  '@noble/hashes@2.2.0':
+    resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
+    engines: {node: '>= 20.19.0'}
+
+  '@playwright/test@1.61.0':
+    resolution: {integrity: sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@remix-run/router@1.23.2':
     resolution: {integrity: sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==}
@@ -458,66 +567,79 @@ packages:
     resolution: {integrity: sha512-Ob8YgT5kD/lSIYW2Rcngs5kNB/44Q2RzBSPz9brf2WEtcGR7/f/E9HeHn1wYaAwKBni+bdXEwgHvUd0x12lQSA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.58.0':
     resolution: {integrity: sha512-K+RI5oP1ceqoadvNt1FecL17Qtw/n9BgRSzxif3rTL2QlIu88ccvY+Y9nnHe/cmT5zbH9+bpiJuG1mGHRVwF4Q==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.58.0':
     resolution: {integrity: sha512-T+17JAsCKUjmbopcKepJjHWHXSjeW7O5PL7lEFaeQmiVyw4kkc5/lyYKzrv6ElWRX/MrEWfPiJWqbTvfIvjM1Q==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.58.0':
     resolution: {integrity: sha512-cCePktb9+6R9itIJdeCFF9txPU7pQeEHB5AbHu/MKsfH/k70ZtOeq1k4YAtBv9Z7mmKI5/wOLYjQ+B9QdxR6LA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.58.0':
     resolution: {integrity: sha512-iekUaLkfliAsDl4/xSdoCJ1gnnIXvoNz85C8U8+ZxknM5pBStfZjeXgB8lXobDQvvPRCN8FPmmuTtH+z95HTmg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.58.0':
     resolution: {integrity: sha512-68ofRgJNl/jYJbxFjCKE7IwhbfxOl1muPN4KbIqAIe32lm22KmU7E8OPvyy68HTNkI2iV/c8y2kSPSm2mW/Q9Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.58.0':
     resolution: {integrity: sha512-dpz8vT0i+JqUKuSNPCP5SYyIV2Lh0sNL1+FhM7eLC457d5B9/BC3kDPp5BBftMmTNsBarcPcoz5UGSsnCiw4XQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.58.0':
     resolution: {integrity: sha512-4gdkkf9UJ7tafnweBCR/mk4jf3Jfl0cKX9Np80t5i78kjIH0ZdezUv/JDI2VtruE5lunfACqftJ8dIMGN4oHew==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.58.0':
     resolution: {integrity: sha512-YFS4vPnOkDTD/JriUeeZurFYoJhPf9GQQEF/v4lltp3mVcBmnsAdjEWhr2cjUCZzZNzxCG0HZOvJU44UGHSdzw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.58.0':
     resolution: {integrity: sha512-x2xgZlFne+QVNKV8b4wwaCS8pwq3y14zedZ5DqLzjdRITvreBk//4Knbcvm7+lWmms9V9qFp60MtUd0/t/PXPw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.58.0':
     resolution: {integrity: sha512-jIhrujyn4UnWF8S+DHSkAkDEO3hLX0cjzxJZPLF80xFyzyUIYgSMRcYQ3+uqEoyDD2beGq7Dj7edi8OnJcS/hg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.58.0':
     resolution: {integrity: sha512-+410Srdoh78MKSJxTQ+hZ/Mx+ajd6RjjPwBPNd0R3J9FtL6ZA0GqiiyNjCO9In0IzZkCNrpGymSfn+kgyPQocg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.58.0':
     resolution: {integrity: sha512-ZjMyby5SICi227y1MTR3VYBpFTdZs823Rs/hpakufleBoufoOIB6jtm9FEoxn/cgO7l6PM2rCEl5Kre5vX0QrQ==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.58.0':
     resolution: {integrity: sha512-ds4iwfYkSQ0k1nb8LTcyXw//ToHOnNTJtceySpL3fa7tc/AsE+UpUFphW126A6fKBGJD5dhRvg8zw1rvoGFxmw==}
@@ -554,6 +676,15 @@ packages:
 
   '@stellar/freighter-api@6.0.1':
     resolution: {integrity: sha512-eqwakEqSg+zoLuPpSbKyrX0pG8DQFzL/J5GtbfuMCmJI+h+oiC9pQ5C6QLc80xopZQKdGt8dUAFCmDMNdAG95w==}
+
+  '@stellar/js-xdr@4.0.0':
+    resolution: {integrity: sha512-+NmNa7Tk5BI5XFdy/6xGTqAN4J9a9KgCrCGhj2uEUTCBhLkch0M+QbKzNH8zEnejWe0p8w+0q5hUVX6L3OzoVA==}
+    engines: {node: '>=20.0.0', pnpm: '>=9.0.0'}
+
+  '@stellar/stellar-sdk@16.1.0':
+    resolution: {integrity: sha512-MOIrUvbzuTnSvUurL+9nrS1UW6Ko+QTW00RggSomm4WaWkE8onKPo2MRJMd89X7qPaGPjYjxNX6B671AEQlzxQ==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
 
   '@tailwindcss/node@4.2.0':
     resolution: {integrity: sha512-Yv+fn/o2OmL5fh/Ir62VXItdShnUxfpkMA4Y7jdeC8O81WPB8Kf6TT6GSHvnqgSwDzlB5iT7kDpeXxLsUS0T6Q==}
@@ -593,24 +724,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.0':
     resolution: {integrity: sha512-XKcSStleEVnbH6W/9DHzZv1YhjE4eSS6zOu2eRtYAIh7aV4o3vIBs+t/B15xlqoxt6ef/0uiqJVB6hkHjWD/0A==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.0':
     resolution: {integrity: sha512-/hlXCBqn9K6fi7eAM0RsobHwJYa5V/xzWspVTzxnX+Ft9v6n+30Pz8+RxCn7sQL/vRHHLS30iQPrHQunu6/vJA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.0':
     resolution: {integrity: sha512-lKUaygq4G7sWkhQbfdRRBkaq4LY39IriqBQ+Gk6l5nKq6Ay2M2ZZb1tlIyRNgZKS8cbErTwuYSor0IIULC0SHw==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.0':
     resolution: {integrity: sha512-xuDjhAsFdUuFP5W9Ze4k/o4AskUtI8bcAGU4puTYprr89QaYFmhYOPfP+d1pH+k9ets6RoE23BXZM1X1jJqoyw==}
@@ -695,8 +830,14 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
+  '@types/esrecurse@4.3.1':
+    resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
   '@types/node@25.6.0':
     resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
@@ -711,6 +852,65 @@ packages:
 
   '@types/react@18.3.28':
     resolution: {integrity: sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==}
+
+  '@typescript-eslint/eslint-plugin@8.65.0':
+    resolution: {integrity: sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.65.0
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/parser@8.65.0':
+    resolution: {integrity: sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/project-service@8.65.0':
+    resolution: {integrity: sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/scope-manager@8.65.0':
+    resolution: {integrity: sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.65.0':
+    resolution: {integrity: sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/type-utils@8.65.0':
+    resolution: {integrity: sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/types@8.65.0':
+    resolution: {integrity: sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.65.0':
+    resolution: {integrity: sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/utils@8.65.0':
+    resolution: {integrity: sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/visitor-keys@8.65.0':
+    resolution: {integrity: sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
@@ -756,6 +956,23 @@ packages:
   '@vitest/utils@4.1.5':
     resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
 
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  acorn@8.17.0:
+    resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
+  ajv@6.15.0:
+    resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -778,9 +995,27 @@ packages:
   ast-v8-to-istanbul@1.0.0:
     resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
 
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
   axe-core@4.11.3:
     resolution: {integrity: sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==}
     engines: {node: '>=4'}
+
+  axe-core@4.12.1:
+    resolution: {integrity: sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==}
+    engines: {node: '>=4'}
+
+  axios@1.18.0:
+    resolution: {integrity: sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==}
+
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
+  base32.js@0.1.0:
+    resolution: {integrity: sha512-n3TkB02ixgBOhTvANakDb4xaMXnYUVkNoRFJjQflcqMQhyEKxEHdj3E6N8t8sUQ0mjH/3/JxzlXuz3ul/J90pQ==}
+    engines: {node: '>=0.12.0'}
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -793,6 +1028,13 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
+  bignumber.js@11.1.5:
+    resolution: {integrity: sha512-6WmzCNtUnfKpbozq+hOgWaZMMzORmYBwF1xZScyoIX3QRYWeKTtxxwDOW5tIz7C9BdjkIYHGTcelCLkXg0mndw==}
+
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
+
   browserslist@4.28.1:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -800,6 +1042,10 @@ packages:
 
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
 
   caniuse-lite@1.0.30001770:
     resolution: {integrity: sha512-x/2CLQ1jHENRbHg5PSId2sXq1CIO1CISvwWAj027ltMVG2UNgW+w9oH2+HzgEIRFembL8bUlXtfbBHR1fCg2xw==}
@@ -816,8 +1062,20 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
+    engines: {node: '>=20'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
 
   css-tree@3.2.1:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
@@ -845,6 +1103,13 @@ packages:
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
+  deep-is@0.1.4:
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
@@ -859,6 +1124,10 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
   electron-to-chromium@1.5.302:
     resolution: {integrity: sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==}
 
@@ -870,8 +1139,24 @@ packages:
     resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
     engines: {node: '>=20.19.0'}
 
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
 
   esbuild@0.27.3:
     resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
@@ -882,8 +1167,73 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+
+  eslint-plugin-react-hooks@7.1.1:
+    resolution: {integrity: sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0
+
+  eslint-plugin-react-refresh@0.5.3:
+    resolution: {integrity: sha512-5EMmLCV98Pi4o/f/3DP/v/tNqLHMIc9I8LKClNDWhZ9JTho89/kQcitCXQBMG7sAfVRK0Ie3T2EDOzp1YXYiVA==}
+    peerDependencies:
+      eslint: ^9 || ^10
+
+  eslint-scope@9.1.2:
+    resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint@10.7.0:
+    resolution: {integrity: sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
+  espree@11.2.0:
+    resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  esquery@1.7.0:
+    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
+    engines: {node: '>=0.10'}
+
+  esrecurse@4.3.0:
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
+
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@4.1.0:
+    resolution: {integrity: sha512-2GuF51iuHX6A9xdTccMTsNb7VO0lHZihApxhvQzJB5A03DvHDd2FQepodbMaztPBmBcE/ox7o2gqaxGhYB9LhQ==}
+    engines: {node: '>=20.0.0'}
 
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
@@ -892,6 +1242,15 @@ packages:
   fast-check@4.8.0:
     resolution: {integrity: sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==}
     engines: {node: '>=12.17.0'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-levenshtein@2.0.6:
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -902,14 +1261,69 @@ packages:
       picomatch:
         optional: true
 
+  feaxios@0.0.23:
+    resolution: {integrity: sha512-eghR0A21fvbkcQBgZuMfQhrXxJzC0GNUGC9fXhBge33D+mFDTwl0aJ35zoQQn575BhyjQitRc5N4f+L4cP708g==}
+
+  file-entry-cache@8.0.0:
+    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
+    engines: {node: '>=16.0.0'}
+
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
+  flat-cache@4.0.1:
+    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
+    engines: {node: '>=16'}
+
+  flatted@3.4.3:
+    resolution: {integrity: sha512-/zipXxyO6rGvuNGDiULY9MvEGSkb2gaG4GGH4ygMi0ZZzyMHdUZBmntJmx5x1G2VuPytCwGN4xsJP6cw+sK+vQ==}
+
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
+    engines: {node: '>= 6'}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -918,6 +1332,24 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
+
+  hermes-estree@0.25.1:
+    resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
+
+  hermes-parser@0.25.1:
+    resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
+
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -925,15 +1357,49 @@ packages:
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
+
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  ignore@5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  ignore@7.0.6:
+    resolution: {integrity: sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==}
+    engines: {node: '>= 4'}
+
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
 
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
 
+  invariant@2.2.4:
+    resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  is-retry-allowed@3.0.0:
+    resolution: {integrity: sha512-9xH0xvoggby+u0uGF7cZXdrutWiBiaFG8ZT4YFPXL8NzkyAwX3AKGLeFQLvzDpM430+nDFBZ1LHkie/8ocL06A==}
+    engines: {node: '>=12'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
@@ -971,10 +1437,26 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-stable-stringify-without-jsonify@1.0.1:
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  levn@0.4.1:
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
 
   lightningcss-android-arm64@1.31.1:
     resolution: {integrity: sha512-HXJF3x8w9nQ4jbXRiNppBCqeZPIAfUo8zE/kOEGbW5NZvGc/K7nMxbhIr+YlFlHW5mpbg/YFPdbnCh1wAXCKFg==}
@@ -1011,24 +1493,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.31.1:
     resolution: {integrity: sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.31.1:
     resolution: {integrity: sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.31.1:
     resolution: {integrity: sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.31.1:
     resolution: {integrity: sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w==}
@@ -1045,6 +1531,10 @@ packages:
   lightningcss@1.31.1:
     resolution: {integrity: sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==}
     engines: {node: '>= 12.0.0'}
+
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
 
   lodash-es@4.18.1:
     resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
@@ -1079,12 +1569,28 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
 
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
+
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -1094,14 +1600,37 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  natural-compare@1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
+  optionator@0.9.4:
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
+
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+
   parse5@8.0.1:
     resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -1113,13 +1642,36 @@ packages:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
+  playwright-core@1.61.0:
+    resolution: {integrity: sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.0:
+    resolution: {integrity: sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  prelude-ls@1.2.1:
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
+
+  prettier@3.9.6:
+    resolution: {integrity: sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==}
+    engines: {node: '>=14'}
+    hasBin: true
+
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -1132,6 +1684,14 @@ packages:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
       react: ^18.3.1
+
+  react-fast-compare@3.2.2:
+    resolution: {integrity: sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==}
+
+  react-helmet-async@2.0.5:
+    resolution: {integrity: sha512-rYUYHeus+i27MvFE+Jaa4WsyBKGkL6qVgbJvSBoX8mbsWoABJXdEO0bZyi0F6i+4f0NuIb8AvqPMj3iXFHkMwg==}
+    peerDependencies:
+      react: ^16.6.0 || ^17.0.0 || ^18.0.0
 
   react-icons@5.5.0:
     resolution: {integrity: sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==}
@@ -1191,8 +1751,28 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  shallowequal@1.1.0:
+    resolution: {integrity: sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  smol-toml@1.7.0:
+    resolution: {integrity: sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ==}
+    engines: {node: '>= 18'}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -1255,10 +1835,31 @@ packages:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
 
+  ts-api-utils@2.5.0:
+    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
+
+  type-check@0.4.0:
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
+
+  typescript-eslint@8.65.0:
+    resolution: {integrity: sha512-/ggrHAwyjENDusvyxbuqxAC2dTnZg/Z8F+fgQtYIz+L6n/9HfSlEZcFGV/NsMNa6CkGk0xUjUAFwC0vHOflvIA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  uint8array-extras@1.5.0:
+    resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
+    engines: {node: '>=18'}
 
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
@@ -1272,6 +1873,9 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
   vite@7.3.1:
     resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
@@ -1375,10 +1979,19 @@ packages:
     resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
 
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
@@ -1389,6 +2002,19 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
+
+  zod-validation-error@4.0.2:
+    resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
 
@@ -1414,6 +2040,11 @@ snapshots:
 
   '@asamuzakjp/nwsapi@2.3.9': {}
 
+  '@axe-core/playwright@4.12.1(playwright-core@1.61.0)':
+    dependencies:
+      axe-core: 4.12.1
+      playwright-core: 1.61.0
+
   '@babel/code-frame@7.29.0':
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
@@ -1422,20 +2053,20 @@ snapshots:
 
   '@babel/compat-data@7.29.0': {}
 
-  '@babel/core@7.29.0':
+  '@babel/core@7.29.0(supports-color@7.2.0)':
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/generator': 7.29.1
       '@babel/helper-compilation-targets': 7.28.6
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)
       '@babel/helpers': 7.28.6
       '@babel/parser': 7.29.0
       '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.0(supports-color@7.2.0)
       '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -1460,19 +2091,19 @@ snapshots:
 
   '@babel/helper-globals@7.28.0': {}
 
-  '@babel/helper-module-imports@7.28.6':
+  '@babel/helper-module-imports@7.28.6(supports-color@7.2.0)':
     dependencies:
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.0(supports-color@7.2.0)
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-imports': 7.28.6
+      '@babel/core': 7.29.0(supports-color@7.2.0)
+      '@babel/helper-module-imports': 7.28.6(supports-color@7.2.0)
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.0(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -1493,14 +2124,14 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
-  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/runtime@7.29.2': {}
@@ -1511,7 +2142,7 @@ snapshots:
       '@babel/parser': 7.29.0
       '@babel/types': 7.29.0
 
-  '@babel/traverse@7.29.0':
+  '@babel/traverse@7.29.0(supports-color@7.2.0)':
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/generator': 7.29.1
@@ -1519,7 +2150,7 @@ snapshots:
       '@babel/parser': 7.29.0
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -1636,7 +2267,59 @@ snapshots:
   '@esbuild/win32-x64@0.27.3':
     optional: true
 
-  '@exodus/bytes@1.15.0': {}
+  '@eslint-community/eslint-utils@4.10.1(eslint@10.7.0(jiti@2.6.1)(supports-color@7.2.0))':
+    dependencies:
+      eslint: 10.7.0(jiti@2.6.1)(supports-color@7.2.0)
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/regexpp@4.12.2': {}
+
+  '@eslint/config-array@0.23.5(supports-color@7.2.0)':
+    dependencies:
+      '@eslint/object-schema': 3.0.5
+      debug: 4.4.3(supports-color@7.2.0)
+      minimatch: 10.2.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/config-helpers@0.6.0':
+    dependencies:
+      '@eslint/core': 1.2.1
+
+  '@eslint/core@1.2.1':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  '@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)(supports-color@7.2.0))':
+    optionalDependencies:
+      eslint: 10.7.0(jiti@2.6.1)(supports-color@7.2.0)
+
+  '@eslint/object-schema@3.0.5': {}
+
+  '@eslint/plugin-kit@0.7.2':
+    dependencies:
+      '@eslint/core': 1.2.1
+      levn: 0.4.1
+
+  '@exodus/bytes@1.15.0(@noble/hashes@2.2.0)':
+    optionalDependencies:
+      '@noble/hashes': 2.2.0
+
+  '@humanfs/core@0.19.2':
+    dependencies:
+      '@humanfs/types': 0.15.0
+
+  '@humanfs/node@0.16.8':
+    dependencies:
+      '@humanfs/core': 0.19.2
+      '@humanfs/types': 0.15.0
+      '@humanwhocodes/retry': 0.4.3
+
+  '@humanfs/types@0.15.0': {}
+
+  '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/retry@0.4.3': {}
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -1656,6 +2339,14 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@noble/ed25519@3.1.0': {}
+
+  '@noble/hashes@2.2.0': {}
+
+  '@playwright/test@1.61.0':
+    dependencies:
+      playwright: 1.61.0
 
   '@remix-run/router@1.23.2': {}
 
@@ -1742,6 +2433,26 @@ snapshots:
     dependencies:
       buffer: 6.0.3
       semver: 7.7.1
+
+  '@stellar/js-xdr@4.0.0': {}
+
+  '@stellar/stellar-sdk@16.1.0(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)':
+    dependencies:
+      '@noble/ed25519': 3.1.0
+      '@noble/hashes': 2.2.0
+      '@stellar/js-xdr': 4.0.0
+      axios: 1.18.0(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)
+      base32.js: 0.1.0
+      bignumber.js: 11.1.5
+      buffer: 6.0.3
+      commander: 14.0.3
+      eventsource: 4.1.0
+      feaxios: 0.0.23
+      smol-toml: 1.7.0
+      uint8array-extras: 1.5.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
 
   '@tailwindcss/node@4.2.0':
     dependencies:
@@ -1875,7 +2586,11 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
+  '@types/esrecurse@4.3.1': {}
+
   '@types/estree@1.0.8': {}
+
+  '@types/json-schema@7.0.15': {}
 
   '@types/node@25.6.0':
     dependencies:
@@ -1892,11 +2607,102 @@ snapshots:
       '@types/prop-types': 15.7.15
       csstype: 3.2.3
 
-  '@vitejs/plugin-react@4.7.0(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1))':
+  '@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.7.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.65.0(eslint@10.7.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.65.0
+      '@typescript-eslint/type-utils': 8.65.0(eslint@10.7.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.65.0(eslint@10.7.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.65.0
+      eslint: 10.7.0(jiti@2.6.1)(supports-color@7.2.0)
+      ignore: 7.0.6
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@8.65.0(eslint@10.7.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.65.0
+      '@typescript-eslint/types': 8.65.0
+      '@typescript-eslint/typescript-estree': 8.65.0(supports-color@7.2.0)(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.65.0
+      debug: 4.4.3(supports-color@7.2.0)
+      eslint: 10.7.0(jiti@2.6.1)(supports-color@7.2.0)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.65.0(supports-color@7.2.0)(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.65.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.65.0
+      debug: 4.4.3(supports-color@7.2.0)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/scope-manager@8.65.0':
+    dependencies:
+      '@typescript-eslint/types': 8.65.0
+      '@typescript-eslint/visitor-keys': 8.65.0
+
+  '@typescript-eslint/tsconfig-utils@8.65.0(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
+
+  '@typescript-eslint/type-utils@8.65.0(eslint@10.7.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.65.0
+      '@typescript-eslint/typescript-estree': 8.65.0(supports-color@7.2.0)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.65.0(eslint@10.7.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      debug: 4.4.3(supports-color@7.2.0)
+      eslint: 10.7.0(jiti@2.6.1)(supports-color@7.2.0)
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/types@8.65.0': {}
+
+  '@typescript-eslint/typescript-estree@8.65.0(supports-color@7.2.0)(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.65.0(supports-color@7.2.0)(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.65.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.65.0
+      '@typescript-eslint/visitor-keys': 8.65.0
+      debug: 4.4.3(supports-color@7.2.0)
+      minimatch: 10.2.5
+      semver: 7.8.5
+      tinyglobby: 0.2.15
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.65.0(eslint@10.7.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.10.1(eslint@10.7.0(jiti@2.6.1)(supports-color@7.2.0))
+      '@typescript-eslint/scope-manager': 8.65.0
+      '@typescript-eslint/types': 8.65.0
+      '@typescript-eslint/typescript-estree': 8.65.0(supports-color@7.2.0)(typescript@5.9.3)
+      eslint: 10.7.0(jiti@2.6.1)(supports-color@7.2.0)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/visitor-keys@8.65.0':
+    dependencies:
+      '@typescript-eslint/types': 8.65.0
+      eslint-visitor-keys: 5.0.1
+
+  '@vitejs/plugin-react@4.7.0(supports-color@7.2.0)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1))':
+    dependencies:
+      '@babel/core': 7.29.0(supports-color@7.2.0)
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0(supports-color@7.2.0))
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0(supports-color@7.2.0))
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
@@ -1916,7 +2722,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1))
+      vitest: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1))
 
   '@vitest/expect@4.1.5':
     dependencies:
@@ -1959,6 +2765,25 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  acorn-jsx@5.3.2(acorn@8.17.0):
+    dependencies:
+      acorn: 8.17.0
+
+  acorn@8.17.0: {}
+
+  agent-base@6.0.2(supports-color@7.2.0):
+    dependencies:
+      debug: 4.4.3(supports-color@7.2.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  ajv@6.15.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+
   ansi-regex@5.0.1: {}
 
   ansi-styles@5.2.0: {}
@@ -1977,7 +2802,25 @@ snapshots:
       estree-walker: 3.0.3
       js-tokens: 10.0.0
 
+  asynckit@0.4.0: {}
+
   axe-core@4.11.3: {}
+
+  axe-core@4.12.1: {}
+
+  axios@1.18.0(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0):
+    dependencies:
+      follow-redirects: 1.16.0(debug@4.4.3(supports-color@7.2.0))
+      form-data: 4.0.6
+      https-proxy-agent: 5.0.1(supports-color@7.2.0)
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  balanced-match@4.0.4: {}
+
+  base32.js@0.1.0: {}
 
   base64-js@1.5.1: {}
 
@@ -1986,6 +2829,12 @@ snapshots:
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
+
+  bignumber.js@11.1.5: {}
+
+  brace-expansion@5.0.8:
+    dependencies:
+      balanced-match: 4.0.4
 
   browserslist@4.28.1:
     dependencies:
@@ -2000,6 +2849,11 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
   caniuse-lite@1.0.30001770: {}
 
   chai@6.2.2: {}
@@ -2008,7 +2862,19 @@ snapshots:
 
   clsx@2.1.1: {}
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
+  commander@14.0.3: {}
+
   convert-source-map@2.0.0: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
 
   css-tree@3.2.1:
     dependencies:
@@ -2019,18 +2885,24 @@ snapshots:
 
   csstype@3.2.3: {}
 
-  data-urls@7.0.0:
+  data-urls@7.0.0(@noble/hashes@2.2.0):
     dependencies:
       whatwg-mimetype: 5.0.0
-      whatwg-url: 16.0.1
+      whatwg-url: 16.0.1(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - '@noble/hashes'
 
-  debug@4.4.3:
+  debug@4.4.3(supports-color@7.2.0):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 7.2.0
 
   decimal.js@10.6.0: {}
+
+  deep-is@0.1.4: {}
+
+  delayed-stream@1.0.0: {}
 
   dequal@2.0.3: {}
 
@@ -2039,6 +2911,12 @@ snapshots:
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
 
   electron-to-chromium@1.5.302: {}
 
@@ -2049,7 +2927,22 @@ snapshots:
 
   entities@8.0.0: {}
 
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@2.1.0: {}
+
+  es-object-atoms@1.1.2:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.4
 
   esbuild@0.27.3:
     optionalDependencies:
@@ -2082,9 +2975,98 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  escape-string-regexp@4.0.0: {}
+
+  eslint-plugin-react-hooks@7.1.1(eslint@10.7.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0):
+    dependencies:
+      '@babel/core': 7.29.0(supports-color@7.2.0)
+      '@babel/parser': 7.29.0
+      eslint: 10.7.0(jiti@2.6.1)(supports-color@7.2.0)
+      hermes-parser: 0.25.1
+      zod: 4.4.3
+      zod-validation-error: 4.0.2(zod@4.4.3)
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-plugin-react-refresh@0.5.3(eslint@10.7.0(jiti@2.6.1)(supports-color@7.2.0)):
+    dependencies:
+      eslint: 10.7.0(jiti@2.6.1)(supports-color@7.2.0)
+
+  eslint-scope@9.1.2:
+    dependencies:
+      '@types/esrecurse': 4.3.1
+      '@types/estree': 1.0.8
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
+  eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@5.0.1: {}
+
+  eslint@10.7.0(jiti@2.6.1)(supports-color@7.2.0):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.10.1(eslint@10.7.0(jiti@2.6.1)(supports-color@7.2.0))
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.23.5(supports-color@7.2.0)
+      '@eslint/config-helpers': 0.6.0
+      '@eslint/core': 1.2.1
+      '@eslint/plugin-kit': 0.7.2
+      '@humanfs/node': 0.16.8
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.8
+      ajv: 6.15.0
+      cross-spawn: 7.0.6
+      debug: 4.4.3(supports-color@7.2.0)
+      escape-string-regexp: 4.0.0
+      eslint-scope: 9.1.2
+      eslint-visitor-keys: 5.0.1
+      espree: 11.2.0
+      esquery: 1.7.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      minimatch: 10.2.5
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    optionalDependencies:
+      jiti: 2.6.1
+    transitivePeerDependencies:
+      - supports-color
+
+  espree@11.2.0:
+    dependencies:
+      acorn: 8.17.0
+      acorn-jsx: 5.3.2(acorn@8.17.0)
+      eslint-visitor-keys: 5.0.1
+
+  esquery@1.7.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  esrecurse@4.3.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  estraverse@5.3.0: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
+
+  esutils@2.0.3: {}
+
+  eventsource-parser@3.1.0: {}
+
+  eventsource@4.1.0:
+    dependencies:
+      eventsource-parser: 3.1.0
 
   expect-type@1.3.0: {}
 
@@ -2092,32 +3074,142 @@ snapshots:
     dependencies:
       pure-rand: 8.4.0
 
+  fast-deep-equal@3.1.3: {}
+
+  fast-json-stable-stringify@2.1.0: {}
+
+  fast-levenshtein@2.0.6: {}
+
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
 
+  feaxios@0.0.23:
+    dependencies:
+      is-retry-allowed: 3.0.0
+
+  file-entry-cache@8.0.0:
+    dependencies:
+      flat-cache: 4.0.1
+
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+
+  flat-cache@4.0.1:
+    dependencies:
+      flatted: 3.4.3
+      keyv: 4.5.4
+
+  flatted@3.4.3: {}
+
+  follow-redirects@1.16.0(debug@4.4.3(supports-color@7.2.0)):
+    optionalDependencies:
+      debug: 4.4.3(supports-color@7.2.0)
+
+  form-data@4.0.6:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.4
+      mime-types: 2.1.35
+
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
+  function-bind@1.1.2: {}
+
   gensync@1.0.0-beta.2: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.4
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.2
+
+  glob-parent@6.0.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
 
   has-flag@4.0.0: {}
 
-  html-encoding-sniffer@6.0.0:
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
     dependencies:
-      '@exodus/bytes': 1.15.0
+      has-symbols: 1.1.0
+
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
+
+  hermes-estree@0.25.1: {}
+
+  hermes-parser@0.25.1:
+    dependencies:
+      hermes-estree: 0.25.1
+
+  html-encoding-sniffer@6.0.0(@noble/hashes@2.2.0):
+    dependencies:
+      '@exodus/bytes': 1.15.0(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - '@noble/hashes'
 
   html-escaper@2.0.2: {}
 
+  https-proxy-agent@5.0.1(supports-color@7.2.0):
+    dependencies:
+      agent-base: 6.0.2(supports-color@7.2.0)
+      debug: 4.4.3(supports-color@7.2.0)
+    transitivePeerDependencies:
+      - supports-color
+
   ieee754@1.2.1: {}
+
+  ignore@5.3.2: {}
+
+  ignore@7.0.6: {}
+
+  imurmurhash@0.1.4: {}
 
   indent-string@4.0.0: {}
 
+  invariant@2.2.4:
+    dependencies:
+      loose-envify: 1.4.0
+
+  is-extglob@2.1.1: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
   is-potential-custom-element-name@1.0.1: {}
+
+  is-retry-allowed@3.0.0: {}
+
+  isexe@2.0.0: {}
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -2138,17 +3230,17 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  jsdom@29.0.2:
+  jsdom@29.0.2(@noble/hashes@2.2.0):
     dependencies:
       '@asamuzakjp/css-color': 5.1.11
       '@asamuzakjp/dom-selector': 7.1.1
       '@bramus/specificity': 2.4.2
       '@csstools/css-syntax-patches-for-csstree': 1.1.3(css-tree@3.2.1)
-      '@exodus/bytes': 1.15.0
+      '@exodus/bytes': 1.15.0(@noble/hashes@2.2.0)
       css-tree: 3.2.1
-      data-urls: 7.0.0
+      data-urls: 7.0.0(@noble/hashes@2.2.0)
       decimal.js: 10.6.0
-      html-encoding-sniffer: 6.0.0
+      html-encoding-sniffer: 6.0.0(@noble/hashes@2.2.0)
       is-potential-custom-element-name: 1.0.1
       lru-cache: 11.3.5
       parse5: 8.0.1
@@ -2159,14 +3251,29 @@ snapshots:
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
-      whatwg-url: 16.0.1
+      whatwg-url: 16.0.1(@noble/hashes@2.2.0)
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - '@noble/hashes'
 
   jsesc@3.1.0: {}
 
+  json-buffer@3.0.1: {}
+
+  json-schema-traverse@0.4.1: {}
+
+  json-stable-stringify-without-jsonify@1.0.1: {}
+
   json5@2.2.3: {}
+
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
+
+  levn@0.4.1:
+    dependencies:
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
 
   lightningcss-android-arm64@1.31.1:
     optional: true
@@ -2217,6 +3324,10 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.31.1
       lightningcss-win32-x64-msvc: 1.31.1
 
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
+
   lodash-es@4.18.1: {}
 
   loose-envify@1.4.0:
@@ -2249,21 +3360,56 @@ snapshots:
     dependencies:
       semver: 7.7.1
 
+  math-intrinsics@1.1.0: {}
+
   mdn-data@2.27.1: {}
 
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
   min-indent@1.0.1: {}
+
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.8
 
   ms@2.1.3: {}
 
   nanoid@3.3.11: {}
 
+  natural-compare@1.4.0: {}
+
   node-releases@2.0.27: {}
 
   obug@2.1.1: {}
 
+  optionator@0.9.4:
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+      word-wrap: 1.2.5
+
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
+
   parse5@8.0.1:
     dependencies:
       entities: 8.0.0
+
+  path-exists@4.0.0: {}
+
+  path-key@3.1.1: {}
 
   pathe@2.0.3: {}
 
@@ -2271,17 +3417,31 @@ snapshots:
 
   picomatch@4.0.3: {}
 
+  playwright-core@1.61.0: {}
+
+  playwright@1.61.0:
+    dependencies:
+      playwright-core: 1.61.0
+    optionalDependencies:
+      fsevents: 2.3.2
+
   postcss@8.5.6:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  prelude-ls@1.2.1: {}
+
+  prettier@3.9.6: {}
+
   pretty-format@27.5.1:
     dependencies:
       ansi-regex: 5.0.1
       ansi-styles: 5.2.0
       react-is: 17.0.2
+
+  proxy-from-env@2.1.0: {}
 
   punycode@2.3.1: {}
 
@@ -2292,6 +3452,15 @@ snapshots:
       loose-envify: 1.4.0
       react: 18.3.1
       scheduler: 0.23.2
+
+  react-fast-compare@3.2.2: {}
+
+  react-helmet-async@2.0.5(react@18.3.1):
+    dependencies:
+      invariant: 2.2.4
+      react: 18.3.1
+      react-fast-compare: 3.2.2
+      shallowequal: 1.1.0
 
   react-icons@5.5.0(react@18.3.1):
     dependencies:
@@ -2367,7 +3536,19 @@ snapshots:
 
   semver@7.7.1: {}
 
+  semver@7.8.5: {}
+
+  shallowequal@1.1.0: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
   siginfo@2.0.0: {}
+
+  smol-toml@1.7.0: {}
 
   source-map-js@1.2.1: {}
 
@@ -2416,7 +3597,28 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  ts-api-utils@2.5.0(typescript@5.9.3):
+    dependencies:
+      typescript: 5.9.3
+
+  type-check@0.4.0:
+    dependencies:
+      prelude-ls: 1.2.1
+
+  typescript-eslint@8.65.0(eslint@10.7.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.7.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.65.0(eslint@10.7.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.65.0(supports-color@7.2.0)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.65.0(eslint@10.7.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      eslint: 10.7.0(jiti@2.6.1)(supports-color@7.2.0)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   typescript@5.9.3: {}
+
+  uint8array-extras@1.5.0: {}
 
   undici-types@7.19.2: {}
 
@@ -2427,6 +3629,10 @@ snapshots:
       browserslist: 4.28.1
       escalade: 3.2.0
       picocolors: 1.1.1
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
 
   vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1):
     dependencies:
@@ -2450,9 +3656,9 @@ snapshots:
       dom-accessibility-api: 0.5.16
       lodash-es: 4.18.1
       redent: 3.0.0
-      vitest: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1))
+      vitest: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1))
 
-  vitest@4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)):
+  vitest@4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)):
     dependencies:
       '@vitest/expect': 4.1.5
       '@vitest/mocker': 4.1.5(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1))
@@ -2477,7 +3683,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.6.0
       '@vitest/coverage-v8': 4.1.5(vitest@4.1.5)
-      jsdom: 29.0.2
+      jsdom: 29.0.2(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - msw
 
@@ -2489,21 +3695,35 @@ snapshots:
 
   whatwg-mimetype@5.0.0: {}
 
-  whatwg-url@16.0.1:
+  whatwg-url@16.0.1(@noble/hashes@2.2.0):
     dependencies:
-      '@exodus/bytes': 1.15.0
+      '@exodus/bytes': 1.15.0(@noble/hashes@2.2.0)
       tr46: 6.0.0
       webidl-conversions: 8.0.1
     transitivePeerDependencies:
       - '@noble/hashes'
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
 
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  word-wrap@1.2.5: {}
+
   xml-name-validator@5.0.0: {}
 
   xmlchars@2.2.0: {}
 
   yallist@3.1.1: {}
+
+  yocto-queue@0.1.0: {}
+
+  zod-validation-error@4.0.2(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
+
+  zod@4.4.3: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,0 @@
-allowBuilds:
-  esbuild: set this to true or false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: set this to true or false

--- a/src/components/treasuryOverviewPage/MetricCard.tsx
+++ b/src/components/treasuryOverviewPage/MetricCard.tsx
@@ -22,16 +22,142 @@ import { Metric } from "./Metric";
 import Sparkline from "./Sparkline";
 import { formatAssetAmount } from "../../lib/formatters";
 import { useOptionalTheme } from "../../theme/ThemeProvider";
+import { GripVertical, MoreVertical } from "lucide-react";
+import React, { useState, useEffect } from "react";
 
-export default function MetricCard({ icon, label, value, desc, trend, tokens }: Metric) {
+export interface MetricCardProps extends Metric {
+  draggable?: boolean;
+  onDragStart?: (e: React.DragEvent<HTMLDivElement>) => void;
+  onDragEnd?: (e: React.DragEvent<HTMLDivElement>) => void;
+  onDragOver?: (e: React.DragEvent<HTMLDivElement>) => void;
+  onDragEnter?: (e: React.DragEvent<HTMLDivElement>) => void;
+  onDragLeave?: (e: React.DragEvent<HTMLDivElement>) => void;
+  onDrop?: (e: React.DragEvent<HTMLDivElement>) => void;
+  isDragging?: boolean;
+  className?: string;
+  style?: React.CSSProperties;
+  onResize?: (size: "1x1" | "2x1") => void;
+  onHide?: () => void;
+  currentSize?: "1x1" | "2x1";
+  reorderButtons?: React.ReactNode;
+  moveMenuOptions?: {
+    onMoveLeft?: () => void;
+    onMoveRight?: () => void;
+    onMoveUp?: () => void;
+    onMoveDown?: () => void;
+    canMoveLeft?: boolean;
+    canMoveRight?: boolean;
+    canMoveUp?: boolean;
+    canMoveDown?: boolean;
+  };
+}
+
+export default function MetricCard({
+  icon,
+  label,
+  value,
+  desc,
+  trend,
+  tokens,
+  draggable = false,
+  onDragStart = () => {},
+  onDragEnd = () => {},
+  onDragOver = () => {},
+  onDragEnter = () => {},
+  onDragLeave = () => {},
+  onDrop = () => {},
+  isDragging = false,
+  className = "",
+  style = {},
+  onResize,
+  onHide,
+  currentSize = "1x1",
+  reorderButtons,
+  moveMenuOptions,
+}: MetricCardProps) {
   const { theme } = useOptionalTheme();
+  const [canDrag, setCanDrag] = useState(false);
+  const [isMoveMenuOpen, setIsMoveMenuOpen] = useState(false);
+  
+  const [menuState, setMenuState] = useState<{
+    isOpen: boolean;
+    x: number;
+    y: number;
+    isFromKebab: boolean;
+  }>({
+    isOpen: false,
+    x: 0,
+    y: 0,
+    isFromKebab: false,
+  });
+
+  const openMenu = (e: React.MouseEvent, isFromKebab: boolean) => {
+    e.preventDefault();
+    e.stopPropagation();
+    
+    if (isFromKebab) {
+      const rect = e.currentTarget.getBoundingClientRect();
+      // Position menu slightly below the kebab button
+      setMenuState({
+        isOpen: true,
+        x: rect.left,
+        y: rect.bottom + window.scrollY + 4,
+        isFromKebab: true,
+      });
+    } else {
+      setMenuState({
+        isOpen: true,
+        x: e.clientX + window.scrollX,
+        y: e.clientY + window.scrollY,
+        isFromKebab: false,
+      });
+    }
+  };
+
+  const closeMenu = () => {
+    setMenuState(prev => ({ ...prev, isOpen: false }));
+  };
+
+  // Close menus on click away
+  useEffect(() => {
+    if (!menuState.isOpen && !isMoveMenuOpen) return;
+    const handleClose = () => {
+      closeMenu();
+      setIsMoveMenuOpen(false);
+    };
+    window.addEventListener("click", handleClose);
+    return () => window.removeEventListener("click", handleClose);
+  }, [menuState.isOpen, isMoveMenuOpen]);
+
+  // Close menus on Escape key
+  useEffect(() => {
+    if (!menuState.isOpen && !isMoveMenuOpen) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        closeMenu();
+        setIsMoveMenuOpen(false);
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [menuState.isOpen, isMoveMenuOpen]);
 
   return (
     <div
-      className={`flex flex-col rounded-xl p-6 h-full${theme === "cyberpunk" ? " cyberpunk-skin" : ""}`}
+      className={`flex flex-col rounded-xl p-6 h-full metric-card-wrapper ${theme === "cyberpunk" ? "cyberpunk-skin" : ""} ${className}`}
       data-skin={theme === "cyberpunk" ? "cyberpunk" : undefined}
       role="group"
       aria-label={label}
+      draggable={draggable && canDrag}
+      onDragStart={onDragStart}
+      onDragEnd={(e) => {
+        setCanDrag(false);
+        onDragEnd(e);
+      }}
+      onDragOver={onDragOver}
+      onDragEnter={onDragEnter}
+      onDragLeave={onDragLeave}
+      onDrop={onDrop}
       style={{
         display: "flex",
         flexDirection: "column",
@@ -40,6 +166,8 @@ export default function MetricCard({ icon, label, value, desc, trend, tokens }: 
         borderRadius: "var(--radius-xl)",
         padding: "var(--space-xl)",
         height: "100%",
+        position: "relative",
+        ...style,
       }}
       /*
        * data-token-surface / data-token-border: anchor points for
@@ -50,20 +178,258 @@ export default function MetricCard({ icon, label, value, desc, trend, tokens }: 
       data-token-surface="color-surface-default"
       data-token-border="color-border-default"
     >
-      <div className="cyberpunk-scanlines flex items-center justify-center w-10 h-10 text-3xl leading-none mb-4 shrink-0" style={{ color: "var(--color-text-secondary)" }}>
+      {/* Top-Right Actions Menu */}
+      <div
+        className="metric-card-actions"
+        style={{
+          position: "absolute",
+          top: "var(--space-md)",
+          right: "var(--space-md)",
+          display: "flex",
+          alignItems: "center",
+          gap: "var(--space-xs)",
+          zIndex: 10,
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Mobile Up/Down Reorder Buttons */}
+        {reorderButtons}
+
+        {/* Keyboard Move Button */}
+        {moveMenuOptions && (
+          <div style={{ position: "relative" }}>
+            <button
+              className="keyboard-move-btn"
+              onClick={(e) => {
+                e.stopPropagation();
+                setIsMoveMenuOpen(!isMoveMenuOpen);
+              }}
+              style={{
+                backgroundColor: "var(--color-surface-default)",
+                border: "1px solid var(--color-border-default)",
+                borderRadius: "var(--radius-sm)",
+                color: "var(--color-text-secondary)",
+                padding: "2px 6px",
+                font: "var(--font-label-sm)",
+                cursor: "pointer",
+                display: "inline-flex",
+                alignItems: "center",
+              }}
+            >
+              Move
+            </button>
+
+            {isMoveMenuOpen && (
+              <div
+                role="menu"
+                style={{
+                  position: "absolute",
+                  top: "100%",
+                  right: 0,
+                  marginTop: "4px",
+                  backgroundColor: "var(--color-bg-primary)",
+                  border: "1px solid var(--color-border-default)",
+                  borderRadius: "var(--radius-md)",
+                  boxShadow: "var(--focus-ring)",
+                  padding: "4px",
+                  minWidth: "120px",
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: "2px",
+                  zIndex: 20,
+                }}
+              >
+                <button
+                  role="menuitem"
+                  disabled={!moveMenuOptions.canMoveLeft}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    moveMenuOptions.onMoveLeft?.();
+                    setIsMoveMenuOpen(false);
+                  }}
+                  style={{
+                    background: "none",
+                    border: "none",
+                    color: moveMenuOptions.canMoveLeft ? "var(--color-text-primary)" : "var(--color-text-muted)",
+                    padding: "4px 8px",
+                    textAlign: "left",
+                    font: "var(--font-body-sm)",
+                    cursor: moveMenuOptions.canMoveLeft ? "pointer" : "not-allowed",
+                    borderRadius: "var(--radius-sm)",
+                    backgroundColor: "transparent",
+                  }}
+                  onMouseOver={(e) => {
+                    if (moveMenuOptions.canMoveLeft) e.currentTarget.style.backgroundColor = "var(--interactive-bg-hover)";
+                  }}
+                  onMouseOut={(e) => {
+                    e.currentTarget.style.backgroundColor = "transparent";
+                  }}
+                >
+                  Move Left
+                </button>
+                <button
+                  role="menuitem"
+                  disabled={!moveMenuOptions.canMoveRight}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    moveMenuOptions.onMoveRight?.();
+                    setIsMoveMenuOpen(false);
+                  }}
+                  style={{
+                    background: "none",
+                    border: "none",
+                    color: moveMenuOptions.canMoveRight ? "var(--color-text-primary)" : "var(--color-text-muted)",
+                    padding: "4px 8px",
+                    textAlign: "left",
+                    font: "var(--font-body-sm)",
+                    cursor: moveMenuOptions.canMoveRight ? "pointer" : "not-allowed",
+                    borderRadius: "var(--radius-sm)",
+                    backgroundColor: "transparent",
+                  }}
+                  onMouseOver={(e) => {
+                    if (moveMenuOptions.canMoveRight) e.currentTarget.style.backgroundColor = "var(--interactive-bg-hover)";
+                  }}
+                  onMouseOut={(e) => {
+                    e.currentTarget.style.backgroundColor = "transparent";
+                  }}
+                >
+                  Move Right
+                </button>
+                <button
+                  role="menuitem"
+                  disabled={!moveMenuOptions.canMoveUp}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    moveMenuOptions.onMoveUp?.();
+                    setIsMoveMenuOpen(false);
+                  }}
+                  style={{
+                    background: "none",
+                    border: "none",
+                    color: moveMenuOptions.canMoveUp ? "var(--color-text-primary)" : "var(--color-text-muted)",
+                    padding: "4px 8px",
+                    textAlign: "left",
+                    font: "var(--font-body-sm)",
+                    cursor: moveMenuOptions.canMoveUp ? "pointer" : "not-allowed",
+                    borderRadius: "var(--radius-sm)",
+                    backgroundColor: "transparent",
+                  }}
+                  onMouseOver={(e) => {
+                    if (moveMenuOptions.canMoveUp) e.currentTarget.style.backgroundColor = "var(--interactive-bg-hover)";
+                  }}
+                  onMouseOut={(e) => {
+                    e.currentTarget.style.backgroundColor = "transparent";
+                  }}
+                >
+                  Move Up
+                </button>
+                <button
+                  role="menuitem"
+                  disabled={!moveMenuOptions.canMoveDown}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    moveMenuOptions.onMoveDown?.();
+                    setIsMoveMenuOpen(false);
+                  }}
+                  style={{
+                    background: "none",
+                    border: "none",
+                    color: moveMenuOptions.canMoveDown ? "var(--color-text-primary)" : "var(--color-text-muted)",
+                    padding: "4px 8px",
+                    textAlign: "left",
+                    font: "var(--font-body-sm)",
+                    cursor: moveMenuOptions.canMoveDown ? "pointer" : "not-allowed",
+                    borderRadius: "var(--radius-sm)",
+                    backgroundColor: "transparent",
+                  }}
+                  onMouseOver={(e) => {
+                    if (moveMenuOptions.canMoveDown) e.currentTarget.style.backgroundColor = "var(--interactive-bg-hover)";
+                  }}
+                  onMouseOut={(e) => {
+                    e.currentTarget.style.backgroundColor = "transparent";
+                  }}
+                >
+                  Move Down
+                </button>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Drag handle grip icon */}
+        {draggable && (
+          <div
+            className="metric-card-drag-handle"
+            onMouseDown={() => setCanDrag(true)}
+            onMouseUp={() => setCanDrag(false)}
+            onMouseLeave={() => setCanDrag(false)}
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              justifyContent: "center",
+              cursor: "grab",
+              color: "var(--color-text-secondary)",
+              padding: "var(--space-xs)",
+              borderRadius: "var(--radius-sm)",
+              transition: "opacity var(--transition-fast), background-color var(--transition-fast)",
+            }}
+            onMouseOver={(e) => {
+              e.currentTarget.style.backgroundColor = "var(--interactive-bg-hover)";
+            }}
+            onMouseOut={(e) => {
+              e.currentTarget.style.backgroundColor = "transparent";
+            }}
+          >
+            <GripVertical size={16} aria-hidden="true" />
+          </div>
+        )}
+
+        {/* ⋮ Kebab Menu Trigger */}
+        {(onResize || onHide) && (
+          <button
+            onClick={(e) => openMenu(e, true)}
+            aria-label={`Menu for ${label}`}
+            style={{
+              background: "none",
+              border: "none",
+              cursor: "pointer",
+              color: "var(--color-text-secondary)",
+              padding: "var(--space-xs)",
+              borderRadius: "var(--radius-sm)",
+              display: "inline-flex",
+              alignItems: "center",
+              justifyContent: "center",
+              transition: "all var(--transition-fast)",
+            }}
+            onMouseOver={(e) => {
+              e.currentTarget.style.backgroundColor = "var(--interactive-bg-hover)";
+            }}
+            onMouseOut={(e) => {
+              e.currentTarget.style.backgroundColor = "transparent";
+            }}
+          >
+            <MoreVertical size={16} aria-hidden="true" />
+          </button>
+        )}
+      </div>
+
+      <div
+        className="cyberpunk-scanlines flex items-center justify-center w-10 h-10 text-3xl leading-none mb-4 shrink-0"
+        style={{ color: "var(--color-text-secondary)", pointerEvents: "none" }}
+      >
         {icon}
       </div>
 
       <div
         className="font-medium text-sm leading-5 mb-2"
-        style={{ color: "var(--color-text-primary)" }}
+        style={{ color: "var(--color-text-primary)", pointerEvents: "none" }}
       >
         {label}
       </div>
 
       <div
         className="text-2xl font-semibold leading-8 mb-2 flex flex-col gap-1"
-        style={{ color: "var(--color-text-vivid)" }}
+        style={{ color: "var(--color-text-vivid)", pointerEvents: "none" }}
       >
         {tokens && tokens.length > 0 ? (
           tokens.map((t, i) => (
@@ -93,10 +459,96 @@ export default function MetricCard({ icon, label, value, desc, trend, tokens }: 
 
       <p
         className="text-sm leading-5 mt-auto"
-        style={{ color: "var(--color-text-secondary)" }}
+        style={{ color: "var(--color-text-secondary)", pointerEvents: "none" }}
       >
         {desc}
       </p>
+
+      {/* Shared Kebab / Context Menu Popup */}
+      {menuState.isOpen && (
+        <div
+          role="menu"
+          style={{
+            position: "fixed",
+            left: `${menuState.x}px`,
+            top: `${menuState.y}px`,
+            backgroundColor: "var(--color-bg-primary)",
+            border: "1px solid var(--color-border-default)",
+            borderRadius: "var(--radius-md)",
+            boxShadow: "var(--shadow-lg)",
+            padding: "var(--space-xs)",
+            minWidth: "150px",
+            display: "flex",
+            flexDirection: "column",
+            gap: "2px",
+            zIndex: 100,
+          }}
+          onClick={(e) => e.stopPropagation()}
+        >
+          {onResize && (
+            <button
+              role="menuitem"
+              onClick={(e) => {
+                e.stopPropagation();
+                onResize(currentSize === "1x1" ? "2x1" : "1x1");
+                closeMenu();
+              }}
+              style={{
+                background: "none",
+                border: "none",
+                color: "var(--color-text-primary)",
+                padding: "6px 12px",
+                textAlign: "left",
+                font: "var(--font-body-sm)",
+                cursor: "pointer",
+                borderRadius: "var(--radius-sm)",
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: "center",
+              }}
+              onMouseOver={(e) => {
+                e.currentTarget.style.backgroundColor = "var(--interactive-bg-hover)";
+              }}
+              onMouseOut={(e) => {
+                e.currentTarget.style.backgroundColor = "transparent";
+              }}
+            >
+              <span>Resize</span>
+              <span style={{ color: "var(--color-text-secondary)", font: "var(--font-label-sm)", marginLeft: "var(--space-sm)" }}>
+                {currentSize === "1x1" ? "to 2x1" : "to 1x1"}
+              </span>
+            </button>
+          )}
+          {onHide && (
+            <button
+              role="menuitem"
+              onClick={(e) => {
+                e.stopPropagation();
+                onHide();
+                closeMenu();
+              }}
+              style={{
+                background: "none",
+                border: "none",
+                color: "var(--color-danger)",
+                padding: "6px 12px",
+                textAlign: "left",
+                font: "var(--font-body-sm)",
+                cursor: "pointer",
+                borderRadius: "var(--radius-sm)",
+              }}
+              onMouseOver={(e) => {
+                e.currentTarget.style.backgroundColor = "var(--color-danger-bg)";
+              }}
+              onMouseOut={(e) => {
+                e.currentTarget.style.backgroundColor = "transparent";
+              }}
+            >
+              Hide widget
+            </button>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/treasuryOverviewPage/Metrics.tsx
+++ b/src/components/treasuryOverviewPage/Metrics.tsx
@@ -1,5 +1,9 @@
+import { useState, useEffect, useMemo } from "react";
 import MetricCard from "./MetricCard";
 import { Metric } from "./Metric";
+import { useWidgetLayout, slugify } from "./useWidgetLayout";
+import WidgetTray from "./WidgetTray";
+import { WidgetConfig } from "./widgetLayout";
 
 interface MetricsProps {
   metrics: Metric[];
@@ -7,7 +11,242 @@ interface MetricsProps {
   error?: string | null;
 }
 
+// Inline useMediaQuery hook for md breakpoint detection (768px)
+function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(() => window.matchMedia(query).matches);
+
+  useEffect(() => {
+    const media = window.matchMedia(query);
+    const listener = (e: MediaQueryListEvent) => setMatches(e.matches);
+    
+    if (media.addEventListener) {
+      media.addEventListener("change", listener);
+    } else {
+      media.addListener(listener);
+    }
+
+    return () => {
+      if (media.removeEventListener) {
+        media.removeEventListener("change", listener);
+      } else {
+        media.removeListener(listener);
+      }
+    };
+  }, [query]);
+
+  return matches;
+}
+
 export default function Metrics({ metrics, loading, error }: MetricsProps) {
+  const isMobile = useMediaQuery("(max-width: 767px)");
+  const {
+    layout,
+    reorderWidgets,
+    updateWidgetSize,
+    updateWidgetVisibility,
+    resetLayout,
+  } = useWidgetLayout(metrics);
+
+  const [draggedId, setDraggedId] = useState<string | null>(null);
+  const [dragOverId, setDragOverId] = useState<string | null>(null);
+  const [invalidDragOverId, setInvalidDragOverId] = useState<string | null>(null);
+  
+  const [announcement, setAnnouncement] = useState("");
+  const [focusTargetId, setFocusTargetId] = useState<string | null>(null);
+
+  // Return column count based on viewport width
+  const getGridCols = () => {
+    if (window.innerWidth >= 1024) return 3;
+    return 2;
+  };
+
+  // Keyboard reorder handler
+  const handleKeyboardMove = (id: string, direction: "left" | "right" | "up" | "down") => {
+    const { visible } = orderedMetrics;
+    const idx = visible.findIndex((item) => item.config.id === id);
+    if (idx === -1) return;
+
+    const cols = getGridCols();
+    let targetIdx = idx;
+    if (direction === "left") {
+      targetIdx = idx - 1;
+    } else if (direction === "right") {
+      targetIdx = idx + 1;
+    } else if (direction === "up") {
+      targetIdx = idx - cols;
+    } else if (direction === "down") {
+      targetIdx = idx + cols;
+    }
+
+    if (targetIdx >= 0 && targetIdx < visible.length) {
+      const newConfigs = [...layout.widgets];
+      const srcConfigIdx = newConfigs.findIndex((w) => w.id === id);
+      const destConfigIdx = newConfigs.findIndex((w) => w.id === visible[targetIdx].config.id);
+
+      if (srcConfigIdx !== -1 && destConfigIdx !== -1) {
+        const temp = newConfigs[srcConfigIdx].order;
+        newConfigs[srcConfigIdx].order = newConfigs[destConfigIdx].order;
+        newConfigs[destConfigIdx].order = temp;
+
+        reorderWidgets(newConfigs);
+        setFocusTargetId(id);
+
+        const label = visible[idx].metric.label;
+        setAnnouncement(`${label} moved to position ${targetIdx + 1} of ${visible.length}`);
+      }
+    }
+  };
+
+  // Mobile reorder handler (Up / Down buttons)
+  const handleMobileSwap = (id: string, currentIdx: number, targetIdx: number) => {
+    const { visible } = orderedMetrics;
+    if (targetIdx >= 0 && targetIdx < visible.length) {
+      const newConfigs = [...layout.widgets];
+      const srcConfigIdx = newConfigs.findIndex((w) => w.id === id);
+      const destConfigIdx = newConfigs.findIndex((w) => w.id === visible[targetIdx].config.id);
+
+      if (srcConfigIdx !== -1 && destConfigIdx !== -1) {
+        const temp = newConfigs[srcConfigIdx].order;
+        newConfigs[srcConfigIdx].order = newConfigs[destConfigIdx].order;
+        newConfigs[destConfigIdx].order = temp;
+
+        reorderWidgets(newConfigs);
+
+        const label = visible[currentIdx].metric.label;
+        setAnnouncement(`${label} moved to position ${targetIdx + 1} of ${visible.length}`);
+      }
+    }
+  };
+
+  // Focus restoration hook after layout change
+  useEffect(() => {
+    if (focusTargetId) {
+      const cardEl = document.querySelector(`[data-widget-id="${focusTargetId}"]`);
+      if (cardEl) {
+        const moveBtn = cardEl.querySelector(".keyboard-move-btn") as HTMLElement;
+        if (moveBtn) {
+          moveBtn.focus();
+        }
+      }
+      setFocusTargetId(null);
+    }
+  }, [focusTargetId, layout.widgets]);
+
+  // Order metrics based on layout configuration
+  const orderedMetrics = useMemo(() => {
+    const sortedConfigs = [...layout.widgets].sort((a, b) => a.order - b.order);
+    const visible: { metric: Metric; config: WidgetConfig }[] = [];
+    const hidden: { metric: Metric; config: WidgetConfig }[] = [];
+
+    sortedConfigs.forEach((config) => {
+      const match = metrics.find((m) => slugify(m.label) === config.id);
+      if (match) {
+        if (config.visible) {
+          visible.push({ metric: match, config });
+        } else {
+          hidden.push({ metric: match, config });
+        }
+      }
+    });
+
+    // Merge check: catch any incoming metrics missing in the layout configuration
+    metrics.forEach((m) => {
+      const id = slugify(m.label);
+      if (!sortedConfigs.some((w) => w.id === id)) {
+        visible.push({
+          metric: m,
+          config: { id, size: "1x1", visible: true, order: sortedConfigs.length },
+        });
+      }
+    });
+
+    return { visible, hidden };
+  }, [layout.widgets, metrics]);
+
+  // Drag and Drop Event Handlers
+  const handleDragStart = (e: React.DragEvent, id: string) => {
+    e.dataTransfer.effectAllowed = "move";
+    e.dataTransfer.setData("text/plain", id);
+    setDraggedId(id);
+  };
+
+  const handleDragEnd = () => {
+    setDraggedId(null);
+    setDragOverId(null);
+    setInvalidDragOverId(null);
+  };
+
+  const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault();
+  };
+
+  const handleDragEnter = (e: React.DragEvent, targetId: string) => {
+    e.preventDefault();
+    if (draggedId && draggedId !== targetId) {
+      setDragOverId(targetId);
+    }
+  };
+
+  const handleDragLeave = (targetId: string) => {
+    if (dragOverId === targetId) {
+      setDragOverId(null);
+    }
+  };
+
+  const handleDrop = (e: React.DragEvent, targetId: string) => {
+    e.preventDefault();
+    const sourceId = e.dataTransfer.getData("text/plain") || draggedId;
+    if (sourceId && sourceId !== targetId) {
+      const { visible } = orderedMetrics;
+      const sourceIdx = visible.findIndex((item) => item.config.id === sourceId);
+      const targetIdx = visible.findIndex((item) => item.config.id === targetId);
+
+      if (sourceIdx !== -1 && targetIdx !== -1) {
+        const newConfigs = [...layout.widgets];
+        const srcConfig = newConfigs.find((w) => w.id === sourceId);
+        const destConfig = newConfigs.find((w) => w.id === targetId);
+
+        if (srcConfig && destConfig) {
+          const temp = srcConfig.order;
+          srcConfig.order = destConfig.order;
+          destConfig.order = temp;
+
+          reorderWidgets(newConfigs);
+
+          const label = visible[sourceIdx].metric.label;
+          setAnnouncement(`${label} moved to position ${targetIdx + 1} of ${visible.length}`);
+        }
+      }
+    }
+    setDraggedId(null);
+    setDragOverId(null);
+  };
+
+  // Drag over Widget Tray (Invalid Targets)
+  const handleTrayDragOver = (e: React.DragEvent) => {
+    e.preventDefault();
+  };
+
+  const handleTrayDragEnter = (e: React.DragEvent, id: string) => {
+    e.preventDefault();
+    if (draggedId) {
+      setInvalidDragOverId(id);
+    }
+  };
+
+  const handleTrayDragLeave = (id: string) => {
+    if (invalidDragOverId === id) {
+      setInvalidDragOverId(null);
+    }
+  };
+
+  const handleTrayDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    setInvalidDragOverId(null);
+    setDraggedId(null);
+  };
+
+  // Rendering loading / error states exactly as they are currently
   if (loading) {
     return (
       <p role="status" className="text-sm" style={{ color: "var(--color-text-secondary)" }}>
@@ -24,16 +263,124 @@ export default function Metrics({ metrics, loading, error }: MetricsProps) {
     );
   }
 
+  const { visible, hidden } = orderedMetrics;
+  const cols = getGridCols();
+
   return (
-    <section
-      aria-label="Treasury metrics"
-      className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6 items-stretch"
-    >
-      {metrics.length > 0 ? (
-        metrics.map((m: Metric, i: number) => <MetricCard key={i} {...m} />)
-      ) : (
-        <p className="text-sm" style={{ color: "var(--color-text-secondary)" }}>No treasury metrics available.</p>
-      )}
-    </section>
+    <div>
+      {/* Live Region for screen reader announcements */}
+      <div role="status" aria-live="polite" className="sr-only">
+        {announcement}
+      </div>
+
+      <section
+        aria-label="Treasury metrics"
+        className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6 items-stretch"
+      >
+        {visible.length > 0 ? (
+          visible.map((item, idx) => {
+            const isDragging = draggedId === item.config.id;
+            const isDragOver = dragOverId === item.config.id;
+            
+            const colSpan = item.config.size === "2x1" ? "sm:col-span-2 col-span-1" : "col-span-1";
+
+            // Mobile-only Up/Down Buttons props
+            const mobileReorderButtons = isMobile ? (
+              <div style={{ display: "flex", gap: "2px" }} onClick={(e) => e.stopPropagation()}>
+                <button
+                  disabled={idx === 0}
+                  onClick={() => handleMobileSwap(item.config.id, idx, idx - 1)}
+                  aria-label={`Move ${item.metric.label} widget up`}
+                  style={{
+                    background: "var(--color-surface-default)",
+                    border: "1px solid var(--color-border-default)",
+                    borderRadius: "var(--radius-sm)",
+                    color: idx === 0 ? "var(--color-text-muted)" : "var(--color-text-secondary)",
+                    padding: "2px 6px",
+                    font: "var(--font-label-sm)",
+                    cursor: idx === 0 ? "not-allowed" : "pointer",
+                  }}
+                >
+                  ▲
+                </button>
+                <button
+                  disabled={idx === visible.length - 1}
+                  onClick={() => handleMobileSwap(item.config.id, idx, idx + 1)}
+                  aria-label={`Move ${item.metric.label} widget down`}
+                  style={{
+                    background: "var(--color-surface-default)",
+                    border: "1px solid var(--color-border-default)",
+                    borderRadius: "var(--radius-sm)",
+                    color: idx === visible.length - 1 ? "var(--color-text-muted)" : "var(--color-text-secondary)",
+                    padding: "2px 6px",
+                    font: "var(--font-label-sm)",
+                    cursor: idx === visible.length - 1 ? "not-allowed" : "pointer",
+                  }}
+                >
+                  ▼
+                </button>
+              </div>
+            ) : undefined;
+
+            // Keyboard-only reorder menus
+            const keyboardMoveMenu = !isMobile ? {
+              onMoveLeft: () => handleKeyboardMove(item.config.id, "left"),
+              onMoveRight: () => handleKeyboardMove(item.config.id, "right"),
+              onMoveUp: () => handleKeyboardMove(item.config.id, "up"),
+              onMoveDown: () => handleKeyboardMove(item.config.id, "down"),
+              canMoveLeft: idx > 0,
+              canMoveRight: idx < visible.length - 1,
+              canMoveUp: idx >= cols,
+              canMoveDown: idx + cols < visible.length,
+            } : undefined;
+
+            return (
+              <div
+                key={item.config.id}
+                data-widget-id={item.config.id}
+                className={`${colSpan} ${isDragOver ? "widget-drop-valid" : ""} ${isDragging ? "widget-dragging" : ""}`}
+                style={{
+                  transition: "all var(--transition-base)",
+                  borderRadius: "var(--radius-xl)",
+                }}
+              >
+                <MetricCard
+                  {...item.metric}
+                  draggable={!isMobile}
+                  onDragStart={(e) => handleDragStart(e, item.config.id)}
+                  onDragEnd={handleDragEnd}
+                  onDragOver={handleDragOver}
+                  onDragEnter={(e) => handleDragEnter(e, item.config.id)}
+                  onDragLeave={() => handleDragLeave(item.config.id)}
+                  onDrop={(e) => handleDrop(e, item.config.id)}
+                  isDragging={isDragging}
+                  onResize={(size) => updateWidgetSize(item.config.id, size)}
+                  onHide={() => updateWidgetVisibility(item.config.id, false)}
+                  currentSize={item.config.size}
+                  reorderButtons={mobileReorderButtons}
+                  moveMenuOptions={keyboardMoveMenu}
+                />
+              </div>
+            );
+          })
+        ) : (
+          <p className="text-sm col-span-full" style={{ color: "var(--color-text-secondary)" }}>
+            No treasury metrics available.
+          </p>
+        )}
+      </section>
+
+      {/* Widget Tray panel for customization */}
+      <WidgetTray
+        hiddenWidgets={hidden}
+        onRestore={(id) => updateWidgetVisibility(id, true)}
+        onResetAll={resetLayout}
+        onDragOver={handleTrayDragOver}
+        onDragEnter={handleTrayDragEnter}
+        onDragLeave={handleTrayDragLeave}
+        onDrop={handleTrayDrop}
+        invalidDragOverId={invalidDragOverId}
+      />
+    </div>
   );
 }

--- a/src/components/treasuryOverviewPage/WidgetTray.tsx
+++ b/src/components/treasuryOverviewPage/WidgetTray.tsx
@@ -1,0 +1,172 @@
+import { Metric } from "./Metric";
+import { Plus } from "lucide-react";
+import React from "react";
+
+interface WidgetTrayProps {
+  hiddenWidgets: { metric: Metric; id: string }[];
+  onRestore: (id: string) => void;
+  onResetAll?: () => void;
+  onDragOver?: (e: React.DragEvent, id: string) => void;
+  onDragEnter?: (e: React.DragEvent, id: string) => void;
+  onDragLeave?: (e: React.DragEvent, id: string) => void;
+  onDrop?: (e: React.DragEvent, id: string) => void;
+  invalidDragOverId?: string | null;
+}
+
+export default function WidgetTray({
+  hiddenWidgets,
+  onRestore,
+  onResetAll,
+  onDragOver = () => {},
+  onDragEnter = () => {},
+  onDragLeave = () => {},
+  onDrop = () => {},
+  invalidDragOverId = null,
+}: WidgetTrayProps) {
+  return (
+    <section
+      aria-label="Add widgets"
+      style={{
+        backgroundColor: "var(--color-bg-secondary)",
+        border: "1px solid var(--color-border-default)",
+        borderRadius: "var(--radius-xl)",
+        padding: "var(--space-xl)",
+        marginTop: "var(--space-xl)",
+        transition: "all var(--transition-base)",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          marginBottom: hiddenWidgets.length > 0 ? "var(--space-lg)" : "0px",
+        }}
+      >
+        <div>
+          <h3
+            style={{
+              font: "var(--font-heading-4)",
+              color: "var(--color-text-primary)",
+              margin: 0,
+              display: "flex",
+              alignItems: "center",
+              gap: "var(--space-sm)",
+            }}
+          >
+            Customize Dashboard Widgets
+          </h3>
+          <p
+            style={{
+              font: "var(--font-body-sm)",
+              color: "var(--color-text-secondary)",
+              margin: "var(--space-xs) 0 0 0",
+            }}
+          >
+            {hiddenWidgets.length > 0
+              ? "Select which metrics are displayed on your treasury grid."
+              : "All metrics are currently active on your dashboard."}
+          </p>
+        </div>
+        {onResetAll && (
+          <button
+            onClick={onResetAll}
+            className="ui-secondary-control"
+            style={{
+              padding: "var(--space-xs) var(--space-sm)",
+              borderRadius: "var(--radius-md)",
+              font: "var(--font-label-sm)",
+              cursor: "pointer",
+              backgroundColor: "var(--color-surface-default)",
+              border: "1px solid var(--color-border-default)",
+              color: "var(--color-text-secondary)",
+              transition: "all var(--transition-fast)",
+            }}
+            onMouseOver={(e) => {
+              e.currentTarget.style.backgroundColor = "var(--interactive-bg-hover)";
+              e.currentTarget.style.color = "var(--color-text-primary)";
+            }}
+            onMouseOut={(e) => {
+              e.currentTarget.style.backgroundColor = "var(--color-surface-default)";
+              e.currentTarget.style.color = "var(--color-text-secondary)";
+            }}
+          >
+            Reset Layout
+          </button>
+        )}
+      </div>
+
+      {hiddenWidgets.length > 0 && (
+        <div
+          style={{
+            display: "flex",
+            flexWrap: "wrap",
+            gap: "var(--space-md)",
+          }}
+        >
+          {hiddenWidgets.map(({ metric, id }) => {
+            const isInvalidDragOver = invalidDragOverId === id;
+            return (
+              <div
+                key={id}
+                onDragOver={(e) => onDragOver(e, id)}
+                onDragEnter={(e) => onDragEnter(e, id)}
+                onDragLeave={(e) => onDragLeave(e, id)}
+                onDrop={(e) => onDrop(e, id)}
+                className={isInvalidDragOver ? "widget-drop-invalid" : ""}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "var(--space-md)",
+                  backgroundColor: "var(--color-surface-default)",
+                  border: "1px solid var(--color-border-default)",
+                  borderRadius: "var(--radius-lg)",
+                  padding: "var(--space-sm) var(--space-md)",
+                  boxShadow: "var(--shadow-sm)",
+                  transition: "all var(--transition-base)",
+                }}
+              >
+                <span style={{ fontSize: "1.5rem", userSelect: "none" }}>{metric.icon}</span>
+                <span
+                  style={{
+                    font: "var(--font-label-md)",
+                    color: "var(--color-text-primary)",
+                  }}
+                >
+                  {metric.label}
+                </span>
+                <button
+                  onClick={() => onRestore(id)}
+                  aria-label={`Restore ${metric.label} widget`}
+                  style={{
+                    display: "inline-flex",
+                    alignItems: "center",
+                    gap: "var(--space-xs)",
+                    padding: "var(--space-xs) var(--space-sm)",
+                    backgroundColor: "var(--color-accent-primary)",
+                    border: "none",
+                    borderRadius: "var(--radius-md)",
+                    color: "var(--color-text-inverse)",
+                    cursor: "pointer",
+                    font: "var(--font-label-sm)",
+                    fontWeight: 600,
+                    transition: "all var(--transition-fast)",
+                  }}
+                  onMouseOver={(e) => {
+                    e.currentTarget.style.backgroundColor = "var(--color-accent-primary-dark)";
+                  }}
+                  onMouseOut={(e) => {
+                    e.currentTarget.style.backgroundColor = "var(--color-accent-primary)";
+                  }}
+                >
+                  <Plus size={14} aria-hidden="true" />
+                  Add
+                </button>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/treasuryOverviewPage/__tests__/useWidgetLayout.test.tsx
+++ b/src/components/treasuryOverviewPage/__tests__/useWidgetLayout.test.tsx
@@ -1,0 +1,150 @@
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { useWidgetLayout } from "../useWidgetLayout";
+import { Metric } from "../Metric";
+
+// Mock the useWallet hook
+let mockWalletAddress: string | null = null;
+vi.mock("../../../components/wallet-connect/Walletcontext", () => ({
+  useWallet: () => ({
+    address: mockWalletAddress,
+  }),
+}));
+
+describe("useWidgetLayout hook", () => {
+  const mockMetrics: Metric[] = [
+    { label: "Total Balance", value: "$100k", desc: "Balance", icon: "💰" },
+    { label: "Active Streams", value: "5", desc: "Streams", icon: "🌊" },
+    { label: "Pending Claims", value: "$5k", desc: "Claims", icon: "⏱️" },
+  ];
+
+  beforeEach(() => {
+    mockWalletAddress = null;
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("returns default fallback layout when localStorage is empty", () => {
+    const { result } = renderHook(() => useWidgetLayout(mockMetrics));
+
+    expect(result.current.layout.version).toBe(1);
+    expect(result.current.layout.widgets).toHaveLength(3);
+    
+    // Check default configs
+    expect(result.current.layout.widgets[0]).toEqual({
+      id: "total-balance",
+      size: "1x1",
+      visible: true,
+      order: 0,
+    });
+    expect(result.current.layout.widgets[1].id).toBe("active-streams");
+    expect(result.current.layout.widgets[2].id).toBe("pending-claims");
+  });
+
+  it("handles localStorage round-trip", () => {
+    const { result } = renderHook(() => useWidgetLayout(mockMetrics));
+
+    // Reorder widgets: swap first and second
+    act(() => {
+      const reordered = [
+        result.current.layout.widgets[1],
+        result.current.layout.widgets[0],
+        result.current.layout.widgets[2],
+      ];
+      result.current.reorderWidgets(reordered);
+    });
+
+    // Verify state updated
+    expect(result.current.layout.widgets[0].id).toBe("active-streams");
+    expect(result.current.layout.widgets[0].order).toBe(0);
+    expect(result.current.layout.widgets[1].id).toBe("total-balance");
+    expect(result.current.layout.widgets[1].order).toBe(1);
+
+    // Verify it is written to unscoped key in localStorage
+    const saved = localStorage.getItem("fluxora:treasury:widget-layout");
+    expect(saved).not.toBeNull();
+    const parsed = JSON.parse(saved!);
+    expect(parsed.widgets[0].id).toBe("active-streams");
+  });
+
+  it("uses wallet-scoped key when wallet is connected", () => {
+    mockWalletAddress = "G-MOCK-WALLET-ADDRESS-123";
+    const { result } = renderHook(() => useWidgetLayout(mockMetrics));
+
+    // Resize a widget
+    act(() => {
+      result.current.updateWidgetSize("total-balance", "2x1");
+    });
+
+    expect(result.current.layout.widgets[0].size).toBe("2x1");
+
+    // Verify it is saved in the wallet-scoped key
+    const unscopedSaved = localStorage.getItem("fluxora:treasury:widget-layout");
+    const scopedSaved = localStorage.getItem(`fluxora:treasury:widget-layout:${mockWalletAddress}`);
+
+    expect(unscopedSaved).toBeNull();
+    expect(scopedSaved).not.toBeNull();
+    const parsed = JSON.parse(scopedSaved!);
+    expect(parsed.widgets[0].size).toBe("2x1");
+  });
+
+  it("falls back to unscoped key when no wallet is connected", () => {
+    // Save some data to unscoped key
+    const initialLayout = {
+      version: 1,
+      widgets: [
+        { id: "total-balance", size: "2x1", visible: false, order: 0 },
+        { id: "active-streams", size: "1x1", visible: true, order: 1 },
+        { id: "pending-claims", size: "1x1", visible: true, order: 2 },
+      ],
+    };
+    localStorage.setItem("fluxora:treasury:widget-layout", JSON.stringify(initialLayout));
+
+    mockWalletAddress = null; // No wallet
+    const { result } = renderHook(() => useWidgetLayout(mockMetrics));
+
+    expect(result.current.layout.widgets[0].size).toBe("2x1");
+    expect(result.current.layout.widgets[0].visible).toBe(false);
+  });
+
+  it("recovers from parse failure and logs a warning", () => {
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    
+    // Put corrupt JSON in localStorage
+    localStorage.setItem("fluxora:treasury:widget-layout", "{invalid-json-corrupt");
+
+    const { result } = renderHook(() => useWidgetLayout(mockMetrics));
+
+    // Should fall back to default order
+    expect(result.current.layout.widgets).toHaveLength(3);
+    expect(result.current.layout.widgets[0].id).toBe("total-balance");
+    expect(consoleWarnSpy).toHaveBeenCalled();
+
+    consoleWarnSpy.mockRestore();
+  });
+
+  it("merges incoming new metrics that are missing from stored layout", () => {
+    // Stored layout only has 2 of the widgets
+    const storedLayout = {
+      version: 1,
+      widgets: [
+        { id: "total-balance", size: "2x1", visible: true, order: 0 },
+        { id: "active-streams", size: "1x1", visible: true, order: 1 },
+      ],
+    };
+    localStorage.setItem("fluxora:treasury:widget-layout", JSON.stringify(storedLayout));
+
+    const { result } = renderHook(() => useWidgetLayout(mockMetrics));
+
+    // Missing metric (pending-claims) should be appended with correct order index
+    expect(result.current.layout.widgets).toHaveLength(3);
+    expect(result.current.layout.widgets[0].size).toBe("2x1");
+    expect(result.current.layout.widgets[2].id).toBe("pending-claims");
+    expect(result.current.layout.widgets[2].order).toBe(2);
+    expect(result.current.layout.widgets[2].visible).toBe(true);
+  });
+});

--- a/src/components/treasuryOverviewPage/useWidgetLayout.ts
+++ b/src/components/treasuryOverviewPage/useWidgetLayout.ts
@@ -1,0 +1,131 @@
+import { useState, useEffect, useMemo, useCallback } from "react";
+import { useWallet } from "../wallet-connect/Walletcontext";
+import { WidgetLayout, WidgetConfig, WidgetSize } from "./widgetLayout";
+import { Metric } from "./Metric";
+
+export const slugify = (text: string): string => {
+  return text
+    .toLowerCase()
+    .trim()
+    .replace(/[^\w\s-]/g, "")
+    .replace(/[\s_]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+};
+
+const DEFAULT_VERSION = 1;
+
+export function useWidgetLayout(metrics: Metric[]) {
+  const { address } = useWallet();
+
+  const storageKey = useMemo(() => {
+    return address
+      ? `fluxora:treasury:widget-layout:${address}`
+      : `fluxora:treasury:widget-layout`;
+  }, [address]);
+
+  // Generate the default fallback layout from incoming metrics
+  const generateDefaultLayout = useCallback((currentMetrics: Metric[]): WidgetLayout => {
+    return {
+      version: DEFAULT_VERSION,
+      widgets: currentMetrics.map((m, index) => ({
+        id: slugify(m.label),
+        size: "1x1",
+        visible: true,
+        order: index,
+      })),
+    };
+  }, []);
+
+  const loadLayout = useCallback((): WidgetLayout => {
+    const defaultLayout = generateDefaultLayout(metrics);
+    try {
+      const data = localStorage.getItem(storageKey);
+      if (!data) {
+        return defaultLayout;
+      }
+      const parsed = JSON.parse(data) as WidgetLayout;
+      if (parsed && parsed.version === DEFAULT_VERSION && Array.isArray(parsed.widgets)) {
+        // Merge logic: ensure any incoming metrics that are not in the stored layout get appended,
+        // and any stored widgets that no longer exist in the incoming metrics get filtered out.
+        const incomingIds = new Set(metrics.map(m => slugify(m.label)));
+        
+        // Filter out widgets that are no longer present in incoming metrics
+        const validStoredWidgets = parsed.widgets.filter(w => incomingIds.has(w.id));
+
+        // Add any incoming metrics that are not yet in the stored layout
+        const storedIds = new Set(validStoredWidgets.map(w => w.id));
+        const newWidgets: WidgetConfig[] = [...validStoredWidgets];
+
+        metrics.forEach((m) => {
+          const id = slugify(m.label);
+          if (!storedIds.has(id)) {
+            newWidgets.push({
+              id,
+              size: "1x1",
+              visible: true,
+              order: newWidgets.length,
+            });
+          }
+        });
+
+        // Re-index order to be continuous 0..N-1
+        const normalizedWidgets = newWidgets.map((w, idx) => ({
+          ...w,
+          order: idx,
+        }));
+
+        return {
+          version: DEFAULT_VERSION,
+          widgets: normalizedWidgets,
+        };
+      }
+      throw new Error("Invalid layout structure or version");
+    } catch (e) {
+      console.warn("Failed to load layout from localStorage, falling back to default.", e);
+      return defaultLayout;
+    }
+  }, [metrics, storageKey, generateDefaultLayout]);
+
+  const [layout, setLayout] = useState<WidgetLayout>(() => loadLayout());
+
+  // Reload layout when the storageKey (wallet address) changes
+  useEffect(() => {
+    setLayout(loadLayout());
+  }, [loadLayout]);
+
+  const saveLayout = useCallback((newLayout: WidgetLayout) => {
+    setLayout(newLayout);
+    localStorage.setItem(storageKey, JSON.stringify(newLayout));
+  }, [storageKey]);
+
+  const reorderWidgets = useCallback((newWidgets: WidgetConfig[]) => {
+    const updated = newWidgets.map((w, index) => ({ ...w, order: index }));
+    saveLayout({ version: DEFAULT_VERSION, widgets: updated });
+  }, [saveLayout]);
+
+  const updateWidgetSize = useCallback((id: string, size: WidgetSize) => {
+    const updated = layout.widgets.map((w) =>
+      w.id === id ? { ...w, size } : w
+    );
+    saveLayout({ version: DEFAULT_VERSION, widgets: updated });
+  }, [layout.widgets, saveLayout]);
+
+  const updateWidgetVisibility = useCallback((id: string, visible: boolean) => {
+    const updated = layout.widgets.map((w) =>
+      w.id === id ? { ...w, visible } : w
+    );
+    saveLayout({ version: DEFAULT_VERSION, widgets: updated });
+  }, [layout.widgets, saveLayout]);
+
+  const resetLayout = useCallback(() => {
+    saveLayout(generateDefaultLayout(metrics));
+  }, [metrics, generateDefaultLayout, saveLayout]);
+
+  return {
+    layout,
+    reorderWidgets,
+    updateWidgetSize,
+    updateWidgetVisibility,
+    resetLayout,
+  };
+}

--- a/src/components/treasuryOverviewPage/widgetLayout.ts
+++ b/src/components/treasuryOverviewPage/widgetLayout.ts
@@ -1,0 +1,13 @@
+export type WidgetSize = "1x1" | "2x1";
+
+export interface WidgetConfig {
+  id: string;
+  size: WidgetSize;
+  visible: boolean;
+  order: number;
+}
+
+export interface WidgetLayout {
+  version: 1;
+  widgets: WidgetConfig[];
+}

--- a/src/index.css
+++ b/src/index.css
@@ -599,3 +599,253 @@ button[aria-label*="Switch"]:hover {
   top: 0;
   outline: none;
 }
+
+/* Drag and Drop Widget States */
+.widget-drop-valid {
+  border: 2px dashed var(--color-accent-primary-dark) !important;
+  background-color: color-mix(in srgb, var(--color-accent-primary) 30%, transparent) !important;
+}
+
+:root[data-theme="dark"] .widget-drop-valid {
+  border: 2px dashed var(--color-accent-primary) !important;
+}
+
+  font-weight: 600;
+}
+
+.nf-desc {
+  color: var(--nf-muted);
+  margin: 0 0 22px;
+  max-width: 640px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.nf-actions {
+  display: flex;
+  gap: var(--space-md);
+  justify-content: center;
+  margin-top: var(--space-sm);
+  flex-wrap: wrap;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px var(--space-lg);
+  border-radius: 10px;
+  font-weight: 600;
+  cursor: pointer;
+  border: 1px solid transparent;
+}
+
+.btn:focus-visible {
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: var(--focus-ring-offset);
+  box-shadow: var(--focus-ring-shadow);
+}
+
+.btn-icon {
+  font-size: 1.05rem;
+}
+
+.btn-primary {
+  background: linear-gradient(90deg, #2bbfdf, #42c9d9);
+  color: white;
+  border: 1px solid rgba(75, 192, 217, 0.35);
+  box-shadow: 0 6px 24px rgba(75, 192, 217, 0.12);
+}
+
+.btn-secondary {
+  background: var(--surface-raised);
+  color: var(--color-text-primary);
+  border: 1px solid var(--border-neutral);
+}
+
+@media (max-width: 560px) {
+  .nf-code {
+    font-size: 3rem;
+  }
+  .notfound-card {
+    padding: var(--space-2xl) var(--space-lg);
+  }
+}
+
+/* ═══════════════════════════════════════════════════════════
+   SKELETON SHIMMER UTILITY
+   ═══════════════════════════════════════════════════════════ */
+
+.skeleton {
+  background: linear-gradient(
+    90deg,
+    var(--skeleton-base) 25%,
+    var(--skeleton-shine) 50%,
+    var(--skeleton-base) 75%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 1.5s ease-in-out infinite;
+  border-radius: var(--radius-sm);
+}
+
+/* ═══════════════════════════════════════════════════════════
+   REDUCED MOTION
+   Disable all CSS animations, transitions, and the shimmer /
+   spin keyframe animations for users who prefer reduced motion.
+   JS-driven animations (e.g. GlowingDot glow) are handled in
+   the component via the matchMedia API.
+   ═══════════════════════════════════════════════════════════ */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+/* ═══════════════════════════════════════════════════════════
+   TYPOGRAPHY UTILITY CLASSES
+   Maps design-token font shorthands to reusable class names.
+   Usage: <h1 className="text-heading-1">…</h1>
+   ═══════════════════════════════════════════════════════════ */
+
+.text-heading-1 {
+  font: var(--font-heading-1);
+  letter-spacing: var(--letter-spacing-tight);
+}
+
+.text-heading-2 {
+  font: var(--font-heading-2);
+  letter-spacing: var(--letter-spacing-tight);
+}
+
+.text-heading-3 {
+  font: var(--font-heading-3);
+}
+
+.text-heading-4 {
+  font: var(--font-heading-4);
+}
+
+.text-body-lg {
+  font: var(--font-body-lg);
+}
+
+.text-body-md {
+  font: var(--font-body-md);
+}
+
+.text-body-sm {
+  font: var(--font-body-sm);
+}
+
+.text-label-lg {
+  font: var(--font-label-lg);
+  letter-spacing: var(--letter-spacing-wide);
+}
+
+.text-label-md {
+  font: var(--font-label-md);
+  letter-spacing: var(--letter-spacing-wide);
+}
+
+.text-label-sm {
+  font: var(--font-label-sm);
+  letter-spacing: var(--letter-spacing-wide);
+}
+
+.text-mono-sm {
+  font: var(--font-mono-sm);
+}
+
+/* Screen-reader only utility */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Skip to content link */
+.skip-link {
+  position: absolute;
+  top: -100px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--accent);
+  color: #000;
+  padding: 12px 24px;
+  z-index: 9999;
+  font-weight: 700;
+  border-radius: 0 0 8px 8px;
+  transition: top 0.2s ease-in-out;
+  text-decoration: none;
+}
+
+.skip-link:focus {
+  top: 0;
+  outline: none;
+}
+
+/* Drag and Drop Widget States */
+.widget-drop-valid {
+  border: 2px dashed var(--color-accent-primary-dark) !important;
+  background-color: color-mix(in srgb, var(--color-accent-primary) 30%, transparent) !important;
+}
+
+:root[data-theme="dark"] .widget-drop-valid {
+  border: 2px dashed var(--color-accent-primary) !important;
+}
+
+.widget-drop-invalid {
+  border: 2px dashed var(--color-danger) !important;
+  background-color: var(--color-danger-bg) !important;
+}
+
+.widget-dragging {
+  opacity: 0.6 !important;
+}
+
+/* MetricCard actions visibility */
+.metric-card-actions {
+  opacity: 0;
+  transition: opacity var(--transition-fast);
+}
+
+.metric-card-wrapper:hover .metric-card-actions,
+.metric-card-wrapper:focus-within .metric-card-actions {
+  opacity: 1;
+}
+
+/* For keyboard focus reorder button, make sure it is visually hidden until focused */
+.keyboard-move-btn {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.keyboard-move-btn:focus,
+.keyboard-move-btn:focus-visible {
+  position: static;
+  width: auto;
+  height: auto;
+  padding: 2px 6px;
+  margin: 0;
+  overflow: visible;
+  clip: auto;
+  white-space: normal;
+}


### PR DESCRIPTION
Closes #829

---

---

## Summary

Implements a drag-to-arrange widget system for the treasury metrics grid (issue #829). Treasury admins can now reorder and resize `MetricCard` instances via drag-and-drop on desktop, Up/Down buttons on mobile, and a keyboard-accessible Move menu with `aria-live` announcements. Widget visibility and order persist to `localStorage` scoped by wallet address, with an "Add widget" tray to restore hidden metrics.

## Changes

- **`widgetLayout.ts`** (new): `WidgetSize`, `WidgetConfig`, and `WidgetLayout` types
- **`useWidgetLayout.ts`** (new): hook for reading/writing layout to `localStorage` under `fluxora:treasury:widget-layout:<walletAddress>`, with merge logic for new metrics and parse-failure fallback
- **`WidgetTray.tsx`** (new): tray below the grid listing hidden widgets with restore and reset controls
- **`MetricCard.tsx`** (modified): added optional drag handle (`GripVertical`), keyboard Move button, and single `⋮`/right-click context menu handler for resize and hide; all new props are optional, existing tests unchanged
- **`Metrics.tsx`** (modified): integrated `useWidgetLayout`, inline `useMediaQuery` hook, HTML5 DnD handlers, mobile Up/Down reorder buttons, and `aria-live="polite"` position announcements
- **`index.css`** (modified): added `widget-drop-valid`, `widget-drop-invalid`, `widget-dragging` classes using theme-aware token variables
- **`docs/TREASURY_WIDGET_DRAG_ARRANGE_SPEC.md`** (new): interaction states, data schema, keyboard behavior, storage strategy, and WCAG contrast ratios
- **`useWidgetLayout.test.tsx`** (new): 6 tests covering default fallback, round-trip, wallet-scoped key, unscoped fallback, and parse failure recovery
- **`vitest.config.ts`** (modified): added `widgetLayout.ts`, `useWidgetLayout.ts`, `WidgetTray.tsx` to the coverage `include` array

## Test plan

- [x] `npm run build` passes (type-check + production build)
- [x] `npm run test` passes — 6 new `useWidgetLayout` tests, 5 existing `MetricCard` tests, 4 existing `demoMode` tests all green
- [x] `npm run test:coverage` passes — new production modules added to `include` array in `vitest.config.ts`
- [x] New code covered by tests; `widgetLayout.ts`, `useWidgetLayout.ts`, and `WidgetTray.tsx` appended to the coverage include list