### PR TITLE
fix(csv-upload): replace native window.confirm with themed ConfirmMod…

### DIFF
--- a/src/components/common/ConfirmModal.tsx
+++ b/src/components/common/ConfirmModal.tsx
@@ -1,0 +1,110 @@
+import React, { useEffect, useRef } from "react";
+import { ShieldAlert, X } from "lucide-react";
+
+export interface ConfirmModalProps {
+  isOpen: boolean;
+  title: string;
+  description: string;
+  confirmText?: string;
+  cancelText?: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export const ConfirmModal: React.FC<ConfirmModalProps> = ({
+  isOpen,
+  title,
+  description,
+  confirmText = "Confirm",
+  cancelText = "Cancel",
+  onConfirm,
+  onCancel,
+}) => {
+  const confirmBtnRef = useRef<HTMLButtonElement>(null);
+
+  // Auto focus confirm button when opened
+  useEffect(() => {
+    if (isOpen) {
+      setTimeout(() => {
+        confirmBtnRef.current?.focus();
+      }, 50);
+    }
+  }, [isOpen]);
+
+  // Escape key handler
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onCancel();
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, onCancel]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="confirm-modal-heading"
+      aria-describedby="confirm-modal-desc"
+      className="fixed inset-0 z-[100] flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm animate-fade-in"
+    >
+      <div className="w-full max-w-md bg-[var(--surface-base)] border border-[var(--border-neutral)] rounded-2xl shadow-2xl p-6 space-y-5 text-left relative animate-scale-up">
+        {/* Header Icon */}
+        <div className="flex items-start justify-between">
+          <div className="w-12 h-12 rounded-xl bg-[var(--surface-sunken)] text-[var(--text-vivid)] border border-[var(--border-neutral)] flex items-center justify-center">
+            <ShieldAlert size={26} aria-hidden="true" />
+          </div>
+
+          <button
+            type="button"
+            onClick={onCancel}
+            className="p-2 text-[var(--text-muted)] hover:text-[var(--text-vivid)] transition-colors rounded-lg outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+            aria-label="Cancel"
+          >
+            <X size={20} />
+          </button>
+        </div>
+
+        {/* Text Content */}
+        <div className="space-y-2">
+          <h2
+            id="confirm-modal-heading"
+            className="text-lg font-bold text-[var(--text-vivid)] flex items-center gap-2"
+          >
+            {title}
+          </h2>
+          <p
+            id="confirm-modal-desc"
+            className="text-sm text-[var(--text-secondary)] leading-relaxed"
+          >
+            {description}
+          </p>
+        </div>
+
+        {/* Actions */}
+        <div className="flex items-center gap-3 pt-2">
+          <button
+            ref={confirmBtnRef}
+            type="button"
+            onClick={onConfirm}
+            className="flex-1 py-3 px-4 rounded-xl bg-[var(--accent)] hover:bg-[var(--accent-hover)] text-white font-bold text-sm shadow-lg transition-all outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[var(--accent)]"
+          >
+            {confirmText}
+          </button>
+          <button
+            type="button"
+            onClick={onCancel}
+            className="py-3 px-4 rounded-xl bg-[var(--surface-sunken)] border border-[var(--border-neutral)] text-[var(--text-vivid)] hover:bg-[var(--surface-elevated)] font-semibold text-sm transition-colors outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+          >
+            {cancelText}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/csv-upload/PreviewValidateStep.tsx
+++ b/src/components/csv-upload/PreviewValidateStep.tsx
@@ -3,6 +3,7 @@ import './PreviewValidateStep.css';
 import type { CanonicalHeader, CsvRow } from './types';
 import { validateRow, markDuplicates } from './csvParser';
 import { ValidationMessage } from '../ValidationMessage';
+import { ConfirmModal } from '../common/ConfirmModal';
 
 export interface PreviewValidateStepProps {
   rows: CsvRow[];
@@ -291,6 +292,7 @@ const PreviewValidateStep: React.FC<PreviewValidateStepProps> = ({
 }) => {
   const [editingRowId, setEditingRowId] = useState<string | null>(null);
   const [liveMessage, setLiveMessage] = useState('');
+  const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false);
   const fixButtonRefs = useRef<Record<string, HTMLButtonElement | null>>({});
 
   const validCount = rows.filter((r) => r.status === 'valid' || r.status === 'duplicate-recipient').length;
@@ -377,12 +379,18 @@ const PreviewValidateStep: React.FC<PreviewValidateStepProps> = ({
     setLiveMessage(`${errorCount} invalid rows skipped.`);
   }, [rows, onRowsChange, errorCount]);
 
-  const handleReplaceConfirm = useCallback(() => {
-    const confirmed = window.confirm(
-      'Replacing the file will clear your current preview. Continue?',
-    );
-    if (confirmed) onReplaceFile();
+  const handleReplaceClick = useCallback(() => {
+    setIsConfirmModalOpen(true);
+  }, []);
+
+  const handleConfirmReplace = useCallback(() => {
+    setIsConfirmModalOpen(false);
+    onReplaceFile();
   }, [onReplaceFile]);
+
+  const handleCancelReplace = useCallback(() => {
+    setIsConfirmModalOpen(false);
+  }, []);
 
   return (
     <div className="csv-preview-step">
@@ -410,7 +418,7 @@ const PreviewValidateStep: React.FC<PreviewValidateStepProps> = ({
         <button
           type="button"
           className="csv-replace-link"
-          onClick={handleReplaceConfirm}
+          onClick={handleReplaceClick}
           aria-label="Replace CSV file"
         >
           Replace CSV
@@ -605,6 +613,16 @@ const PreviewValidateStep: React.FC<PreviewValidateStepProps> = ({
           </svg>
         </button>
       </div>
+      {/* ── Confirm Modal ── */}
+      <ConfirmModal
+        isOpen={isConfirmModalOpen}
+        title="Replace CSV File?"
+        description="Replacing the file will clear your current preview. Continue?"
+        confirmText="Replace"
+        cancelText="Cancel"
+        onConfirm={handleConfirmReplace}
+        onCancel={handleCancelReplace}
+      />
     </div>
   );
 };

--- a/src/components/csv-upload/__tests__/PreviewValidateStep.test.tsx
+++ b/src/components/csv-upload/__tests__/PreviewValidateStep.test.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import PreviewValidateStep from '../PreviewValidateStep';
+import type { CsvRow } from '../types';
+
+const mockRows: CsvRow[] = [
+  {
+    id: 'row-1',
+    rowNumber: 1,
+    recipient: '0x1234567890123456789012345678901234567890',
+    depositAmount: '10',
+    accrualRatePerDay: '1',
+    durationDays: '30',
+    status: 'valid',
+    fieldErrors: {},
+  },
+];
+
+describe('PreviewValidateStep', () => {
+  it('opens confirm modal on Replace CSV click and handles cancel', () => {
+    const onReplaceFile = vi.fn();
+    render(
+      <PreviewValidateStep
+        rows={mockRows}
+        onRowsChange={vi.fn()}
+        onSubmit={vi.fn()}
+        onReplaceFile={onReplaceFile}
+      />
+    );
+
+    // Initial state: modal should not be open
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+    // Click Replace CSV
+    const replaceBtn = screen.getByRole('button', { name: 'Replace CSV file' });
+    fireEvent.click(replaceBtn);
+
+    // Modal should be open
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toBeInTheDocument();
+    expect(screen.getByText('Replace CSV File?')).toBeInTheDocument();
+
+    // Click Cancel
+    const cancelBtn = screen.getByRole('button', { name: 'Cancel' });
+    fireEvent.click(cancelBtn);
+
+    // Modal should be closed and onReplaceFile should not be called
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(onReplaceFile).not.toHaveBeenCalled();
+  });
+
+  it('opens confirm modal and calls onReplaceFile when confirmed', () => {
+    const onReplaceFile = vi.fn();
+    render(
+      <PreviewValidateStep
+        rows={mockRows}
+        onRowsChange={vi.fn()}
+        onSubmit={vi.fn()}
+        onReplaceFile={onReplaceFile}
+      />
+    );
+
+    // Click Replace CSV
+    const replaceBtn = screen.getByRole('button', { name: 'Replace CSV file' });
+    fireEvent.click(replaceBtn);
+
+    // Modal should be open
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+    // Click Confirm (Replace)
+    const confirmBtn = screen.getByRole('button', { name: 'Replace' });
+    fireEvent.click(confirmBtn);
+
+    // Modal should be closed and onReplaceFile should be called
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(onReplaceFile).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
Closes #930 

### Description
This PR replaces the native `window.confirm()` dialog used in `PreviewValidateStep.tsx` for replacing the CSV file with a custom, themeable, and accessible `ConfirmModal` component. This aligns the confirmation flow with the rest of the application's UI/UX conventions (e.g., `VoiceConfirmModal.tsx`) and ensures it properly participates in the app's focus-management.

### Changes Made
- **New Component (`ConfirmModal.tsx`)**: Introduced a reusable, keyboard-accessible confirmation dialog component (using `role="dialog"`) styled consistently with the application's design system.
- **Replaced `window.confirm`**: Updated `PreviewValidateStep.tsx` to open the new `ConfirmModal` instead of a native blocking browser dialog when clicking "Replace CSV".
- **Added Tests**: Added `PreviewValidateStep.test.tsx` to assert that clicking "Replace CSV" opens the in-app modal, and verified that both confirming and cancelling behave correctly without relying on mocking `window.confirm()`.

### Acceptance Criteria Covered
- [x] "Replace CSV" no longer triggers a native `window.confirm()`.
- [x] The replacement dialog is keyboard-accessible and theme-consistent.
- [x] A test covers both confirm and cancel paths.