### PR TITLE
test: add unit tests for StreamComparePane diffing logic and usePaneS…

### DIFF
--- a/src/components/StreamComparePane.tsx
+++ b/src/components/StreamComparePane.tsx
@@ -52,7 +52,7 @@ const healthColor: Record<string, string> = {
 };
 
 /** Fields shown in the aligned comparison grid and their display labels. */
-const COMPARE_FIELDS: Array<{
+export const COMPARE_FIELDS: Array<{
   key: keyof StreamRecord;
   label: string;
   format?: (v: StreamRecord) => string;
@@ -94,14 +94,14 @@ const COMPARE_FIELDS: Array<{
   { key: "health", label: "Health" },
 ];
 
-function fieldValue(r: StreamRecord, field: (typeof COMPARE_FIELDS)[number]): string {
+export function fieldValue(r: StreamRecord, field: (typeof COMPARE_FIELDS)[number]): string {
   if (field.format) return field.format(r);
   const raw = r[field.key];
   return raw === undefined || raw === null ? "—" : String(raw);
 }
 
 /** Returns the number of fields that differ between two records. */
-function countDiffs(a: StreamRecord, b: StreamRecord): number {
+export function countDiffs(a: StreamRecord, b: StreamRecord): number {
   return COMPARE_FIELDS.filter(
     (f) => fieldValue(a, f) !== fieldValue(b, f),
   ).length;
@@ -109,7 +109,7 @@ function countDiffs(a: StreamRecord, b: StreamRecord): number {
 
 // ── Hook: fetch a single pane ─────────────────────────────────────────────────
 
-function usePaneStream(streamId: string): PaneState {
+export function usePaneStream(streamId: string): PaneState {
   const [state, setState] = useState<PaneState>({
     streamId,
     stream: undefined,

--- a/src/components/__tests__/StreamComparePane.test.tsx
+++ b/src/components/__tests__/StreamComparePane.test.tsx
@@ -1,0 +1,365 @@
+import { act, renderHook, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import userEvent from "@testing-library/user-event";
+import type { StreamRecord } from "../../data/streamRecords";
+import { makeStreamRecord } from "../../fixtures/malformedStreamRecords";
+import StreamComparePane, {
+  COMPARE_FIELDS,
+  fieldValue,
+  countDiffs,
+  usePaneStream,
+} from "../StreamComparePane";
+
+// ─── mocks ───────────────────────────────────────────────────────────────────
+
+const getStreamById = vi.fn();
+
+vi.mock("../../lib/api/streamsService", () => ({
+  getStreamById: (...args: unknown[]) => getStreamById(...args),
+  isMockMode: () => false,
+}));
+
+// ─── fixtures ────────────────────────────────────────────────────────────────
+
+function makeRecord(overrides: Partial<StreamRecord> = {}): StreamRecord {
+  return makeStreamRecord(overrides) as StreamRecord;
+}
+
+const BASE_RECORD = makeRecord({
+  id: "STR-TEST-001",
+  name: "Test Stream",
+});
+
+const ALT_RECORD = makeRecord({
+  id: "STR-TEST-002",
+  name: "Alt Stream",
+  status: "Paused",
+  monthlyRate: 3000,
+  depositAmount: 36000,
+  streamedAmount: 12000,
+  withdrawableAmount: 5000,
+  remainingAmount: 24000,
+  progress: 33.3,
+  startDate: "2026-03-01",
+  endDate: "2026-09-01",
+  cliffDate: "2026-03-15",
+  health: "Attention",
+  asset: "USDC",
+});
+
+beforeEach(() => {
+  getStreamById.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllTimers();
+});
+
+// ─── 1. fieldValue ───────────────────────────────────────────────────────────
+
+describe("fieldValue", () => {
+  it("formats monthlyRate with asset suffix", () => {
+    const field = COMPARE_FIELDS.find((f) => f.key === "monthlyRate")!;
+    expect(fieldValue(BASE_RECORD, field)).toBe("1,000 USDC/mo");
+  });
+
+  it("formats depositAmount with asset suffix", () => {
+    const field = COMPARE_FIELDS.find((f) => f.key === "depositAmount")!;
+    expect(fieldValue(BASE_RECORD, field)).toBe("12,000 USDC");
+  });
+
+  it("formats streamedAmount with asset suffix", () => {
+    const field = COMPARE_FIELDS.find((f) => f.key === "streamedAmount")!;
+    expect(fieldValue(BASE_RECORD, field)).toBe("3,000 USDC");
+  });
+
+  it("formats withdrawableAmount with asset suffix", () => {
+    const field = COMPARE_FIELDS.find((f) => f.key === "withdrawableAmount")!;
+    expect(fieldValue(BASE_RECORD, field)).toBe("500 USDC");
+  });
+
+  it("formats remainingAmount with asset suffix", () => {
+    const field = COMPARE_FIELDS.find((f) => f.key === "remainingAmount")!;
+    expect(fieldValue(BASE_RECORD, field)).toBe("9,000 USDC");
+  });
+
+  it("formats progress as percentage with one decimal", () => {
+    const field = COMPARE_FIELDS.find((f) => f.key === "progress")!;
+    expect(fieldValue(BASE_RECORD, field)).toBe("25.0%");
+  });
+
+  it("returns raw string for status", () => {
+    const field = COMPARE_FIELDS.find((f) => f.key === "status")!;
+    expect(fieldValue(BASE_RECORD, field)).toBe("Active");
+  });
+
+  it("returns raw string for startDate", () => {
+    const field = COMPARE_FIELDS.find((f) => f.key === "startDate")!;
+    expect(fieldValue(BASE_RECORD, field)).toBe("2026-01-01");
+  });
+
+  it("returns raw string for endDate", () => {
+    const field = COMPARE_FIELDS.find((f) => f.key === "endDate")!;
+    expect(fieldValue(BASE_RECORD, field)).toBe("2026-12-31");
+  });
+
+  it("returns raw string for health", () => {
+    const field = COMPARE_FIELDS.find((f) => f.key === "health")!;
+    expect(fieldValue(BASE_RECORD, field)).toBe("Healthy");
+  });
+
+  it("returns formatted cliffDate when present", () => {
+    const field = COMPARE_FIELDS.find((f) => f.key === "cliffDate")!;
+    expect(fieldValue(BASE_RECORD, field)).toBe("2026-02-01");
+  });
+
+  it("returns em-dash for cliffDate when undefined", () => {
+    const field = COMPARE_FIELDS.find((f) => f.key === "cliffDate")!;
+    const noCliff = makeRecord({ cliffDate: undefined });
+    expect(fieldValue(noCliff, field)).toBe("—");
+  });
+});
+
+// ─── 2. countDiffs ───────────────────────────────────────────────────────────
+
+describe("countDiffs", () => {
+  it("returns 0 for identical records", () => {
+    expect(countDiffs(BASE_RECORD, makeRecord({ id: "STR-other", name: "Clone" }))).toBe(0);
+  });
+
+  it("returns 1 when a single field differs", () => {
+    const modified = makeRecord({ ...BASE_RECORD, status: "Paused" });
+    expect(countDiffs(BASE_RECORD, modified)).toBe(1);
+  });
+
+  it("returns correct count when multiple fields differ", () => {
+    const diffCount = countDiffs(BASE_RECORD, ALT_RECORD);
+    expect(diffCount).toBeGreaterThan(1);
+    expect(diffCount).toBeLessThanOrEqual(COMPARE_FIELDS.length);
+  });
+
+  it("returns COMPARE_FIELDS.length when every field differs", () => {
+    const allDiff = makeRecord({
+      status: "Completed",
+      monthlyRate: 9999,
+      depositAmount: 1,
+      streamedAmount: 0,
+      withdrawableAmount: 0,
+      remainingAmount: 1,
+      progress: 0,
+      startDate: "2025-01-01",
+      endDate: "2025-06-01",
+      cliffDate: "2025-01-15",
+      health: "Settled",
+    });
+    expect(countDiffs(BASE_RECORD, allDiff)).toBe(COMPARE_FIELDS.length);
+  });
+});
+
+// ─── 3. usePaneStream ────────────────────────────────────────────────────────
+
+describe("usePaneStream", () => {
+  it("starts in loading state (stream undefined, no error)", () => {
+    getStreamById.mockReturnValue(new Promise(() => {}));
+
+    const { result } = renderHook(() => usePaneStream("STR-TEST-001"));
+
+    expect(result.current.streamId).toBe("STR-TEST-001");
+    expect(result.current.stream).toBeUndefined();
+    expect(result.current.error).toBeNull();
+  });
+
+  it("transitions to loaded state on successful fetch", async () => {
+    getStreamById.mockResolvedValue(BASE_RECORD);
+
+    const { result } = renderHook(() => usePaneStream("STR-TEST-001"));
+
+    expect(result.current.stream).toBeUndefined();
+
+    await waitFor(() => expect(result.current.stream).toBe(BASE_RECORD));
+    expect(result.current.error).toBeNull();
+  });
+
+  it("transitions to error state on API failure", async () => {
+    getStreamById.mockRejectedValue(new Error("Network failure"));
+
+    const { result } = renderHook(() => usePaneStream("STR-TEST-001"));
+
+    await waitFor(() => expect(result.current.error).toBe("Network failure"));
+    expect(result.current.stream).toBeUndefined();
+  });
+
+  it("renders null stream when getStreamById returns null", async () => {
+    getStreamById.mockResolvedValue(null);
+
+    const { result } = renderHook(() => usePaneStream("STR-NONEXISTENT"));
+
+    await waitFor(() => expect(result.current.stream).toBeNull());
+    expect(result.current.error).toBeNull();
+  });
+
+  it("updates streamId on rerender and refetches", async () => {
+    getStreamById.mockResolvedValue(BASE_RECORD);
+
+    const { result, rerender } = renderHook(
+      (id: string) => usePaneStream(id),
+      { initialProps: "STR-TEST-001" },
+    );
+
+    await waitFor(() => expect(result.current.stream).toBe(BASE_RECORD));
+    expect(result.current.streamId).toBe("STR-TEST-001");
+
+    getStreamById.mockResolvedValue(ALT_RECORD);
+
+    rerender("STR-TEST-002");
+
+    expect(result.current.streamId).toBe("STR-TEST-002");
+    expect(result.current.stream).toBeUndefined();
+    expect(result.current.error).toBeNull();
+
+    await waitFor(() => expect(result.current.stream).toBe(ALT_RECORD));
+  });
+
+  it("ignores stale response after mid-fetch streamId swap (cancellation)", async () => {
+    let resolveFirst!: (v: StreamRecord) => void;
+    getStreamById.mockReturnValue(
+      new Promise<StreamRecord>((resolve) => {
+        resolveFirst = resolve;
+      }),
+    );
+
+    const { result, rerender } = renderHook(
+      (id: string) => usePaneStream(id),
+      { initialProps: "STR-FIRST" },
+    );
+
+    expect(result.current.stream).toBeUndefined();
+
+    getStreamById.mockResolvedValue(ALT_RECORD);
+
+    rerender("STR-SECOND");
+
+    await waitFor(() => expect(result.current.stream).toBe(ALT_RECORD));
+    expect(result.current.streamId).toBe("STR-SECOND");
+
+    // Resolve the stale promise; it should NOT update the state
+    act(() => {
+      resolveFirst!(BASE_RECORD);
+    });
+
+    // The state should still reflect the second stream
+    expect(result.current.stream).toBe(ALT_RECORD);
+    expect(result.current.streamId).toBe("STR-SECOND");
+  });
+});
+
+// ─── 4. Rendering (swap / remove handlers) ───────────────────────────────────
+
+describe("StreamComparePane rendering", () => {
+  beforeEach(() => {
+    getStreamById.mockResolvedValue(BASE_RECORD);
+  });
+
+  it("renders both panes and the toolbar with diff badge", async () => {
+    getStreamById.mockImplementation((id: string) => {
+      if (id === "STR-LEFT") return Promise.resolve(BASE_RECORD);
+      return Promise.resolve(ALT_RECORD);
+    });
+
+    render(
+      <StreamComparePane
+        leftId="STR-LEFT"
+        rightId="STR-RIGHT"
+        onExit={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Pane A")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Pane B")).toBeInTheDocument();
+    expect(screen.getByText(/Comparing 2 streams/)).toBeInTheDocument();
+    expect(screen.getByText(/difference(s)?/)).toBeInTheDocument();
+  });
+
+  it("calls onExit when Remove (✕) button is clicked on left pane", async () => {
+    const onExit = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <StreamComparePane
+        leftId="STR-LEFT"
+        rightId="STR-RIGHT"
+        onExit={onExit}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getAllByLabelText(/Remove .* from comparison/i)).toHaveLength(2);
+    });
+
+    const removeBtns = screen.getAllByLabelText(/Remove .* from comparison/i);
+    await user.click(removeBtns[0]);
+
+    expect(onExit).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onExit when Remove (✕) button is clicked on right pane", async () => {
+    const onExit = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <StreamComparePane
+        leftId="STR-LEFT"
+        rightId="STR-RIGHT"
+        onExit={onExit}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getAllByLabelText(/Remove .* from comparison/i)).toHaveLength(2);
+    });
+
+    const removeBtns = screen.getAllByLabelText(/Remove .* from comparison/i);
+    await user.click(removeBtns[1]);
+
+    expect(onExit).toHaveBeenCalledTimes(1);
+  });
+
+  it("swaps pane IDs when the Swap button is clicked", async () => {
+    const leftRecord = makeRecord({ id: "STR-LEFT", name: "Left Stream" });
+    const rightRecord = makeRecord({ id: "STR-RIGHT", name: "Right Stream" });
+
+    getStreamById.mockImplementation((id: string) => {
+      if (id === "STR-LEFT") return Promise.resolve(leftRecord);
+      return Promise.resolve(rightRecord);
+    });
+
+    const user = userEvent.setup();
+
+    render(
+      <StreamComparePane
+        leftId="STR-LEFT"
+        rightId="STR-RIGHT"
+        onExit={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Pane A")).toBeInTheDocument();
+    });
+
+    const swapBtn = screen.getByRole("button", { name: /swap/i });
+    await user.click(swapBtn);
+
+    // After swap, left pane should show the right record
+    await waitFor(() => {
+      const paneA = screen.getByText("Pane A").closest("section")!;
+      expect(paneA.textContent).toContain("Right Stream");
+    });
+
+    const paneB = screen.getByText("Pane B").closest("section")!;
+    expect(paneB.textContent).toContain("Left Stream");
+  });
+});


### PR DESCRIPTION
## test: add unit tests for StreamComparePane diffing logic and usePaneStream loading states (#964)

### Problem
`StreamComparePane.tsx` had zero test coverage despite containing non-trivial pure logic (`fieldValue`, `countDiffs`) and a hook (`usePaneStream`) managing async loading/loaded/error states — a regression in field normalization, diff counting, or the loading-state machine would ship silently.

### Changes

**`src/components/StreamComparePane.tsx`**
- Added named exports for `COMPARE_FIELDS`, `fieldValue`, `countDiffs`, and `usePaneStream` for direct unit testing

**`src/components/__tests__/StreamComparePane.test.tsx`** (new, 26 tests)
- **`fieldValue`** (12 tests) — each `COMPARE_FIELDS` entry: formatted (monthlyRate, depositAmount, etc.), raw string (status, dates, health), optional cliffDate present → value, missing → em-dash
- **`countDiffs`** (4 tests) — zero-diff (identical records), single diff, multiple diffs, all-fields-diff
- **`usePaneStream`** (6 tests) — initial loading state, loaded transition, error transition, null stream (not found), streamId-change refetch, mid-fetch cancellation (stale response ignored)
- **Rendering** (4 tests) — panes render with diff badge, remove left calls `onExit`, remove right calls `onExit`, swap button exchanges pane content

### Acceptance Criteria
- [x] `fieldValue` unit-tested for each `COMPARE_FIELDS` entry
- [x] `countDiffs` tested for zero-diff, partial-diff, all-diff
- [x] `usePaneStream` tested for loading/loaded/error/mid-fetch-swap
- [x] Pane swap/remove handlers tested via rendering
- [x] All 26 tests pass

Close #964 