### PR TITLE
fix: isolate embed announcer lifecycle

### DIFF
--- a/src/hooks/__tests__/useEmbedAccessibility.test.tsx
+++ b/src/hooks/__tests__/useEmbedAccessibility.test.tsx
@@ -1,0 +1,44 @@
+import { render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { announceToScreenReader, useEmbedAccessibility } from "../useEmbedAccessibility";
+
+function TestWidget({ title }: { title: string }) {
+  useEmbedAccessibility({ title, description: "Widget description", isMainContent: true });
+  return <div data-testid={`widget-${title}`} />;
+}
+
+describe("useEmbedAccessibility announcer", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    document.body.innerHTML = "";
+  });
+
+  it("keeps each widget instance isolated from other live-region announcers", () => {
+    const { unmount: unmountFirst } = render(<TestWidget title="First" />);
+    const { unmount: unmountSecond } = render(<TestWidget title="Second" />);
+
+    const initialAnnouncers = document.querySelectorAll('[aria-live="polite"]');
+    expect(initialAnnouncers).toHaveLength(2);
+
+    const firstMessage = "Widget loaded: First";
+    const secondMessage = "Widget loaded: Second";
+
+    const firstNode = initialAnnouncers[0] as HTMLElement;
+    const secondNode = initialAnnouncers[1] as HTMLElement;
+    expect(firstNode.textContent).toBe(firstMessage);
+    expect(secondNode.textContent).toBe(secondMessage);
+    expect(firstNode.id).not.toBe(secondNode.id);
+
+    unmountFirst();
+    unmountSecond();
+
+    expect(document.querySelectorAll('[aria-live="polite"]').length).toBe(0);
+  });
+});

--- a/src/hooks/useEmbedAccessibility.ts
+++ b/src/hooks/useEmbedAccessibility.ts
@@ -51,34 +51,8 @@ export function useEmbedAccessibility({
     const originalLang = html.getAttribute('lang') || 'en';
     html.setAttribute('lang', 'en');
     
-    // Announce widget load to screen readers
-    const announceToScreenReader = () => {
-      const announcer = document.getElementById('embed-accessibility-announcer');
-      if (announcer) {
-        announcer.textContent = `Widget loaded: ${title}`;
-      }
-    };
-    
-    // Create screen reader announcer if it doesn't exist
-    let announcer = document.getElementById('embed-accessibility-announcer');
-    if (!announcer) {
-      announcer = document.createElement('div');
-      announcer.id = 'embed-accessibility-announcer';
-      announcer.style.position = 'absolute';
-      announcer.style.width = '1px';
-      announcer.style.height = '1px';
-      announcer.style.padding = '0';
-      announcer.style.margin = '-1px';
-      announcer.style.overflow = 'hidden';
-      announcer.style.clip = 'rect(0, 0, 0, 0)';
-      announcer.style.whiteSpace = 'nowrap';
-      announcer.style.borderWidth = '0';
-      announcer.setAttribute('aria-live', 'polite');
-      announcer.setAttribute('aria-atomic', 'true');
-      document.body.appendChild(announcer);
-    }
-    
-    announceToScreenReader();
+    // Announce widget load to screen readers using a per-instance announcer
+    const cleanupAnnouncer = announceToScreenReader(`Widget loaded: ${title}`);
     
     // Set focus to widget container for keyboard users
     const widgetContainer = document.querySelector('[role="article"], main');
@@ -108,6 +82,8 @@ export function useEmbedAccessibility({
       if (widgetContainer) {
         widgetContainer.removeAttribute('tabindex');
       }
+
+      cleanupAnnouncer();
     };
   }, [title, description, isMainContent]);
 }
@@ -196,15 +172,30 @@ export function createAccessibleWidgetContainer(
   };
 }
 
+let announcerInstanceId = 0;
+
 /**
- * Announces a message to screen readers
+ * Announces a message to screen readers.
+ *
+ * Returns a cleanup function that removes the live-region node and cancels any
+ * pending clear timer so the announcer does not outlive its owner.
  */
-export function announceToScreenReader(message: string, priority: 'polite' | 'assertive' = 'polite'): void {
-  let announcer = document.getElementById('embed-accessibility-announcer');
-  
+export function announceToScreenReader(
+  message: string,
+  priority: 'polite' | 'assertive' = 'polite',
+  options: { container?: HTMLElement | null; id?: string } = {}
+): () => void {
+  const container = options.container ?? document.body;
+  if (!container) {
+    return () => undefined;
+  }
+
+  const announcerId = options.id ?? `embed-accessibility-announcer-${++announcerInstanceId}`;
+  let announcer = container.querySelector<HTMLElement>(`#${announcerId}`);
+
   if (!announcer) {
     announcer = document.createElement('div');
-    announcer.id = 'embed-accessibility-announcer';
+    announcer.id = announcerId;
     announcer.style.position = 'absolute';
     announcer.style.width = '1px';
     announcer.style.height = '1px';
@@ -216,19 +207,25 @@ export function announceToScreenReader(message: string, priority: 'polite' | 'as
     announcer.style.borderWidth = '0';
     announcer.setAttribute('aria-live', priority);
     announcer.setAttribute('aria-atomic', 'true');
-    document.body.appendChild(announcer);
+    container.appendChild(announcer);
   } else {
     announcer.setAttribute('aria-live', priority);
   }
-  
+
   announcer.textContent = message;
-  
-  // Clear message after a delay to allow re-announcement
-  setTimeout(() => {
-    if (announcer && announcer.textContent === message) {
+
+  const timeoutId = window.setTimeout(() => {
+    if (announcer?.isConnected && announcer.textContent === message) {
       announcer.textContent = '';
     }
   }, 1000);
+
+  return () => {
+    window.clearTimeout(timeoutId);
+    if (announcer?.isConnected) {
+      announcer.remove();
+    }
+  };
 }
 
 /**


### PR DESCRIPTION
# fix: isolate embed announcer lifecycle

## Summary
This change fixes the embed accessibility announcer so each widget instance owns its own live-region node and cleanup path instead of sharing a single persistent DOM node.

## What changed
- Replaced the shared fixed announcer behavior with a per-instance announcement lifecycle.
- Ensured the announcer node and pending timeout are cleaned up when the owning widget unmounts.
- Added a regression test covering multiple concurrent embed widget instances to ensure they do not clobber one another.

## Verification
- Added regression coverage in useEmbedAccessibility.test.tsx
- Verified with:
  - pnpm vitest run useEmbedAccessibility.test.tsx useLiveAnnouncer.test.tsx

Closes: #950
