### PR TITLE
fix(voice): prevent destructive command misfire from partial substring matches (#938)

### DIFF
--- a/src/components/voice/VoiceContext.tsx
+++ b/src/components/voice/VoiceContext.tsx
@@ -92,17 +92,28 @@ export const VoiceProvider: React.FC<{ children: React.ReactNode }> = ({
     }
   }, []);
 
-  // Match phrase to command dictionary
+  // Match phrase to command dictionary.
+  // Partial-match (substring) fallback is only applied to non-destructive
+  // commands so that longer utterances that happen to contain the phrase
+  // "Cancel stream" do not accidentally trigger the destructive confirmation
+  // flow (Issue #938).
   const matchCommand = useCallback((spokenText: string): VoiceCommandDef | null => {
     const clean = spokenText.trim().toLowerCase();
     if (!clean) return null;
 
+    // Exact-match pass — check every command's phrase and aliases first.
     for (const cmd of DEFAULT_COMMANDS) {
       if (cmd.phrase.toLowerCase() === clean) return cmd;
       if (cmd.aliases.some((alias) => alias.toLowerCase() === clean)) return cmd;
-      // Partial match support
-      if (clean.includes(cmd.phrase.toLowerCase())) return cmd;
     }
+
+    // Partial-match pass — only for non-destructive commands.
+    for (const cmd of DEFAULT_COMMANDS) {
+      if (cmd.requiresConfirmation) continue;
+      if (clean.includes(cmd.phrase.toLowerCase())) return cmd;
+      if (cmd.aliases.some((alias) => clean.includes(alias.toLowerCase()))) return cmd;
+    }
+
     return null;
   }, []);
 

--- a/src/components/voice/__tests__/VoiceCommandManager.test.tsx
+++ b/src/components/voice/__tests__/VoiceCommandManager.test.tsx
@@ -113,6 +113,53 @@ describe("Voice Command Navigation System", () => {
     );
   });
 
+  it("does NOT trigger destructive confirmation for utterances that merely contain the destructive phrase as a substring (Issue #938)", () => {
+    function SubstringTester() {
+      const { state, processSpokenPhrase } = useVoiceContext();
+      return (
+        <div>
+          <span data-testid="state">{state}</span>
+          <button
+            data-testid="negated-btn"
+            onClick={() =>
+              processSpokenPhrase("please don't cancel stream")
+            }
+          >
+            Negated Phrase
+          </button>
+          <button
+            data-testid="exact-btn"
+            onClick={() => processSpokenPhrase("Cancel stream")}
+          >
+            Exact Phrase
+          </button>
+        </div>
+      );
+    }
+
+    render(
+      <MemoryRouter initialEntries={["/app"]}>
+        <VoiceProvider>
+          <SubstringTester />
+          <VoiceConfirmModal />
+        </VoiceProvider>
+      </MemoryRouter>
+    );
+
+    // Saying a longer utterance that contains the substring "cancel stream" must
+    // NOT transition to confirming-destructive.
+    fireEvent.click(screen.getByTestId("negated-btn"));
+    expect(screen.getByTestId("state").textContent).not.toBe(
+      "confirming-destructive"
+    );
+
+    // The exact phrase should still work as before.
+    fireEvent.click(screen.getByTestId("exact-btn"));
+    expect(screen.getByTestId("state").textContent).toBe(
+      "confirming-destructive"
+    );
+  });
+
   it("displays unrecognized status when non-grammar phrase is received", () => {
     function UnrecognizedTester() {
       const { state, processSpokenPhrase } = useVoiceContext();


### PR DESCRIPTION
## Description

**Fixes #938** — VoiceContext's unanchored partial-phrase matcher can misfire the destructive \"Cancel stream\" confirmation on unrelated speech.

### Problem

`src/components/voice/VoiceContext.tsx`'s `matchCommand` function used a single-pass loop where every command — including the one destructive command \"Cancel stream\" with `requiresConfirmation: true` — was checked with `clean.includes(cmd.phrase.toLowerCase())`. This meant any longer utterance that happened to contain the substring \"cancel stream\" (e.g., \"please don't cancel stream\", \"I said cancel stream by mistake\", or any misrecognized speech) would immediately transition the global voice state to `confirming-destructive`, opening the confirmation modal for a destructive action the user did not actually request.

### Solution

Split `matchCommand` into two distinct passes:

1. **Exact-match pass** — checks every command’s phrase and aliases with strict equality (applies to all commands including destructive)
2. **Partial-match pass** — only iterates over non-destructive commands (`!cmd.requiresConfirmation`), skipping the destructive \"Cancel stream\" command entirely

The partial-match pass also now checks aliases (not just the primary phrase), which is a small improvement for non-destructive command recognition.

### Changes

| File | Change |
|------|--------|
| `src/components/voice/VoiceContext.tsx` | Split `matchCommand` into exact-match + partial-match passes; partial-match skips destructive commands |
| `src/components/voice/__tests__/VoiceCommandManager.test.tsx` | Added regression test: utterance \"please don't cancel stream\" does NOT transition to `confirming-destructive`, while exact phrase \"Cancel stream\" still does |

### Acceptance Criteria

- [x] Utterances that merely contain the destructive phrase as a substring no longer trigger the destructive confirmation flow
- [x] The exact destructive phrase and its documented aliases still work as before
- [x] A regression test covers the false-positive substring case

### Test Results

```
✓ src/components/voice/__tests__/VoiceCommandManager.test.tsx (6 tests | all passed)
```

### Security

None — this is a UX correctness/safety fix. The destructive command still requires explicit confirmation before executing, so no unauthorized actions can occur. The fix prevents startling/unintended destructive-action prompts from appearing, which is important for voice-accessibility user trust.