### PR TITLE
Test/voice command panel 967

### DIFF
--- a/src/components/voice/__tests__/VoiceCommandPanel.test.tsx
+++ b/src/components/voice/__tests__/VoiceCommandPanel.test.tsx
@@ -1,0 +1,528 @@
+/**
+ * Tests for src/components/voice/VoiceCommandPanel.tsx
+ *
+ * Covers:
+ *  • All eight VoiceState branches of getStatusBadge (7 explicit + default/idle)
+ *  • panelOpen=false renders nothing
+ *  • Category filtering — Navigation / Action / Destructive command buckets
+ *  • isSupported=false renders the unsupported-browser alert
+ *  • state="permission-denied" renders the mic-denied alert
+ *  • state="confirming-destructive" renders the confirmation banner
+ *  • Live transcript display when transcript / recognizedCommand are set
+ *  • Manual simulator form (input + submit)
+ *  • togglePanel and toggleListening wiring
+ *  • Close button calls togglePanel
+ *
+ * Issue: #967
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import { VoiceCommandPanel } from "../VoiceCommandPanel";
+import * as VoiceContextModule from "../VoiceContext";
+import type { VoiceContextValue, VoiceState, VoiceCommandDef } from "../voiceTypes";
+
+// ─── Mock helpers ──────────────────────────────────────────────────────────────
+
+/**
+ * Build the minimum VoiceContextValue mock, overridable per-test.
+ */
+function buildCtx(overrides: Partial<VoiceContextValue> = {}): VoiceContextValue {
+  return {
+    state: "idle",
+    isSupported: true,
+    transcript: "",
+    recognizedCommand: null,
+    pendingDestructiveCommand: null,
+    availableCommands: [],
+    panelOpen: true,
+    toggleListening: vi.fn(),
+    startListening: vi.fn(),
+    stopListening: vi.fn(),
+    togglePanel: vi.fn(),
+    confirmDestructiveAction: vi.fn(),
+    cancelDestructiveAction: vi.fn(),
+    processSpokenPhrase: vi.fn(() => true),
+    ...overrides,
+  };
+}
+
+/**
+ * Spy on useVoiceContext and return the given context value.
+ */
+function mockUseVoiceContext(ctx: VoiceContextValue) {
+  vi.spyOn(VoiceContextModule, "useVoiceContext").mockReturnValue(ctx);
+}
+
+// ─── Sample commands ───────────────────────────────────────────────────────────
+
+const NAV_CMD: VoiceCommandDef = {
+  id: "nav-dashboard",
+  phrase: "Go to dashboard",
+  aliases: ["dashboard"],
+  category: "Navigation",
+  description: "Navigate to dashboard",
+};
+
+const ACTION_CMD: VoiceCommandDef = {
+  id: "action-withdraw",
+  phrase: "Withdraw",
+  aliases: ["claim funds"],
+  category: "Action",
+  description: "Initiate withdrawal",
+};
+
+const DESTRUCTIVE_CMD: VoiceCommandDef = {
+  id: "destructive-cancel",
+  phrase: "Cancel stream",
+  aliases: ["delete stream"],
+  category: "Destructive",
+  description: "Cancel active stream",
+  requiresConfirmation: true,
+};
+
+const ALL_CATEGORY_COMMANDS: VoiceCommandDef[] = [NAV_CMD, ACTION_CMD, DESTRUCTIVE_CMD];
+
+// ─── Restore mocks after every test ───────────────────────────────────────────
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ─── panelOpen gate ────────────────────────────────────────────────────────────
+
+describe("VoiceCommandPanel — panelOpen gate", () => {
+  it("renders nothing when panelOpen is false", () => {
+    mockUseVoiceContext(buildCtx({ panelOpen: false }));
+    const { container } = render(<VoiceCommandPanel />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders the panel aside when panelOpen is true", () => {
+    mockUseVoiceContext(buildCtx({ panelOpen: true }));
+    render(<VoiceCommandPanel />);
+    expect(screen.getByRole("complementary")).toBeInTheDocument();
+  });
+});
+
+// ─── getStatusBadge — all VoiceState branches ─────────────────────────────────
+
+describe("VoiceCommandPanel — getStatusBadge", () => {
+  const cases: Array<{ state: VoiceState; expectedLabel: string }> = [
+    { state: "idle", expectedLabel: "Idle (Off)" },
+    { state: "listening", expectedLabel: "Listening..." },
+    { state: "processing", expectedLabel: "Processing..." },
+    { state: "command-recognized", expectedLabel: "Recognized" },
+    { state: "command-unrecognized", expectedLabel: "Not Recognized" },
+    { state: "confirming-destructive", expectedLabel: "Confirmation Required" },
+    { state: "permission-denied", expectedLabel: "Mic Denied" },
+    { state: "unsupported-browser", expectedLabel: "Unsupported" },
+  ];
+
+  cases.forEach(({ state, expectedLabel }) => {
+    it(`state="${state}" renders badge label "${expectedLabel}"`, () => {
+      mockUseVoiceContext(buildCtx({ state }));
+      render(<VoiceCommandPanel />);
+      // The badge label appears in the status span inside the header
+      expect(screen.getByText(expectedLabel)).toBeInTheDocument();
+    });
+  });
+
+  it('default branch (idle) renders "Idle (Off)" badge label', () => {
+    // Explicitly pass idle to exercise the default case
+    mockUseVoiceContext(buildCtx({ state: "idle" }));
+    render(<VoiceCommandPanel />);
+    expect(screen.getByText("Idle (Off)")).toBeInTheDocument();
+  });
+});
+
+// ─── Category filtering ────────────────────────────────────────────────────────
+
+describe("VoiceCommandPanel — category filtering", () => {
+  it("renders a 'Navigation Commands' section heading", () => {
+    mockUseVoiceContext(buildCtx({ availableCommands: ALL_CATEGORY_COMMANDS }));
+    render(<VoiceCommandPanel />);
+    expect(screen.getByText("Navigation Commands")).toBeInTheDocument();
+  });
+
+  it("renders an 'Action Commands' section heading", () => {
+    mockUseVoiceContext(buildCtx({ availableCommands: ALL_CATEGORY_COMMANDS }));
+    render(<VoiceCommandPanel />);
+    expect(screen.getByText("Action Commands")).toBeInTheDocument();
+  });
+
+  it("renders a 'Destructive Commands' section heading", () => {
+    mockUseVoiceContext(buildCtx({ availableCommands: ALL_CATEGORY_COMMANDS }));
+    render(<VoiceCommandPanel />);
+    expect(screen.getByText("Destructive Commands")).toBeInTheDocument();
+  });
+
+  it("places Navigation command phrase only under Navigation Commands", () => {
+    mockUseVoiceContext(buildCtx({ availableCommands: ALL_CATEGORY_COMMANDS }));
+    render(<VoiceCommandPanel />);
+
+    // The phrase should appear; we verify it is NOT inside the Action section
+    const navSection = screen.getByText("Navigation Commands").closest("div")!;
+    const navSectionContainer = navSection.parentElement!;
+    expect(within(navSectionContainer).getByText(/"Go to dashboard"/)).toBeInTheDocument();
+    // Action command phrase should not be in the nav section container
+    expect(within(navSectionContainer).queryByText(/"Withdraw"/)).toBeNull();
+  });
+
+  it("places Action command phrase only under Action Commands", () => {
+    mockUseVoiceContext(buildCtx({ availableCommands: ALL_CATEGORY_COMMANDS }));
+    render(<VoiceCommandPanel />);
+
+    const actionSection = screen.getByText("Action Commands").closest("div")!;
+    const actionSectionContainer = actionSection.parentElement!;
+    expect(within(actionSectionContainer).getByText(/"Withdraw"/)).toBeInTheDocument();
+    expect(within(actionSectionContainer).queryByText(/"Go to dashboard"/)).toBeNull();
+  });
+
+  it("places Destructive command phrase only under Destructive Commands", () => {
+    mockUseVoiceContext(buildCtx({ availableCommands: ALL_CATEGORY_COMMANDS }));
+    render(<VoiceCommandPanel />);
+
+    const destructiveSection = screen.getByText("Destructive Commands").closest("div")!;
+    const destructiveSectionContainer = destructiveSection.parentElement!;
+    expect(within(destructiveSectionContainer).getByText(/"Cancel stream"/)).toBeInTheDocument();
+    expect(within(destructiveSectionContainer).queryByText(/"Withdraw"/)).toBeNull();
+  });
+
+  it("renders 'Requires Confirm' badge only on commands with requiresConfirmation=true", () => {
+    mockUseVoiceContext(buildCtx({ availableCommands: ALL_CATEGORY_COMMANDS }));
+    render(<VoiceCommandPanel />);
+    const confirmBadges = screen.getAllByText("Requires Confirm");
+    expect(confirmBadges).toHaveLength(1);
+  });
+
+  it("renders command descriptions", () => {
+    mockUseVoiceContext(buildCtx({ availableCommands: ALL_CATEGORY_COMMANDS }));
+    render(<VoiceCommandPanel />);
+    expect(screen.getByText("Navigate to dashboard")).toBeInTheDocument();
+    expect(screen.getByText("Initiate withdrawal")).toBeInTheDocument();
+    expect(screen.getByText("Cancel active stream")).toBeInTheDocument();
+  });
+
+  it("renders command aliases as text", () => {
+    mockUseVoiceContext(buildCtx({ availableCommands: [NAV_CMD] }));
+    render(<VoiceCommandPanel />);
+    expect(screen.getByText(/Aliases:/)).toBeInTheDocument();
+    expect(screen.getByText(/"dashboard"/)).toBeInTheDocument();
+  });
+
+  it("renders empty category sections when no commands are provided", () => {
+    mockUseVoiceContext(buildCtx({ availableCommands: [] }));
+    render(<VoiceCommandPanel />);
+    // All three section headings still render (category loop always runs)
+    expect(screen.getByText("Navigation Commands")).toBeInTheDocument();
+    expect(screen.getByText("Action Commands")).toBeInTheDocument();
+    expect(screen.getByText("Destructive Commands")).toBeInTheDocument();
+    // No command phrases rendered
+    expect(screen.queryByText(/"Go to dashboard"/)).toBeNull();
+  });
+
+  it("filters correctly when only one category has commands", () => {
+    mockUseVoiceContext(buildCtx({ availableCommands: [NAV_CMD] }));
+    render(<VoiceCommandPanel />);
+    expect(screen.getByText(/"Go to dashboard"/)).toBeInTheDocument();
+    expect(screen.queryByText(/"Withdraw"/)).toBeNull();
+    expect(screen.queryByText(/"Cancel stream"/)).toBeNull();
+  });
+
+  it("clicking a command row calls processSpokenPhrase with the phrase", () => {
+    const processSpokenPhrase = vi.fn(() => true);
+    mockUseVoiceContext(
+      buildCtx({ availableCommands: [NAV_CMD], processSpokenPhrase })
+    );
+    render(<VoiceCommandPanel />);
+    // The command row has a title attribute
+    const row = screen.getByTitle('Click to test phrase "Go to dashboard"');
+    fireEvent.click(row);
+    expect(processSpokenPhrase).toHaveBeenCalledWith("Go to dashboard");
+  });
+});
+
+// ─── isSupported=false alert ───────────────────────────────────────────────────
+
+describe("VoiceCommandPanel — isSupported=false alert", () => {
+  it("renders the SpeechRecognition Unsupported alert when isSupported is false", () => {
+    mockUseVoiceContext(buildCtx({ isSupported: false }));
+    render(<VoiceCommandPanel />);
+    expect(screen.getByText("SpeechRecognition Unsupported")).toBeInTheDocument();
+  });
+
+  it("does not render the unsupported alert when isSupported is true", () => {
+    mockUseVoiceContext(buildCtx({ isSupported: true }));
+    render(<VoiceCommandPanel />);
+    expect(screen.queryByText("SpeechRecognition Unsupported")).toBeNull();
+  });
+});
+
+// ─── permission-denied alert ──────────────────────────────────────────────────
+
+describe("VoiceCommandPanel — state=permission-denied alert", () => {
+  it("renders the Microphone Permission Blocked alert", () => {
+    mockUseVoiceContext(buildCtx({ state: "permission-denied" }));
+    render(<VoiceCommandPanel />);
+    expect(screen.getByText("Microphone Permission Blocked")).toBeInTheDocument();
+  });
+
+  it("does not render the mic-denied alert for other states", () => {
+    mockUseVoiceContext(buildCtx({ state: "idle" }));
+    render(<VoiceCommandPanel />);
+    expect(screen.queryByText("Microphone Permission Blocked")).toBeNull();
+  });
+});
+
+// ─── confirming-destructive banner ────────────────────────────────────────────
+
+describe("VoiceCommandPanel — state=confirming-destructive banner", () => {
+  it("renders the confirmation banner when state is confirming-destructive and pendingDestructiveCommand is set", () => {
+    mockUseVoiceContext(
+      buildCtx({
+        state: "confirming-destructive",
+        pendingDestructiveCommand: DESTRUCTIVE_CMD,
+      })
+    );
+    render(<VoiceCommandPanel />);
+    // "Confirmation Required" appears in both the status badge AND the banner heading —
+    // use getAllByText and assert at least two occurrences to verify the banner rendered.
+    const instances = screen.getAllByText("Confirmation Required");
+    expect(instances.length).toBeGreaterThanOrEqual(2);
+    // The Confirm button only appears in the banner, not the badge
+    expect(screen.getByText('Say / Click "Confirm"')).toBeInTheDocument();
+    expect(screen.getByText(/"Cancel stream"/)).toBeInTheDocument();
+  });
+
+  it("calls confirmDestructiveAction when confirm button is clicked", () => {
+    const confirmDestructiveAction = vi.fn();
+    mockUseVoiceContext(
+      buildCtx({
+        state: "confirming-destructive",
+        pendingDestructiveCommand: DESTRUCTIVE_CMD,
+        confirmDestructiveAction,
+      })
+    );
+    render(<VoiceCommandPanel />);
+    fireEvent.click(screen.getByText('Say / Click "Confirm"'));
+    expect(confirmDestructiveAction).toHaveBeenCalledOnce();
+  });
+
+  it("calls cancelDestructiveAction when cancel button is clicked", () => {
+    const cancelDestructiveAction = vi.fn();
+    mockUseVoiceContext(
+      buildCtx({
+        state: "confirming-destructive",
+        pendingDestructiveCommand: DESTRUCTIVE_CMD,
+        cancelDestructiveAction,
+      })
+    );
+    render(<VoiceCommandPanel />);
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(cancelDestructiveAction).toHaveBeenCalledOnce();
+  });
+
+  it("does not render the confirmation banner when pendingDestructiveCommand is null", () => {
+    mockUseVoiceContext(
+      buildCtx({
+        state: "confirming-destructive",
+        pendingDestructiveCommand: null,
+      })
+    );
+    render(<VoiceCommandPanel />);
+    // "Confirmation Required" appears in the badge but NOT the big banner button
+    expect(screen.queryByText('Say / Click "Confirm"')).toBeNull();
+  });
+});
+
+// ─── Live transcript display ───────────────────────────────────────────────────
+
+describe("VoiceCommandPanel — live transcript display", () => {
+  it("renders transcript text when transcript is non-empty", () => {
+    mockUseVoiceContext(buildCtx({ transcript: "go to streams" }));
+    render(<VoiceCommandPanel />);
+    expect(screen.getByText('"go to streams"')).toBeInTheDocument();
+  });
+
+  it("renders recognizedCommand rawTranscript when transcript is empty", () => {
+    mockUseVoiceContext(
+      buildCtx({
+        transcript: "",
+        recognizedCommand: {
+          command: NAV_CMD,
+          rawTranscript: "Go to dashboard",
+          timestamp: Date.now(),
+        },
+      })
+    );
+    render(<VoiceCommandPanel />);
+    expect(screen.getByText('"Go to dashboard"')).toBeInTheDocument();
+    // Matched label appears
+    expect(screen.getByText("✓ Matched")).toBeInTheDocument();
+  });
+
+  it("does not render transcript section when both transcript and recognizedCommand are empty/null", () => {
+    mockUseVoiceContext(buildCtx({ transcript: "", recognizedCommand: null }));
+    render(<VoiceCommandPanel />);
+    expect(screen.queryByText("Live Transcript")).toBeNull();
+  });
+
+  it("highlights the recognized command row when it matches a command in availableCommands", () => {
+    mockUseVoiceContext(
+      buildCtx({
+        availableCommands: [NAV_CMD],
+        recognizedCommand: {
+          command: NAV_CMD,
+          rawTranscript: "Go to dashboard",
+          timestamp: Date.now(),
+        },
+      })
+    );
+    render(<VoiceCommandPanel />);
+    // The highlighted row has the accent class applied
+    const row = screen.getByTitle('Click to test phrase "Go to dashboard"');
+    expect(row.className).toMatch(/accent/);
+  });
+});
+
+// ─── Manual simulator form ────────────────────────────────────────────────────
+
+describe("VoiceCommandPanel — voice command simulator form", () => {
+  it("renders the simulator input and Speak button", () => {
+    mockUseVoiceContext(buildCtx());
+    render(<VoiceCommandPanel />);
+    expect(
+      screen.getByLabelText("Voice Command Simulator (Keyboard Test)")
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /speak/i })).toBeInTheDocument();
+  });
+
+  it("calls processSpokenPhrase with the typed phrase on form submit", () => {
+    const processSpokenPhrase = vi.fn(() => true);
+    mockUseVoiceContext(buildCtx({ processSpokenPhrase }));
+    render(<VoiceCommandPanel />);
+    const input = screen.getByLabelText("Voice Command Simulator (Keyboard Test)");
+    fireEvent.change(input, { target: { value: "Go to streams" } });
+    fireEvent.click(screen.getByRole("button", { name: /speak/i }));
+    expect(processSpokenPhrase).toHaveBeenCalledWith("Go to streams");
+  });
+
+  it("clears the input after submit", () => {
+    mockUseVoiceContext(buildCtx());
+    render(<VoiceCommandPanel />);
+    const input = screen.getByLabelText(
+      "Voice Command Simulator (Keyboard Test)"
+    ) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "Withdraw" } });
+    fireEvent.click(screen.getByRole("button", { name: /speak/i }));
+    expect(input.value).toBe("");
+  });
+
+  it("does not call processSpokenPhrase when input is blank", () => {
+    const processSpokenPhrase = vi.fn(() => true);
+    mockUseVoiceContext(buildCtx({ processSpokenPhrase }));
+    render(<VoiceCommandPanel />);
+    // Submit empty form
+    fireEvent.click(screen.getByRole("button", { name: /speak/i }));
+    expect(processSpokenPhrase).not.toHaveBeenCalled();
+  });
+
+  it("does not call processSpokenPhrase when input is whitespace only", () => {
+    const processSpokenPhrase = vi.fn(() => true);
+    mockUseVoiceContext(buildCtx({ processSpokenPhrase }));
+    render(<VoiceCommandPanel />);
+    const input = screen.getByLabelText("Voice Command Simulator (Keyboard Test)");
+    fireEvent.change(input, { target: { value: "   " } });
+    fireEvent.click(screen.getByRole("button", { name: /speak/i }));
+    expect(processSpokenPhrase).not.toHaveBeenCalled();
+  });
+});
+
+// ─── Header controls ──────────────────────────────────────────────────────────
+
+describe("VoiceCommandPanel — header controls", () => {
+  it("close button calls togglePanel", () => {
+    const togglePanel = vi.fn();
+    mockUseVoiceContext(buildCtx({ togglePanel }));
+    render(<VoiceCommandPanel />);
+    fireEvent.click(
+      screen.getByRole("button", { name: /close voice command reference panel/i })
+    );
+    expect(togglePanel).toHaveBeenCalledOnce();
+  });
+
+  it("has the correct aria-label on the panel aside", () => {
+    mockUseVoiceContext(buildCtx());
+    render(<VoiceCommandPanel />);
+    expect(
+      screen.getByRole("complementary", {
+        name: "Voice Command Reference & Controls",
+      })
+    ).toBeInTheDocument();
+  });
+});
+
+// ─── Footer controls ──────────────────────────────────────────────────────────
+
+describe("VoiceCommandPanel — footer controls", () => {
+  it("renders 'Start Listening' button when state is not listening", () => {
+    mockUseVoiceContext(buildCtx({ state: "idle" }));
+    render(<VoiceCommandPanel />);
+    expect(
+      screen.getByRole("button", { name: /start listening/i })
+    ).toBeInTheDocument();
+  });
+
+  it("renders 'Stop Listening' button when state is listening", () => {
+    mockUseVoiceContext(buildCtx({ state: "listening" }));
+    render(<VoiceCommandPanel />);
+    expect(
+      screen.getByRole("button", { name: /stop listening/i })
+    ).toBeInTheDocument();
+  });
+
+  it("toggleListening button is disabled when isSupported is false", () => {
+    mockUseVoiceContext(buildCtx({ isSupported: false, state: "idle" }));
+    render(<VoiceCommandPanel />);
+    expect(
+      screen.getByRole("button", { name: /start listening/i })
+    ).toBeDisabled();
+  });
+
+  it("calls toggleListening when the footer button is clicked", () => {
+    const toggleListening = vi.fn();
+    mockUseVoiceContext(buildCtx({ toggleListening, state: "idle" }));
+    render(<VoiceCommandPanel />);
+    fireEvent.click(screen.getByRole("button", { name: /start listening/i }));
+    expect(toggleListening).toHaveBeenCalledOnce();
+  });
+
+  it("renders the 'Opt-in Motor Aid' label in the footer", () => {
+    mockUseVoiceContext(buildCtx());
+    render(<VoiceCommandPanel />);
+    expect(screen.getByText("Opt-in Motor Aid")).toBeInTheDocument();
+  });
+});
+
+// ─── Static header content ────────────────────────────────────────────────────
+
+describe("VoiceCommandPanel — static header content", () => {
+  it("renders the 'Voice Navigation' heading", () => {
+    mockUseVoiceContext(buildCtx());
+    render(<VoiceCommandPanel />);
+    expect(screen.getByText("Voice Navigation")).toBeInTheDocument();
+  });
+
+  it("renders the 'Motor accessibility control' sub-heading", () => {
+    mockUseVoiceContext(buildCtx());
+    render(<VoiceCommandPanel />);
+    expect(screen.getByText("Motor accessibility control")).toBeInTheDocument();
+  });
+
+  it("renders the 'Command Grammar Reference' section title", () => {
+    mockUseVoiceContext(buildCtx());
+    render(<VoiceCommandPanel />);
+    expect(screen.getByText("Command Grammar Reference")).toBeInTheDocument();
+  });
+});

--- a/src/lib/__tests__/formatters.test.ts
+++ b/src/lib/__tests__/formatters.test.ts
@@ -21,6 +21,8 @@ import {
   formatNumber,
   formatAssetAmount,
   formatLocalDate,
+  formatTokenAmount,
+  assertSafeInteger,
 } from "../formatters";
 
 // ─── formatUsdc ──────────────────────────────────────────────────────────────
@@ -149,6 +151,170 @@ describe("formatAssetAmount", () => {
     // Default maxFractionDigits = 0: should round to nearest integer
     const numericPart = result.replace(/[^\d]/g, "");
     expect(parseInt(numericPart, 10)).toBe(1235);
+  });
+});
+
+// ─── assertSafeInteger ───────────────────────────────────────────────────────
+
+describe("assertSafeInteger", () => {
+  it("does not throw for a safe integer", () => {
+    expect(() => assertSafeInteger(0)).not.toThrow();
+    expect(() => assertSafeInteger(Number.MAX_SAFE_INTEGER)).not.toThrow();
+    expect(() => assertSafeInteger(-Number.MAX_SAFE_INTEGER)).not.toThrow();
+  });
+
+  it("does not throw for a non-integer float", () => {
+    // Floats are allowed through — only integer values are guarded
+    expect(() => assertSafeInteger(1234.56)).not.toThrow();
+  });
+
+  it("throws RangeError for a positive unsafe integer", () => {
+    const unsafe = Number.MAX_SAFE_INTEGER + 1;
+    expect(() => assertSafeInteger(unsafe)).toThrow(RangeError);
+  });
+
+  it("throws RangeError for a negative unsafe integer", () => {
+    const unsafe = -(Number.MAX_SAFE_INTEGER + 1);
+    expect(() => assertSafeInteger(unsafe)).toThrow(RangeError);
+  });
+});
+
+// ─── formatTokenAmount ───────────────────────────────────────────────────────
+
+describe("formatTokenAmount", () => {
+  // ── Basic positive amounts ────────────────────────────────────────────────
+
+  it("formats 1 XLM expressed in stroops (bigint)", () => {
+    // 1 XLM = 10_000_000 stroops, 7 decimals
+    const result = formatTokenAmount(10_000_000n, 7, "XLM");
+    expect(result).toMatch(/1[.,]0{7} XLM/);
+  });
+
+  it("formats zero stroops as 0 (bigint)", () => {
+    const result = formatTokenAmount(0n, 7, "XLM");
+    expect(result).toMatch(/^0[.,]0{7} XLM$/);
+  });
+
+  it("formats a large bigint beyond MAX_SAFE_INTEGER without precision loss", () => {
+    const large = 9_007_199_254_740_993n;
+    const result = formatTokenAmount(large, 0, "USDC");
+    // The exact digits must be present (no rounding)
+    expect(result).toContain("9");
+    expect(result).toContain("USDC");
+    // The raw numeric portion must round-trip without silent truncation
+    const digits = result.replace(/\D/g, "");
+    expect(digits).toContain("9007199254740993".replace(/\D/g, ""));
+  });
+
+  it("accepts a decimal integer string and formats correctly", () => {
+    const result = formatTokenAmount("10000000", 7, "XLM");
+    expect(result).toMatch(/1[.,]0{7} XLM/);
+  });
+
+  it("accepts a safe number and formats correctly", () => {
+    const result = formatTokenAmount(10_000_000, 7, "XLM");
+    expect(result).toMatch(/1[.,]0{7} XLM/);
+  });
+
+  it("appends a suffix when provided", () => {
+    const result = formatTokenAmount(10_000_000n, 7, "XLM", "/mo");
+    expect(result).toMatch(/XLM\/mo$/);
+  });
+
+  it("omits the asset when asset is empty string", () => {
+    const result = formatTokenAmount(10_000_000n, 7);
+    expect(result).not.toContain("XLM");
+    expect(result).not.toContain("  ");
+  });
+
+  it("formats decimals=0 as a pure integer with locale grouping", () => {
+    const result = formatTokenAmount(9_000_000n, 0, "USDC");
+    // Just check the number appears and the asset is present
+    const numericPart = parseInt(result.replace(/\D/g, ""), 10);
+    expect(numericPart).toBe(9_000_000);
+    expect(result).toContain("USDC");
+  });
+
+  // ── Negative amounts with non-zero whole part ─────────────────────────────
+
+  it("formats -1 XLM (negative large magnitude) correctly (bigint)", () => {
+    // -10_000_000 stroops = -1.0000000 XLM
+    const result = formatTokenAmount(-10_000_000n, 7, "XLM");
+    expect(result).toMatch(/^-/);
+    expect(result).toContain("XLM");
+  });
+
+  it("formats -1 XLM correctly (string input)", () => {
+    const result = formatTokenAmount("-10000000", 7, "XLM");
+    expect(result).toMatch(/^-/);
+  });
+
+  it("formats -1 XLM correctly (number input)", () => {
+    const result = formatTokenAmount(-10_000_000, 7, "XLM");
+    expect(result).toMatch(/^-/);
+  });
+
+  // ── #954 regression: negative zero-whole-part ────────────────────────────
+  // raw = -500_000, decimals = 7 → wholePart = 0n, represents -0.05 XLM.
+  // Before the fix this rendered as "0.0500000 XLM" (sign silently dropped).
+
+  it("#954 bigint: -500_000n with 7 decimals starts with '-' (not '0')", () => {
+    const result = formatTokenAmount(-500_000n, 7, "XLM");
+    expect(result).toMatch(/^-/);
+    expect(result).toContain("XLM");
+    // Must NOT start with bare "0" (which would mean sign was lost)
+    expect(result).not.toMatch(/^0/);
+  });
+
+  it("#954 string: '-500000' with 7 decimals starts with '-'", () => {
+    const result = formatTokenAmount("-500000", 7, "XLM");
+    expect(result).toMatch(/^-/);
+    expect(result).not.toMatch(/^0/);
+  });
+
+  it("#954 number: -500_000 with 7 decimals starts with '-'", () => {
+    const result = formatTokenAmount(-500_000, 7, "XLM");
+    expect(result).toMatch(/^-/);
+    expect(result).not.toMatch(/^0/);
+  });
+
+  it("#954 fractional digits are preserved for zero-whole-part negative", () => {
+    // -500_000 / 10^7 = -0.0500000 — verify the fractional digits are correct
+    const result = formatTokenAmount(-500_000n, 7, "XLM");
+    // After the leading '-0<sep>' the fractional part should be '0500000'
+    expect(result).toMatch(/^-0[.,]0500000 XLM$/);
+  });
+
+  it("#954 smallest negative amount (-1 stroop) renders with leading '-'", () => {
+    const result = formatTokenAmount(-1n, 7, "XLM");
+    expect(result).toMatch(/^-/);
+    expect(result).not.toMatch(/^0/);
+  });
+
+  it("#954 positive zero is unaffected (no spurious '-')", () => {
+    const result = formatTokenAmount(0n, 7, "XLM");
+    expect(result).not.toMatch(/^-/);
+  });
+
+  it("#954 positive small amount is unaffected", () => {
+    const result = formatTokenAmount(500_000n, 7, "XLM");
+    expect(result).not.toMatch(/^-/);
+    expect(result).toMatch(/^0/);
+  });
+
+  // ── Input validation ──────────────────────────────────────────────────────
+
+  it("throws TypeError for a non-integer string", () => {
+    expect(() => formatTokenAmount("1234.56", 7, "XLM")).toThrow(TypeError);
+  });
+
+  it("throws TypeError for an empty string", () => {
+    expect(() => formatTokenAmount("", 7, "XLM")).toThrow(TypeError);
+  });
+
+  it("throws RangeError for an unsafe integer number", () => {
+    const unsafe = Number.MAX_SAFE_INTEGER + 1;
+    expect(() => formatTokenAmount(unsafe, 0, "USDC")).toThrow(RangeError);
   });
 });
 

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -295,7 +295,14 @@ export function formatTokenAmount(
     // Determine the locale decimal separator
     const decimalSep = getDecimalSeparator();
 
-    displayStr = `${wholeFormatted}${decimalSep}${fracStr}`;
+    // When raw is negative but its magnitude is smaller than the divisor,
+    // BigInt truncating division yields wholePart = 0n, so Intl.NumberFormat
+    // renders "0" with no minus sign — silently losing the negative sign.
+    // Fix: detect the sign from the original raw value and prepend "-" when
+    // the whole part is zero but the original amount is negative.
+    const negativePrefix = raw < 0n && wholePart === 0n ? "-" : "";
+
+    displayStr = `${negativePrefix}${wholeFormatted}${decimalSep}${fracStr}`;
   }
 
   return `${displayStr}${asset ? ` ${asset}` : ""}${suffix}`;


### PR DESCRIPTION
## Summary

<!-- What does this PR change and why? -->

## Changes

closes #967 
<!-- List the key changes made. -->

## Test plan

- [ ] `npm run build` passes (type-check + production build)
- [ ] `npm run test` passes (all unit tests green)
- [ ] `npm run test:coverage` passes (statements/branches/functions/lines ≥ 95%)
- [ ] New code is covered by tests; the coverage include list in `vitest.config.ts` is expanded if new production modules are added

## Coverage gate

CI enforces **95% coverage thresholds** (statements, branches, functions, lines) via
the `coverage` job in `.github/workflows/ci.yml`. The job runs `npm run test:coverage`
and fails the PR check when any threshold is missed. The coverage report is uploaded
as a build artifact for every run.

To add a new production file to the coverage baseline, append it to the `include`
array in `vitest.config.ts` and ensure tests cover it before opening the PR.
