### PR TITLE
fix: avoid NaN cache-busting in meta tags

### DIFF
--- a/src/components/MetaTags.tsx
+++ b/src/components/MetaTags.tsx
@@ -7,7 +7,11 @@ import type { StreamRecord } from '../data/streamRecords';
  * Uses a dynamic image URL that points to the server-generated OG image.
  */
 export const MetaTags: React.FC<{ stream: StreamRecord }> = ({ stream }) => {
-  const ogImageUrl = `https://fluxora.app/og-image/${stream.id}.png?v=${Date.parse(stream.updatedAt ?? '')}`;
+  const parsedUpdatedAt = stream.updatedAt ? Date.parse(stream.updatedAt) : Number.NaN;
+  const hasValidUpdatedAt = Number.isFinite(parsedUpdatedAt);
+  const ogImageUrl = hasValidUpdatedAt
+    ? `https://fluxora.app/og-image/${stream.id}.png?v=${parsedUpdatedAt}`
+    : `https://fluxora.app/og-image/${stream.id}.png`;
   const ogTitle = `${stream.name} – Fluxora`;
   const ogDescription = stream.summary ?? 'Stream treasury capital on Stellar';
   const ogAlt = `Fluxora stream ${stream.name}, status ${stream.status}, recipient ${stream.recipient}`;

--- a/src/pages/StreamDetail.test.tsx
+++ b/src/pages/StreamDetail.test.tsx
@@ -69,4 +69,30 @@ describe("StreamDetail MetaTags Integration", () => {
       expect(ogImage?.getAttribute("content")).toContain(`?v=${expectedTimestamp}`);
     });
   });
+
+  it("omits the cache-busting query when updatedAt is missing", async () => {
+    const helmetContext = {};
+    const streamWithoutUpdate = {
+      ...mockStream,
+      updatedAt: undefined,
+    };
+
+    render(
+      <HelmetProvider context={helmetContext}>
+        <MetaTags stream={streamWithoutUpdate} />
+      </HelmetProvider>
+    );
+
+    await waitFor(() => {
+      const ogImage = document.querySelector('meta[property="og:image"]');
+      const twitterImage = document.querySelector('meta[name="twitter:image"]');
+      const imageContent = ogImage?.getAttribute("content") ?? "";
+      const twitterContent = twitterImage?.getAttribute("content") ?? "";
+
+      expect(imageContent).not.toContain("v=NaN");
+      expect(twitterContent).not.toContain("v=NaN");
+      expect(imageContent).toContain("https://fluxora.app/og-image/STR-001.png");
+      expect(twitterContent).toContain("https://fluxora.app/og-image/STR-001.png");
+    });
+  });
 });


### PR DESCRIPTION
# fix: avoid NaN cache-busting in meta tags

## Summary
This change prevents the Open Graph and Twitter image URLs from rendering a literal v=NaN cache-busting query when a stream does not have a valid updatedAt value.

## What changed
- Guarded the timestamp parsing in MetaTags so the cache-busting query is only appended when the timestamp is valid.
- Omitted the query parameter entirely when updatedAt is missing or invalid.
- Added a regression test covering the missing-updatedAt case.

## Verification
- Added regression coverage in StreamDetail.test.tsx
- Verified with:
  - pnpm vitest run StreamDetail.test.tsx

Closes: #960 