### PR TITLE
Closes #825

### DIFF
--- a/docs/THEME_AUTO_OPTION_SPEC.md
+++ b/docs/THEME_AUTO_OPTION_SPEC.md
@@ -1,0 +1,93 @@
+# Theme Auto Option & Segmented Control Specification
+
+This document specifies the technical design, keyboard behaviors, storage rules, and accessibility details for the theme preference options including the "Auto" (system default) selection.
+
+---
+
+## 1. Distinction Between Preference and DOM Theme
+
+We distinguish between the user's stored *intent* (theme preference) and the actual resolved *rendered* theme driving the document root (`<html>` element `data-theme` attribute).
+
+*   **`ThemePreference`**: `"light" | "dark" | "auto"`
+    Exposed on the context as `themePreference`. Represents the user's preference choice.
+*   **`Theme`**: `"light" | "dark" | "cyberpunk"`
+    Exposed on the context as `theme`. Drives the DOM (`data-theme` attribute).
+    When `themePreference` is `"auto"`, `theme` dynamically resolves to the OS preference.
+
+---
+
+## 2. The Four Application Theme States
+
+| State | User Preference | Local OS Mode | Resolved DOM Theme | LocalStorage `theme` Key |
+|---|---|---|---|---|
+| **light-selected** | `"light"` | *Any* | `"light"` | `"light"` |
+| **dark-selected** | `"dark"` | *Any* | `"dark"` | `"dark"` |
+| **auto-selected-currently-light** | `"auto"` | Light | `"light"` | *Removed (null)* |
+| **auto-selected-currently-dark** | `"auto"` | Dark | `"dark"` | *Removed (null)* |
+
+---
+
+## 3. Storage Behavior
+
+*   **Explicit preference (`"light"` or `"dark"`)**:
+    Persists to `window.localStorage` under the key `"theme"`. Gates the OS scheme listener (preventing changes to the system theme from modifying the viewport).
+*   **System preference following (`"auto"`)**:
+    Removes the `"theme"` item from `window.localStorage` (clears it completely, i.e., `removeItem`). Registers an OS `prefers-color-scheme` listener that dynamically updates the resolved theme as the OS preferences change.
+*   **Cross-tab synchronization**:
+    A storage event listener is registered. If a user changes their preference in tab A:
+    *   If tab A stores `"light"` or `"dark"`, tab B receives the value and updates its local preference state and DOM theme.
+    *   If tab A clears the storage item (setting the preference to `"auto"`), tab B receives `newValue === null`, updates preference to `"auto"`, and resumes matching the system theme.
+
+---
+
+## 4. UI Component: ThemeSegmentedControl
+
+The theme selector is rendered as a segmented button group replacing the previous toggle button.
+
+### 4.1 Icon Selection
+*   **Light**: `Sun` icon from `lucide-react`.
+*   **Dark**: `Moon` icon from `lucide-react`.
+*   **Auto**: `Monitor` icon from `lucide-react`.
+*   *Note*: Icon class size matches `className="icon-xs"`.
+
+### 4.2 ARIA Attributes & Responsive Labels
+*   The container has `role="radiogroup"` with `aria-label="Theme preference"`.
+*   Each option is a `<button>` with `role="radio"` and `aria-checked` set to `true`/`false`.
+*   **Labels**:
+    *   On narrow viewports (below `md`), labels are visually hidden using the `.sr-only` class.
+    *   On wider viewports (at or above `md`), labels are shown inline alongside the icons.
+*   **Auto Radio Announcement**:
+    To assist screen-readers, when the `"Auto"` radio is focused or selected, its `aria-label` dynamically announces the currently resolved theme state:
+    *   `aria-label="Auto (currently light)"`
+    *   `aria-label="Auto (currently dark)"`
+
+---
+
+## 5. Keyboard Navigation (ARIA Radiogroup Pattern)
+
+To ensure full keyboard accessibility, the segmented control implements the standard ARIA radiogroup pattern:
+
+*   **Tab Navigation**: Only the *selected/active* option is focusable (`tabIndex={0}`). Unselected options are removed from tab order (`tabIndex={-1}`). Tab moves focus out of the radiogroup entirely.
+*   **Arrow Navigation**:
+    *   Pressing **Right Arrow** or **Down Arrow** moves focus to the next radio option, selects it immediately, and sets focus.
+    *   Pressing **Left Arrow** or **Up Arrow** moves focus to the previous radio option, selects it immediately, and sets focus.
+    *   **Wrapping**: Arrow navigation wraps around:
+        *   `light -> dark -> auto -> light...` (forward)
+        *   `auto -> dark -> light -> auto...` (backward)
+
+---
+
+## 6. Contrast Ratios & Visual Styling
+
+All text, icons, and borders conform to the WCAG AAA/AA contrast requirements (minimum 4.5:1 contrast ratio against the background surface).
+
+*   **Background Surfaces**:
+    *   Unselected buttons use the navbar transparent/sunken background.
+    *   Selected buttons use `var(--color-surface-elevated)` for high distinction.
+*   **Selected Option Styling**:
+    *   Border: `border-[var(--color-accent-primary)]` (vivid accent color).
+    *   Text / Icon: `text-[var(--color-accent-primary)]` (cyan color, > 4.5:1 contrast against light and dark elevated surfaces).
+*   **Unselected Option Styling**:
+    *   Border: `border-[var(--navbar-icon-border)]`
+    *   Text / Icon: `text-[var(--navbar-icon-color)]`
+    *   Hover States: `hover:border-[var(--accent)]/50 hover:text-[var(--accent)]`

--- a/src/components/navigation/AppNavbar.tsx
+++ b/src/components/navigation/AppNavbar.tsx
@@ -13,6 +13,7 @@ import {
   getBrowserTimezone,
 } from "../../lib/timePresentation";
 import { VoiceMicButton } from "../voice/VoiceMicButton";
+import ThemeSegmentedControl from "./ThemeSegmentedControl";
 
 interface AppNavbarProps {
   onSidebarToggle?: () => void;
@@ -423,17 +424,7 @@ const location = useLocation();
             </button>
 
             {/* Theme toggle */}
-            <button
-              onClick={toggleTheme}
-              aria-label={`Switch to ${theme === "light" ? "dark" : "light"} mode`}
-              className="flex items-center justify-center min-h-[44px] min-w-[44px] rounded-full border border-[var(--navbar-icon-border)] text-[var(--navbar-icon-color)] hover:border-[var(--accent)]/50 hover:text-[var(--accent)] transition-colors outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
-            >
-              {theme === "light" ? (
-                <Moon className="icon-xs" aria-hidden="true" />
-              ) : (
-                <Sun className="icon-xs" aria-hidden="true" />
-              )}
-            </button>
+            <ThemeSegmentedControl />
 
             {/* Wallet area */}
             {connecting ? (
@@ -523,17 +514,7 @@ const location = useLocation();
             </button>
 
             {/* Theme toggle */}
-            <button
-              onClick={toggleTheme}
-              aria-label={`Switch to ${theme === "light" ? "dark" : "light"} mode`}
-              className="flex items-center justify-center min-h-[44px] min-w-[44px] rounded-full border border-[var(--navbar-icon-border)] text-[var(--navbar-icon-color)] hover:border-[var(--accent)]/50 hover:text-[var(--accent)] transition-colors outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
-            >
-              {theme === "light" ? (
-                <Moon className="icon-xs" aria-hidden="true" />
-              ) : (
-                <Sun className="icon-xs" aria-hidden="true" />
-              )}
-            </button>
+            <ThemeSegmentedControl />
 
             {connecting ? (
               <ConnectingSkeleton />

--- a/src/components/navigation/ThemeSegmentedControl.tsx
+++ b/src/components/navigation/ThemeSegmentedControl.tsx
@@ -1,0 +1,76 @@
+import { useRef } from "react";
+import { Sun, Moon, Monitor } from "lucide-react";
+import { useTheme, type ThemePreference } from "../../theme/ThemeProvider";
+
+export default function ThemeSegmentedControl() {
+  const { theme, themePreference, setThemePreference } = useTheme();
+
+  const options: { value: ThemePreference; label: string; icon: typeof Sun }[] = [
+    { value: "light", label: "Light", icon: Sun },
+    { value: "dark", label: "Dark", icon: Moon },
+    { value: "auto", label: "Auto", icon: Monitor },
+  ];
+
+  const buttonRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>, index: number) => {
+    let nextIndex = index;
+    if (e.key === "ArrowRight" || e.key === "ArrowDown") {
+      nextIndex = (index + 1) % options.length;
+      e.preventDefault();
+    } else if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
+      nextIndex = (index - 1 + options.length) % options.length;
+      e.preventDefault();
+    } else {
+      return;
+    }
+
+    const nextValue = options[nextIndex].value;
+    setThemePreference(nextValue);
+
+    // Wait for state transition to complete, then focus
+    setTimeout(() => {
+      buttonRefs.current[nextIndex]?.focus();
+    }, 0);
+  };
+
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Theme preference"
+      className="flex items-center gap-1.5"
+    >
+      {options.map((opt, idx) => {
+        const Icon = opt.icon;
+        const isSelected = themePreference === opt.value;
+        const ariaLabel =
+          opt.value === "auto" ? `Auto (currently ${theme})` : opt.label;
+
+        return (
+          <button
+            key={opt.value}
+            ref={(el) => {
+              buttonRefs.current[idx] = el;
+            }}
+            role="radio"
+            aria-checked={isSelected}
+            aria-label={ariaLabel}
+            tabIndex={isSelected ? 0 : -1}
+            onClick={() => setThemePreference(opt.value)}
+            onKeyDown={(e) => handleKeyDown(e, idx)}
+            className={`flex items-center justify-center gap-2 min-h-[44px] min-w-[44px] px-3 md:px-4 rounded-full border transition-all cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] ${
+              isSelected
+                ? "border-[var(--color-accent-primary)] text-[var(--color-accent-primary)] bg-[var(--color-surface-elevated)]"
+                : "border-[var(--navbar-icon-border)] text-[var(--navbar-icon-color)] hover:border-[var(--accent)]/50 hover:text-[var(--accent)] bg-transparent"
+            }`}
+          >
+            <Icon className="icon-xs" aria-hidden="true" />
+            <span className="sr-only md:not-sr-only font-sans text-xs font-semibold">
+              {opt.label}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/navigation/__tests__/AppNavbar.accessibility.test.tsx
+++ b/src/components/navigation/__tests__/AppNavbar.accessibility.test.tsx
@@ -22,6 +22,10 @@ vi.mock("../../wallet-connect/Walletcontext", () => ({
   }),
 }));
 
+vi.mock("../../voice/VoiceMicButton", () => ({
+  VoiceMicButton: () => <div data-testid="mock-voice-mic-button" />,
+}));
+
 // Mock useTickingNow to avoid infinite loops in vi.runAllTimers()
 vi.mock("../../../hooks/useTickingNow", () => ({
   useTickingNow: () => "2026-07-24T05:07:26.000Z",
@@ -83,13 +87,13 @@ describe("Property 3: Icon-only buttons have non-empty aria-labels", () => {
             expect(hamburgerLabel).toBeTruthy();
             expect(hamburgerLabel!.length).toBeGreaterThan(0);
 
-            // Theme toggle (desktop; may be multiple when mobile menu open)
-            const themeToggles = screen.getAllByRole("button", {
-              name: /switch to (dark|light) mode/i,
+            // Theme preference segmented control
+            const themeControls = screen.getAllByRole("radiogroup", {
+              name: /theme preference/i,
             });
-            expect(themeToggles.length).toBeGreaterThanOrEqual(1);
-            themeToggles.forEach((btn) => {
-              const label = btn.getAttribute("aria-label");
+            expect(themeControls.length).toBeGreaterThanOrEqual(1);
+            themeControls.forEach((group) => {
+              const label = group.getAttribute("aria-label");
               expect(label).toBeTruthy();
               expect(label!.length).toBeGreaterThan(0);
             });

--- a/src/components/navigation/__tests__/AppNavbar.disconnect.test.tsx
+++ b/src/components/navigation/__tests__/AppNavbar.disconnect.test.tsx
@@ -22,6 +22,10 @@ vi.mock("../../wallet-connect/Walletcontext", () => ({
   }),
 }));
 
+vi.mock("../../voice/VoiceMicButton", () => ({
+  VoiceMicButton: () => <div data-testid="mock-voice-mic-button" />,
+}));
+
 vi.mock("../../../hooks/useTickingNow", () => ({
   useTickingNow: () => "2026-07-24T05:07:26.000Z",
 }));

--- a/src/components/navigation/__tests__/AppNavbar.timezone.test.tsx
+++ b/src/components/navigation/__tests__/AppNavbar.timezone.test.tsx
@@ -18,6 +18,10 @@ vi.mock("../../wallet-connect/Walletcontext", () => ({
   }),
 }));
 
+vi.mock("../../voice/VoiceMicButton", () => ({
+  VoiceMicButton: () => <div data-testid="mock-voice-mic-button" />,
+}));
+
 // Mock react-router-dom
 vi.mock("react-router-dom", () => ({
   Link: ({

--- a/src/components/navigation/__tests__/ThemeSegmentedControl.test.tsx
+++ b/src/components/navigation/__tests__/ThemeSegmentedControl.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ThemeSegmentedControl from "../ThemeSegmentedControl";
+import { ThemeProvider } from "../../../theme/ThemeProvider";
+
+describe("ThemeSegmentedControl", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.removeAttribute("data-theme");
+  });
+
+  it("renders three options with correct accessibility attributes", () => {
+    render(
+      <ThemeProvider>
+        <ThemeSegmentedControl />
+      </ThemeProvider>
+    );
+
+    const radiogroup = screen.getByRole("radiogroup", { name: "Theme preference" });
+    expect(radiogroup).toBeInTheDocument();
+
+    const radios = screen.getAllByRole("radio");
+    expect(radios).toHaveLength(3);
+
+    // Initial state: Auto is selected (default)
+    expect(radios[0]).toHaveAttribute("aria-checked", "false"); // Light
+    expect(radios[1]).toHaveAttribute("aria-checked", "false"); // Dark
+    expect(radios[2]).toHaveAttribute("aria-checked", "true");  // Auto
+  });
+
+  it("announces the currently resolved theme in the 'Auto' option's label", () => {
+    render(
+      <ThemeProvider>
+        <ThemeSegmentedControl />
+      </ThemeProvider>
+    );
+
+    // Auto is selected, should announce "Auto (currently light)" under default test environment setup.ts
+    const autoRadio = screen.getByRole("radio", { name: "Auto (currently light)" });
+    expect(autoRadio).toBeInTheDocument();
+  });
+
+  it("handles keyboard navigation using arrow keys (Right/Down, Left/Up, wraps)", async () => {
+    const user = userEvent.setup();
+    render(
+      <ThemeProvider>
+        <ThemeSegmentedControl />
+      </ThemeProvider>
+    );
+
+    const radios = screen.getAllByRole("radio");
+    // Start with focus on Auto (index 2), because it is selected
+    radios[2].focus();
+    expect(document.activeElement).toBe(radios[2]);
+
+    // Press ArrowRight from Auto -> Light (index 0)
+    await user.keyboard("{ArrowRight}");
+    expect(radios[0]).toHaveAttribute("aria-checked", "true");
+    expect(document.activeElement).toBe(radios[0]);
+
+    // Press ArrowRight from Light -> Dark (index 1)
+    await user.keyboard("{ArrowRight}");
+    expect(radios[1]).toHaveAttribute("aria-checked", "true");
+    expect(document.activeElement).toBe(radios[1]);
+
+    // Press ArrowDown from Dark -> Auto (index 2)
+    await user.keyboard("{ArrowDown}");
+    expect(radios[2]).toHaveAttribute("aria-checked", "true");
+    expect(document.activeElement).toBe(radios[2]);
+
+    // Press ArrowLeft from Auto -> Dark (index 1)
+    await user.keyboard("{ArrowLeft}");
+    expect(radios[1]).toHaveAttribute("aria-checked", "true");
+    expect(document.activeElement).toBe(radios[1]);
+
+    // Press ArrowUp from Dark -> Light (index 0)
+    await user.keyboard("{ArrowUp}");
+    expect(radios[0]).toHaveAttribute("aria-checked", "true");
+    expect(document.activeElement).toBe(radios[0]);
+  });
+
+  it("updates theme preference when clicked", async () => {
+    const user = userEvent.setup();
+    render(
+      <ThemeProvider>
+        <ThemeSegmentedControl />
+      </ThemeProvider>
+    );
+
+    const radios = screen.getAllByRole("radio");
+
+    // Click Light
+    await user.click(radios[0]);
+    expect(radios[0]).toHaveAttribute("aria-checked", "true");
+    expect(localStorage.getItem("theme")).toBe("light");
+
+    // Click Dark
+    await user.click(radios[1]);
+    expect(radios[1]).toHaveAttribute("aria-checked", "true");
+    expect(localStorage.getItem("theme")).toBe("dark");
+
+    // Click Auto
+    await user.click(radios[2]);
+    expect(radios[2]).toHaveAttribute("aria-checked", "true");
+    expect(localStorage.getItem("theme")).toBeNull();
+  });
+});

--- a/src/theme/ThemeProvider.tsx
+++ b/src/theme/ThemeProvider.tsx
@@ -109,14 +109,27 @@ export interface ThemeRegistrationError {
 
 // ─── 3. Storage helpers ───────────────────────────────────────────────────────
 
-function getStoredTheme(): Theme | null {
+export type ThemePreference = "light" | "dark" | "auto";
+
+export function isThemePreference(value: unknown): value is ThemePreference {
+  return value === "light" || value === "dark" || value === "auto";
+}
+
+function getStoredTheme(): ThemePreference | null {
   if (typeof window === "undefined") return null;
   try {
     const stored = window.localStorage.getItem(THEME_STORAGE_KEY);
-    return isTheme(stored) ? stored : null;
+    return isThemePreference(stored) ? stored : null;
   } catch {
     return null;
   }
+}
+
+export function resolveThemeFromPreference(pref: ThemePreference): Theme {
+  if (pref === "auto") {
+    return getSystemTheme();
+  }
+  return pref;
 }
 
 /**
@@ -191,7 +204,8 @@ const CUSTOM_PROP_PREFIX = "--custom-";
  * no FOUC.
  */
 export function resolveInitialTheme(): Theme {
-  return getStoredTheme() ?? getSystemTheme();
+  const stored = getStoredTheme();
+  return resolveThemeFromPreference(stored ?? "auto");
 }
 
 /**
@@ -293,6 +307,10 @@ export interface ThemeContextValue {
   setEasyReadFont: (easyReadFont: boolean) => void;
   /** Flips the easy-read font preference. */
   toggleEasyReadFont: () => void;
+  /** The theme preference chosen by the user (light, dark, auto). */
+  themePreference: ThemePreference;
+  /** Sets and persists the theme preference. */
+  setThemePreference: (pref: ThemePreference) => void;
 
   /** The currently registered custom theme, or `null`. */
   customTheme: RegisteredTheme | null;
@@ -358,13 +376,22 @@ const ThemeContext = createContext<ThemeContextValue | null>(null);
  */
 export function ThemeProvider({ children }: { children: ReactNode }) {
   // ── built-in theme ──────────────────────────────────────────────────────────
-  const [theme, setThemeState] = useState<Theme>(resolveInitialTheme);
+  const [themePreference, setThemePreferenceState] = useState<ThemePreference>(() => {
+    return getStoredTheme() ?? "auto";
+  });
+  const [theme, setThemeState] = useState<Theme>(() => {
+    const initialPref = getStoredTheme() ?? "auto";
+    return resolveThemeFromPreference(initialPref);
+  });
   const [easyReadFont, setEasyReadState] = useState<boolean>(getStoredFontPreference);
 
   // Whether the user (in this tab or another) has explicitly picked a theme.
   // While `false`, we keep following the OS preference. A ref keeps the latest
   // value available to long-lived event listeners without re-subscribing.
-  const hasExplicitChoiceRef = useRef<boolean>(getStoredTheme() !== null);
+  const hasExplicitChoiceRef = useRef<boolean>(themePreference !== "auto");
+
+  // Keep hasExplicitChoiceRef in sync with themePreference state
+  hasExplicitChoiceRef.current = themePreference !== "auto";
 
   // Mirror built-in theme to DOM (only when not in custom mode).
   useEffect(() => {
@@ -379,17 +406,39 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     applyFontPreference(easyReadFont);
   }, [easyReadFont]);
 
-  const setTheme = useCallback((next: Theme) => {
-    hasExplicitChoiceRef.current = true;
-    try {
-      window.localStorage.setItem(THEME_STORAGE_KEY, next);
-    } catch { /* ignore quota errors */ }
-    setThemeState(next);
+  const setThemePreference = useCallback((pref: ThemePreference) => {
+    setThemePreferenceState(pref);
+    hasExplicitChoiceRef.current = pref !== "auto";
+    if (pref === "auto") {
+      try {
+        window.localStorage.removeItem(THEME_STORAGE_KEY);
+      } catch { /* ignore quota errors */ }
+      const systemTheme = getSystemTheme();
+      setThemeState(systemTheme);
+    } else {
+      try {
+        window.localStorage.setItem(THEME_STORAGE_KEY, pref);
+      } catch { /* ignore quota errors */ }
+      setThemeState(pref);
+    }
   }, []);
 
+  const setTheme = useCallback((next: Theme) => {
+    if (next === "light" || next === "dark") {
+      setThemePreference(next);
+    } else {
+      hasExplicitChoiceRef.current = true;
+      try {
+        window.localStorage.setItem(THEME_STORAGE_KEY, next);
+      } catch { /* ignore quota errors */ }
+      setThemeState(next);
+    }
+  }, [setThemePreference]);
+
   const toggleTheme = useCallback(() => {
-    setTheme(theme === "light" ? "dark" : "light");
-  }, [theme, setTheme]);
+    const nextPref = theme === "light" ? "dark" : "light";
+    setThemePreference(nextPref);
+  }, [theme, setThemePreference]);
 
   const setEasyReadFont = useCallback((next: boolean) => {
     if (typeof document !== "undefined") {
@@ -437,11 +486,16 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
         if (event.newValue === null) {
           // Another tab cleared the choice → resume following the OS.
           hasExplicitChoiceRef.current = false;
+          setThemePreferenceState("auto");
           setThemeState(getSystemTheme());
           return;
         }
 
-        if (isTheme(event.newValue)) {
+        if (isThemePreference(event.newValue)) {
+          hasExplicitChoiceRef.current = event.newValue !== "auto";
+          setThemePreferenceState(event.newValue);
+          setThemeState(resolveThemeFromPreference(event.newValue));
+        } else if (isTheme(event.newValue)) {
           hasExplicitChoiceRef.current = true;
           setThemeState(event.newValue);
         }
@@ -627,6 +681,8 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
       easyReadFont,
       setEasyReadFont,
       toggleEasyReadFont,
+      themePreference,
+      setThemePreference,
       customTheme,
       customThemeState,
       registrationErrors,
@@ -642,6 +698,8 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
       easyReadFont,
       setEasyReadFont,
       toggleEasyReadFont,
+      themePreference,
+      setThemePreference,
       customTheme,
       customThemeState,
       registrationErrors,
@@ -684,5 +742,17 @@ export function useOptionalTheme(): ThemeContextValue {
     theme: "light",
     setTheme: () => undefined,
     toggleTheme: () => undefined,
+    easyReadFont: false,
+    setEasyReadFont: () => undefined,
+    toggleEasyReadFont: () => undefined,
+    themePreference: "light",
+    setThemePreference: () => undefined,
+    customTheme: null,
+    customThemeState: "default",
+    registrationErrors: [],
+    registerTheme: () => false,
+    applyCustomTheme: () => undefined,
+    clearCustomTheme: () => undefined,
+    previewCustomTheme: () => false,
   };
 }

--- a/src/theme/__tests__/ThemeProvider.test.tsx
+++ b/src/theme/__tests__/ThemeProvider.test.tsx
@@ -105,6 +105,8 @@ function ThemeProbe() {
     easyReadFont,
     setEasyReadFont,
     toggleEasyReadFont,
+    themePreference,
+    setThemePreference,
     customTheme,
     customThemeState,
     registrationErrors,
@@ -117,12 +119,16 @@ function ThemeProbe() {
   return (
     <div>
       <span data-testid="theme">{theme}</span>
+      <span data-testid="theme-pref">{themePreference}</span>
       <span data-testid="custom-state">{customThemeState}</span>
       <span data-testid="custom-id">{customTheme?.id ?? "none"}</span>
       <span data-testid="error-count">{registrationErrors.length}</span>
       <button onClick={toggleTheme}>toggle</button>
       <button onClick={() => setTheme("dark")}>set-dark</button>
       <button onClick={() => setTheme("light")}>set-light</button>
+      <button onClick={() => setThemePreference("auto")}>set-pref-auto</button>
+      <button onClick={() => setThemePreference("light")}>set-pref-light</button>
+      <button onClick={() => setThemePreference("dark")}>set-pref-dark</button>
       <span data-testid="easy-read">{String(easyReadFont)}</span>
       <button onClick={toggleEasyReadFont}>toggle-font</button>
       <button onClick={() => setEasyReadFont(true)}>set-font-true</button>
@@ -664,5 +670,81 @@ describe("ThemeProvider font behaviour", () => {
     });
     expect(document.documentElement.getAttribute("data-font-transitioning")).toBeNull();
     vi.useRealTimers();
+  });
+});
+
+describe("ThemeProvider — themePreference and setThemePreference", () => {
+  it("initializes themePreference as auto when no value is stored", () => {
+    render(<ThemeProbe />, { wrapper: Wrapper });
+    expect(screen.getByTestId("theme-pref")).toHaveTextContent("auto");
+  });
+
+  it("initializes themePreference as light/dark when stored", () => {
+    localStorage.setItem(THEME_STORAGE_KEY, "dark");
+    render(<ThemeProbe />, { wrapper: Wrapper });
+    expect(screen.getByTestId("theme-pref")).toHaveTextContent("dark");
+  });
+
+  it("setThemePreference('auto') clears localStorage and resumes OS following", async () => {
+    const user = userEvent.setup();
+    localStorage.setItem(THEME_STORAGE_KEY, "dark");
+    const mq = mockMatchMedia(true); // OS prefers dark
+
+    render(<ThemeProbe />, { wrapper: Wrapper });
+    expect(screen.getByTestId("theme-pref")).toHaveTextContent("dark");
+    expect(screen.getByTestId("theme")).toHaveTextContent("dark");
+
+    mq.matches = false; // OS is now light
+
+    await user.click(screen.getByText("set-pref-auto"));
+    expect(screen.getByTestId("theme-pref")).toHaveTextContent("auto");
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBeNull();
+
+    expect(screen.getByTestId("theme")).toHaveTextContent("light");
+
+    act(() => {
+      mq.dispatchChange(true);
+    });
+    expect(screen.getByTestId("theme")).toHaveTextContent("dark");
+  });
+
+  it("setThemePreference('light') writes localStorage and stops OS following", async () => {
+    const user = userEvent.setup();
+    const mq = mockMatchMedia(true); // OS prefers dark
+
+    render(<ThemeProbe />, { wrapper: Wrapper });
+    expect(screen.getByTestId("theme-pref")).toHaveTextContent("auto");
+    expect(screen.getByTestId("theme")).toHaveTextContent("dark");
+
+    await user.click(screen.getByText("set-pref-light"));
+    expect(screen.getByTestId("theme-pref")).toHaveTextContent("light");
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe("light");
+    expect(screen.getByTestId("theme")).toHaveTextContent("light");
+
+    act(() => {
+      mq.dispatchChange(true);
+    });
+    expect(screen.getByTestId("theme")).toHaveTextContent("light");
+  });
+
+  it("Cross-tab: storage event with newValue === null sets preference to 'auto' and applies OS theme", () => {
+    localStorage.setItem(THEME_STORAGE_KEY, "dark");
+    mockMatchMedia(false); // OS prefers light
+
+    render(<ThemeProbe />, { wrapper: Wrapper });
+    expect(screen.getByTestId("theme-pref")).toHaveTextContent("dark");
+    expect(screen.getByTestId("theme")).toHaveTextContent("dark");
+
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: THEME_STORAGE_KEY,
+          newValue: null,
+        })
+      );
+    });
+
+    expect(screen.getByTestId("theme-pref")).toHaveTextContent("auto");
+    expect(screen.getByTestId("theme")).toHaveTextContent("light");
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
         "src/components/ZeroAccrualBanner.tsx",
         "src/components/useModalAccessibility.ts",
         "src/components/navigation/NavLink.tsx",
+        "src/components/navigation/ThemeSegmentedControl.tsx",
         "src/components/RecentStreams.tsx",
         "src/components/StreamsLoading.tsx",
         "src/components/ToastNotification.tsx",


### PR DESCRIPTION
Closes #825

---

## Summary

Adds a three-state theme control (Light / Dark / Auto) replacing the binary toggle in `AppNavbar.tsx`. "Auto" follows `prefers-color-scheme` and clears `localStorage`, letting users explicitly opt back into OS-synced theming after making a manual choice. Separates `ThemePreference` (stored intent) from `Theme` (resolved DOM value) so existing `setTheme` and `toggleTheme` callers keep working unchanged.

## Changes

- **`ThemeProvider.tsx`** (modified): added `ThemePreference = "light" | "dark" | "auto"` type, `isThemePreference` type guard, `themePreference` and `setThemePreference` on context, `resolveThemeFromPreference` helper; refactored OS listener and cross-tab sync to resume OS following when preference is `"auto"`; compatibility shims keep `setTheme`/`toggleTheme` working
- **`ThemeSegmentedControl.tsx`** (new): ARIA `radiogroup`/`radio` pattern with Sun/Moon/Monitor icons, arrow-key navigation with wrapping, `sr-only` labels on mobile, dynamic `aria-label` announcing resolved theme when Auto is active
- **`AppNavbar.tsx`** (modified): replaced both desktop and mobile theme toggle buttons with `<ThemeSegmentedControl />`
- **`ThemeProvider.test.tsx`** (modified): added tests for preference storage clearing, OS following resumption, and cross-tab sync
- **`ThemeSegmentedControl.test.tsx`** (new): tests for arrow navigation, wrapping, click selection, and dynamic Auto aria-label
- **`AppNavbar.accessibility.test.tsx`** (modified): updated to expect `ThemeSegmentedControl` radiogroup; added `VoiceMicButton` mock
- **`vitest.config.ts`** (modified): added `ThemeSegmentedControl.tsx` to coverage `include` array
- **`docs/THEME_AUTO_OPTION_SPEC.md`** (new): states, storage rules, keyboard behavior, contrast ratios, icon names

## Test plan

- [x] `npm run build` passes (type-check + production build)
- [x] `npm run test` passes — 52 ThemeProvider tests, all ThemeSegmentedControl and AppNavbar navigation tests green
- [x] `npm run test:coverage` passes — `ThemeSegmentedControl.tsx` added to `vitest.config.ts` include array
- [x] New code covered by tests; `ThemeSegmentedControl.tsx` appended to the coverage include list