### PR TITLE
fix(fab): add click-outside-to-dismiss handler for CreateStreamFab action menu (#942)

### DIFF
--- a/src/components/CreateStreamFab.tsx
+++ b/src/components/CreateStreamFab.tsx
@@ -60,6 +60,7 @@ export default function CreateStreamFab({
 }: CreateStreamFabProps) {
   const [expanded, setExpanded] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
   const hasActions = actions.length > 0;
 
   useEffect(() => {
@@ -72,6 +73,26 @@ export default function CreateStreamFab({
       ?.querySelector<HTMLButtonElement>("[role=menuitem]")
       ?.focus();
   }, [expanded, hasActions]);
+
+  // Click outside to dismiss the expanded action menu (Issue #942).
+  // Mirrors the pattern in PresenceBadge.tsx.
+  useEffect(() => {
+    if (!expanded) return;
+
+    const handleOutsideClick = (e: MouseEvent) => {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(e.target as Node)
+      ) {
+        setExpanded(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handleOutsideClick);
+    return () => {
+      document.removeEventListener("mousedown", handleOutsideClick);
+    };
+  }, [expanded]);
 
   if (hidden) return null;
 
@@ -111,7 +132,7 @@ export default function CreateStreamFab({
   };
 
   return (
-    <div className="create-stream-fab" data-expanded={expanded || undefined}>
+    <div ref={containerRef} className="create-stream-fab" data-expanded={expanded || undefined}>
       {expanded && hasActions ? (
         <div
           ref={menuRef}

--- a/src/components/__tests__/CreateStreamFab.test.tsx
+++ b/src/components/__tests__/CreateStreamFab.test.tsx
@@ -63,4 +63,29 @@ describe("CreateStreamFab", () => {
     expect(onImport).toHaveBeenCalledOnce();
     expect(screen.queryByRole("menu")).not.toBeInTheDocument();
   });
+
+  it("closes the expanded action menu when clicking outside the FAB (Issue #942)", () => {
+    const onCreate = vi.fn();
+    const onImport = vi.fn();
+    render(
+      <div>
+        <div data-testid="outside">Outside element</div>
+        <CreateStreamFab
+          onCreateStream={onCreate}
+          actions={[
+            createAction("Create stream", onCreate),
+            createAction("Import CSV", onImport),
+          ]}
+        />
+      </div>,
+    );
+
+    const fab = screen.getByRole("button", { name: "Create stream" });
+    fireEvent.click(fab);
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+
+    // Click outside the FAB — menu should close.
+    fireEvent.mouseDown(screen.getByTestId("outside"));
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Description

**Fixes #942** — CreateStreamFab's expandable action menu has no click-outside-to-dismiss handler.

### Problem

`src/components/CreateStreamFab.tsx` renders an expandable `role="menu"` when actions are provided. The menu only closed via:
- Pressing Escape
- Selecting a menu item
- Clicking the FAB button itself again

There was no document-level click/mousedown listener to close the menu when the user clicks anywhere else on the page. This left the menu floating over unrelated page content when the user clicked elsewhere, unlike the equivalent dropdown pattern already implemented in `PresenceBadge.tsx`.

### Solution

Added a `containerRef` to the FAB root div and a `useEffect` that registers a `document.addEventListener("mousedown", ...)` listener when `expanded` is `true`, mirroring the pattern in `PresenceBadge.tsx`. The listener checks whether the event target is outside the container and calls `setExpanded(false)` if so. The listener is properly cleaned up when the menu closes or the component unmounts.

### Changes

| File | Change |
|------|--------|
| `src/components/CreateStreamFab.tsx` | Added `containerRef`, mousedown listener for outside-click dismissal |
| `src/components/__tests__/CreateStreamFab.test.tsx` | Added test: clicking outside the FAB closes the expanded menu |

### Acceptance Criteria

- [x] Clicking outside the open FAB menu closes it
- [x] Escape and item-selection close behavior remain unchanged
- [x] A regression test covers the outside-click dismissal

### Test Results

```
✓ src/components/__tests__/CreateStreamFab.test.tsx (4 tests | all passed)
```

### Security

None — UX consistency/correctness fix.