### PR TITLE
fix(presence): use useTickingNow for live elapsed time in PresenceViewerList (#955)

### DIFF
--- a/src/components/presence/PresenceViewerList.tsx
+++ b/src/components/presence/PresenceViewerList.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Viewer } from "../../hooks/usePresenceViewers";
 import { maskAddress } from "../../lib/stellar";
+import { useTickingNow } from "../../hooks/useTickingNow";
 
 interface PresenceViewerListProps {
   viewers: Viewer[];
@@ -8,6 +9,11 @@ interface PresenceViewerListProps {
 }
 
 export default function PresenceViewerList({ viewers, onClose }: PresenceViewerListProps) {
+  // Reactive "now" timestamp that ticks on a coarse cadence (useTickingNow)
+  // so the "last seen N seconds ago" text stays live while the list is open
+  // without requiring a viewers prop change (Issue #955).
+  const now = useTickingNow();
+
   // Get masked name or address
   const getDisplayName = (viewer: Viewer) => {
     if (viewer.displayName) return viewer.displayName;
@@ -17,9 +23,11 @@ export default function PresenceViewerList({ viewers, onClose }: PresenceViewerL
     return viewer.id;
   };
 
-  // Get elapsed seconds string
+  // Get elapsed seconds string — uses the reactive `now` timestamp so
+  // the text updates on each tick even while the list stays open.
   const getElapsedSeconds = (lastSeen: number) => {
-    const seconds = Math.max(0, Math.floor((Date.now() - lastSeen) / 1000));
+    const nowMs = new Date(now).getTime();
+    const seconds = Math.max(0, Math.floor((nowMs - lastSeen) / 1000));
     return `last seen ${seconds} seconds ago`;
   };
 

--- a/src/components/presence/__tests__/PresenceViewerList.test.tsx
+++ b/src/components/presence/__tests__/PresenceViewerList.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen, fireEvent } from "@testing-library/react";
-import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import PresenceViewerList from "../PresenceViewerList";
 import { Viewer } from "../../../hooks/usePresenceViewers";
 
@@ -39,7 +39,7 @@ describe("PresenceViewerList", () => {
 
   it("renders raw id if not a Stellar address and displayName is null", () => {
     const mockViewer: Viewer = {
-      id: "G-short", // Starts with G but too short to be Stellar key
+      id: "G-short",
       displayName: null,
       initials: "??",
       color: "#b91c1c",
@@ -51,7 +51,7 @@ describe("PresenceViewerList", () => {
 
   it("renders raw id if starts with another letter and displayName is null", () => {
     const mockViewer: Viewer = {
-      id: "A1111111111111111111111111111111111111111111111111111111", // Length 56 but starts with A
+      id: "A1111111111111111111111111111111111111111111111111111111",
       displayName: null,
       initials: "??",
       color: "#b91c1c",
@@ -59,5 +59,36 @@ describe("PresenceViewerList", () => {
     };
     render(<PresenceViewerList viewers={[mockViewer]} onClose={vi.fn()} />);
     expect(screen.getByText("A1111111111111111111111111111111111111111111111111111111")).toBeInTheDocument();
+  });
+});
+
+describe("PresenceViewerList elapsed time updates", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("updates elapsed seconds text over time without a viewers prop change (Issue #955)", () => {
+    const fixedLastSeen = Date.now() - 5_000;
+    const mockViewer: Viewer = {
+      id: "G1",
+      displayName: "Alice",
+      initials: "AS",
+      color: "#b91c1c",
+      lastSeen: fixedLastSeen,
+    };
+
+    render(<PresenceViewerList viewers={[mockViewer]} onClose={vi.fn()} />);
+
+    expect(screen.getByText(/last seen 5 seconds ago/i)).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(30_000);
+    });
+
+    expect(screen.getByText(/last seen 35 seconds ago/i)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Description

**Fixes #955** — PresenceViewerList's "last seen N seconds ago" text is computed once and never updates while the list stays open.

### Problem

`src/components/presence/PresenceViewerList.tsx` rendered each viewer's elapsed time from a plain, non-reactive computation using `Date.now()` inside a render-time closure:

```tsx
const getElapsedSeconds = (lastSeen: number) => {
  const seconds = Math.max(0, Math.floor((Date.now() - lastSeen) / 1000));
  return `last seen ${seconds} seconds ago`;
};
```

This value was only recomputed when the component re-rendered, which only happened when the `viewers` prop itself changed (a join/leave event). If a user opened the viewer list and left it open, the "last seen N seconds ago" text froze at whatever it was on the render that opened the popover — it did not tick forward like the rest of the app's time-relative UI.

The codebase already had a purpose-built hook for exactly this scenario — `src/hooks/useTickingNow.ts`, a coarse-cadence "now" reference designed for "timelines, accrual progress, cliff countdowns" — but PresenceViewerList wasn't using it.

### Solution

Imported `useTickingNow` and replaced the `Date.now()` call inside `getElapsedSeconds` with `new Date(now).getTime()` using the reactive `now` timestamp returned by the hook. This causes the component to re-render on the shared coarse tick (30s default, 60s with reduced motion), updating the elapsed-time display without requiring a viewers prop change.

### Changes

| File | Change |
|------|--------|
| `src/components/presence/PresenceViewerList.tsx` | Imported `useTickingNow`, replaced `Date.now()` with reactive `now` timestamp |
| `src/components/presence/__tests__/PresenceViewerList.test.tsx` | Added test using fake timers asserting elapsed text advances from 5s to 35s after 30s tick |

### Acceptance Criteria

- [x] The "last seen" text updates periodically while the list remains open and no join/leave occurs
- [x] The update cadence reuses `useTickingNow` rather than a bespoke interval
- [x] A regression test covers the stale-while-open behavior

### Test Results

```
✓ src/components/presence/__tests__/PresenceViewerList.test.tsx (6 tests | all passed)
```

### Security

None — presentation staleness fix only.