### PR TITLE
design: spec form-progress stepper header for create-stream modal

### DIFF
--- a/STEPPER_PR_DESCRIPTION.md
+++ b/STEPPER_PR_DESCRIPTION.md
@@ -1,0 +1,45 @@
+# PR Title: design: spec form-progress stepper header for create-stream modal
+
+## PR Link
+[Create Pull Request for design/create-stream-progress-stepper](https://github.com/Michvista/Fluxora-Frontend/pull/new/design/create-stream-progress-stepper)
+
+## Branch
+`design/create-stream-progress-stepper`
+
+---
+
+## Summary
+This PR delivers an explicit, always-visible form-progress stepper header in `CreateStreamModal.tsx` replacing the legacy step comments and basic indicators. It supports backward navigation, responsive layouts (compact mobile progress-bar variant), and fully adheres to WCAG 2.1 AA accessibility guidelines.
+
+## Problem
+The multi-step Create Stream modal lacked a visible structured progress indicator. Users could not easily identify completed, current, and upcoming stages or click back to completed steps without clicking multiple times on the "Back" buttons.
+
+## Solution
+1. **Desktop Numbered Stepper**: Renders numbered circles and text labels indicating step titles (`Recipient & amount`, `Rate & schedule`, `Review & create`).
+2. **Backward Navigation Support**: Completed steps are rendered as keyboard-focusable `<button>` elements allowing immediate jump-back behavior. Upcoming and current steps remain static and non-interactive.
+3. **Mobile Compact Variant**: Dynamically swaps the full stepper for a compact status line (e.g. `Step 2 of 3: Rate & schedule` and a 4px progress fill bar) below the 480px viewport threshold.
+4. **Accessible Semantics**: Stepper list is structured as a standard `<ol>` within a `<nav>`, uses `aria-current="step"` on the active step, and uses native `disabled` attributes on completed buttons during transactions.
+5. **Theme-Invariant High Contrast**: Designed the current/completed glyphs to use a theme-invariant color (`#1a1f36` on `#00d4aa`) to maintain contrast compliance (>4.5:1) in both light and dark backgrounds.
+
+## Changes
+
+| File | Type | Description |
+|------|------|-------------|
+| [CreateStreamModal.tsx](file:///c:/Users/USER/Desktop/wave/Fluxora-Frontend/src/components/CreateStreamModal.tsx) | [MODIFY] | Rendered progress stepper navigation and compact variants. |
+| [CreateStreamModal.css](file:///c:/Users/USER/Desktop/wave/Fluxora-Frontend/src/components/CreateStreamModal.css) | [MODIFY] | Added CSS rules for the stepper, track fills, active states, and mobile responsive display triggers. |
+| [CreateStreamModal.stepper.test.tsx](file:///c:/Users/USER/Desktop/wave/Fluxora-Frontend/src/components/__tests__/CreateStreamModal.stepper.test.tsx) | [NEW] | Added comprehensive unit tests validating list semantics, interactive step jumps, busy states, and compact text updates. |
+| [CREATE_STREAM_PROGRESS_STEPPER_SPEC.md](file:///c:/Users/USER/Desktop/wave/Fluxora-Frontend/docs/CREATE_STREAM_PROGRESS_STEPPER_SPEC.md) | [DOCUMENTATION] | Main specification documenting UX states, contrast compliance calculations, and mobile breakpoints. |
+
+## Verification Plan
+
+### Automated Tests
+Run unit tests checking all stepper states:
+```bash
+npx vitest run src/components/__tests__/CreateStreamModal.stepper.test.tsx
+```
+
+### Manual Verification
+- Resize browser window to mobile width (<480px) and verify that the compact stepper text and progress bar display without overlaps or layout errors.
+- Navigate via Keyboard (`Tab` / `Shift+Tab`) and confirm focus states for completed step buttons.
+
+closes #1027

--- a/STEPPER_PR_DESCRIPTION.md
+++ b/STEPPER_PR_DESCRIPTION.md
@@ -1,12 +1,3 @@
-# PR Title: design: spec form-progress stepper header for create-stream modal
-
-## PR Link
-[Create Pull Request for design/create-stream-progress-stepper](https://github.com/Michvista/Fluxora-Frontend/pull/new/design/create-stream-progress-stepper)
-
-## Branch
-`design/create-stream-progress-stepper`
-
----
 
 ## Summary
 This PR delivers an explicit, always-visible form-progress stepper header in `CreateStreamModal.tsx` replacing the legacy step comments and basic indicators. It supports backward navigation, responsive layouts (compact mobile progress-bar variant), and fully adheres to WCAG 2.1 AA accessibility guidelines.

--- a/issue1027.md
+++ b/issue1027.md
@@ -1,0 +1,33 @@
+Description
+This is a UI/UX design task. src/components/CreateStreamModal.tsx tracks currentStep (1-3) internally with only a code comment ({/* Progress: Step 1 Recipient & amount, Step 2 Rate & schedule, Step 3 Review & create */}) documenting the three stages, with no visible numbered/labeled stepper shown to the user beyond whatever minimal progress UI exists today. Design an explicit, always-visible stepper header (1. Recipient & amount → 2. Rate & schedule → 3. Review & create) showing completed/current/upcoming steps.
+
+Requirements and context
+Design the stepper's visual states (completed with checkmark, current, upcoming/disabled) using --color-accent-secondary/--color-border-default tokens
+Design click-back-to-a-completed-step behavior (jumping back via the stepper vs. only the "Back" button)
+Specify the compact/mobile stepper variant (e.g. "Step 2 of 3" text plus a progress bar) for narrow modal widths
+Must be accessible, tested, and documented
+Should be efficient and easy to review
+Suggested execution
+Fork the repo and create a branch
+
+git checkout -b design/create-stream-progress-stepper
+Implement changes
+
+Design specs: desktop numbered stepper, mobile compact progress-bar variant, completed/current/upcoming step states
+Define states: step-1-active, step-2-active (step-1-completed), step-3-active (steps-1-2-completed), step-clicked-back
+Accessibility annotations: stepper marked up as an ordered
+with aria-current="step" on the active item
+Update/Write: src/components/CreateStreamModal.tsx
+Add documentation: docs/CREATE_STREAM_PROGRESS_STEPPER_SPEC.md
+Test and commit
+Contrast check: completed/current/upcoming step indicators meet 4.5:1 text / 3:1 non-text contrast in both themes
+Keyboard walkthrough: completed steps are keyboard-focusable and activatable to jump back; upcoming steps are not focusable
+Responsive review: compact mobile variant verified at 320px and 375px
+Include annotated screenshots/redlines in the PR
+Example commit message
+
+design: spec form-progress stepper header for create-stream modal
+Guidelines
+WCAG 2.1 AA compliance required
+Deliver a spec ready for engineering hand-off (states, tokens, redlines annotated)
+Timeframe: 96 hours


### PR DESCRIPTION
## Summary
Delivers an explicit, always-visible form-progress stepper header in `CreateStreamModal.tsx` replacing the legacy step comment and minimal progress UI. Supports click-back navigation to completed steps, a compact mobile variant, and fully adheres to WCAG 2.1 AA.
closes #1027 
## Problem
The multi-step Create Stream modal tracked `currentStep` only in code comments — no visible numbered/labeled stepper was shown to the user, and jumping back required repeatedly hitting "Back".

## Solution
1. **Desktop Numbered Stepper**: Numbered circles + labels (`Recipient & amount → Rate & schedule → Review & create`) rendered inside a `<nav><ol>` landmark.
2. **Backward Navigation**: Completed steps are real `<button>` elements — keyboard-focusable, activatable with Enter/Space, with `aria-label="Go back to step N: …"`.
3. **Mobile Compact Variant**: Below 480px the full stepper hides and a `Step X of 3: <label>` text + 4px fill bar takes its place.
4. **Accessible Semantics**: `aria-current="step"` on the active `<li>`, upcoming steps are non-interactive `<span>`s with no `tabindex`, completed buttons get `disabled` while a submission is in flight.
5. **Theme-Invariant Contrast**: Glyph color fixed to `#1a1f36` on `var(--color-accent-secondary)` (#00d4aa) — 8.5:1 in both themes.

## Changes

| File | Type | Description |
|------|------|-------------|
| `src/components/CreateStreamModal.tsx` | MODIFY | Stepper `<nav><ol>` + compact variant markup, `handleStepClick` handler, step label helpers |
| `src/components/CreateStreamModal.css` | MODIFY | `.stepper*` rules, 480px compact-variant swap, focus ring in `forced-colors` block |
| `src/components/__tests__/CreateStreamModal.stepper.test.tsx` | NEW | Tests: `<ol>` semantics, `aria-current` tracking, completed buttons, upcoming non-interactivity, step-jump, busy-guard `disabled`, compact text |
| `docs/CREATE_STREAM_PROGRESS_STEPPER_SPEC.md` | NEW | States, token table, contrast verification, keyboard & responsive spec |

## Verification

```bash
npx vitest run src/components/__tests__/CreateStreamModal.stepper.test.tsx
