### PR TITLE
[#1012] Design a custom-report builder UI for exporting TreasuryPage.tsx metrics

### DIFF
--- a/src/components/treasuryOverviewPage/ReportBuilderPanel.tsx
+++ b/src/components/treasuryOverviewPage/ReportBuilderPanel.tsx
@@ -1,6 +1,11 @@
 import { useState, useMemo, useEffect } from "react";
 import { Stream } from "./Stream";
 import { useToast } from "../toast/ToastProvider";
+import {
+  filterStreamsByDateRange,
+  downloadReportCSV,
+  printReportAsPDF,
+} from "../../utils/reportExporter";
 
 export interface ReportBuilderPanelProps {
   streams: Stream[];
@@ -10,6 +15,8 @@ export interface ReportBuilderPanelProps {
 export type Field = "name" | "recipient" | "rate" | "accruedAmount" | "status";
 export type Grouping = "None" | "Recipient" | "Status";
 export type ExportFormat = "CSV" | "PDF";
+
+const FIELD_ORDER: Field[] = ["name", "recipient", "rate", "accruedAmount", "status"];
 
 export default function ReportBuilderPanel({ streams, onClose }: ReportBuilderPanelProps) {
   const [startDate, setStartDate] = useState("");
@@ -41,21 +48,39 @@ export default function ReportBuilderPanel({ streams, onClose }: ReportBuilderPa
 
   const canExport = selectedFields.size > 0;
 
+  // Streams matching the selected date range; this is what actually gets exported.
+  const reportStreams = useMemo(
+    () => filterStreamsByDateRange(streams, startDate, endDate),
+    [streams, startDate, endDate]
+  );
+
+  const orderedSelectedFields = useMemo(
+    () => FIELD_ORDER.filter((f) => selectedFields.has(f)),
+    [selectedFields]
+  );
+
   const handleExport = () => {
     if (!canExport) return;
     setIsExporting(true);
-    // Simulate export delay
-    setTimeout(() => {
-      setIsExporting(false);
+    try {
+      if (exportFormat === "CSV") {
+        downloadReportCSV(reportStreams, orderedSelectedFields, grouping);
+      } else {
+        printReportAsPDF(reportStreams, orderedSelectedFields, grouping);
+      }
       addToast(`Successfully exported report as ${exportFormat}`, "success");
       onClose();
-    }, 1500);
+    } catch {
+      addToast("Failed to export report. Please try again.", "error");
+    } finally {
+      setIsExporting(false);
+    }
   };
 
   const filteredStreams = useMemo(() => {
-    // In a real app we'd filter by dateRange and group by `grouping` here.
-    return streams.slice(0, 5); // Just show a few for preview
-  }, [streams, grouping]);
+    // Preview shows only the first few rows of the actual (date-filtered) export set.
+    return reportStreams.slice(0, 5);
+  }, [reportStreams]);
 
   const allFields: { key: Field; label: string }[] = [
     { key: "name", label: "Name" },

--- a/src/utils/reportExporter.test.ts
+++ b/src/utils/reportExporter.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import {
+  filterStreamsByDateRange,
+  groupStreams,
+  buildReportCSV,
+} from "./reportExporter";
+import type { Stream } from "../components/treasuryOverviewPage/Stream";
+
+function makeStream(overrides: Partial<Stream>): Stream {
+  return {
+    id: "1",
+    name: "Test Stream",
+    recipient: "GRECIPIENT",
+    rate: "10 USDC",
+    status: "Active",
+    ...overrides,
+  };
+}
+
+describe("filterStreamsByDateRange", () => {
+  const streams: Stream[] = [
+    makeStream({ id: "1", startDate: "2026-01-05" }),
+    makeStream({ id: "2", startDate: "2026-03-15" }),
+    makeStream({ id: "3", startDate: "2026-06-01" }),
+    makeStream({ id: "4" }), // no startDate
+  ];
+
+  it("returns all streams when no range is given", () => {
+    expect(filterStreamsByDateRange(streams, "", "")).toHaveLength(4);
+  });
+
+  it("filters streams outside the given range", () => {
+    const result = filterStreamsByDateRange(streams, "2026-02-01", "2026-05-01");
+    const ids = result.map((s) => s.id);
+    expect(ids).toEqual(["2", "4"]); // stream without a startDate is always kept
+  });
+
+  it("respects an open-ended start bound", () => {
+    const result = filterStreamsByDateRange(streams, "", "2026-03-31");
+    expect(result.map((s) => s.id)).toEqual(["1", "2", "4"]);
+  });
+});
+
+describe("groupStreams", () => {
+  const streams: Stream[] = [
+    makeStream({ id: "1", recipient: "A", status: "Active" }),
+    makeStream({ id: "2", recipient: "B", status: "Paused" }),
+    makeStream({ id: "3", recipient: "A", status: "Completed" }),
+  ];
+
+  it("returns a single ungrouped bucket for None", () => {
+    const groups = groupStreams(streams, "None");
+    expect(groups).toHaveLength(1);
+    expect(groups[0][1]).toHaveLength(3);
+  });
+
+  it("groups by recipient preserving order", () => {
+    const groups = groupStreams(streams, "Recipient");
+    expect(groups.map(([key]) => key)).toEqual(["A", "B"]);
+    expect(groups[0][1].map((s) => s.id)).toEqual(["1", "3"]);
+  });
+
+  it("groups by status", () => {
+    const groups = groupStreams(streams, "Status");
+    expect(groups.map(([key]) => key)).toEqual(["Active", "Paused", "Completed"]);
+  });
+});
+
+describe("buildReportCSV", () => {
+  const streams: Stream[] = [
+    makeStream({ id: "1", name: "Stream One", recipient: "A", status: "Active" }),
+    makeStream({ id: "2", name: "Stream Two", recipient: "B", status: "Paused" }),
+  ];
+
+  it("includes a header row and one row per stream", () => {
+    const csv = buildReportCSV(streams, ["name", "status"], "None");
+    const lines = csv.split("\n");
+    expect(lines[0]).toBe("Name,Status");
+    expect(lines).toHaveLength(3);
+    expect(lines[1]).toBe("Stream One,Active");
+  });
+
+  it("inserts a group marker row per group when grouping is set", () => {
+    const csv = buildReportCSV(streams, ["name"], "Recipient");
+    const lines = csv.split("\n");
+    expect(lines).toEqual(["Name", "# A", "Stream One", "# B", "Stream Two"]);
+  });
+
+  it("escapes commas and quotes in cell values", () => {
+    const csv = buildReportCSV(
+      [makeStream({ name: 'Stream, "special"' })],
+      ["name"],
+      "None"
+    );
+    expect(csv.split("\n")[1]).toBe('"Stream, ""special"""');
+  });
+});

--- a/src/utils/reportExporter.ts
+++ b/src/utils/reportExporter.ts
@@ -1,0 +1,195 @@
+import type { Stream } from "../components/treasuryOverviewPage/Stream";
+import type { Field, Grouping } from "../components/treasuryOverviewPage/ReportBuilderPanel";
+
+const FIELD_LABELS: Record<Field, string> = {
+  name: "Name",
+  recipient: "Recipient",
+  rate: "Rate",
+  accruedAmount: "Accrued Amount",
+  status: "Status",
+};
+
+function parseDate(dateStr?: string): Date | null {
+  if (!dateStr) return null;
+  const d = new Date(dateStr + "T00:00:00Z");
+  return isNaN(d.getTime()) ? null : d;
+}
+
+/**
+ * Filters streams whose `startDate` falls within [startDate, endDate].
+ * Streams without a startDate are always included (nothing to filter on).
+ * An empty bound on either side is treated as unbounded.
+ */
+export function filterStreamsByDateRange(
+  streams: Stream[],
+  startDate: string,
+  endDate: string
+): Stream[] {
+  const rangeStart = parseDate(startDate);
+  const rangeEnd = parseDate(endDate);
+  if (!rangeStart && !rangeEnd) return streams;
+
+  return streams.filter((s) => {
+    const streamStart = parseDate(s.startDate);
+    if (!streamStart) return true;
+    if (rangeStart && streamStart < rangeStart) return false;
+    if (rangeEnd && streamStart > rangeEnd) return false;
+    return true;
+  });
+}
+
+function groupKeyFor(stream: Stream, grouping: Grouping): string {
+  if (grouping === "Recipient") return stream.recipient;
+  if (grouping === "Status") return stream.status;
+  return "";
+}
+
+/**
+ * Groups streams according to `grouping`, preserving each group's original
+ * relative order. Returns a single ["", streams] entry when grouping is "None".
+ */
+export function groupStreams(
+  streams: Stream[],
+  grouping: Grouping
+): Array<[string, Stream[]]> {
+  if (grouping === "None") return [["", streams]];
+
+  const order: string[] = [];
+  const groups = new Map<string, Stream[]>();
+  streams.forEach((s) => {
+    const key = groupKeyFor(s, grouping);
+    if (!groups.has(key)) {
+      groups.set(key, []);
+      order.push(key);
+    }
+    groups.get(key)!.push(s);
+  });
+
+  return order.map((key) => [key, groups.get(key)!]);
+}
+
+function escapeCsvCell(value: string): string {
+  if (/[",\n]/.test(value)) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+function fieldValue(stream: Stream, field: Field): string {
+  switch (field) {
+    case "name":
+      return stream.name;
+    case "recipient":
+      return stream.recipient;
+    case "rate":
+      return stream.rate;
+    case "accruedAmount":
+      return stream.accruedAmount != null ? String(stream.accruedAmount) : "";
+    case "status":
+      return stream.status;
+  }
+}
+
+/**
+ * Builds CSV text for the given streams, selected fields, and grouping.
+ * Grouped output repeats a "# <group name>" comment row before each group.
+ */
+export function buildReportCSV(
+  streams: Stream[],
+  fields: Field[],
+  grouping: Grouping
+): string {
+  const header = fields.map((f) => escapeCsvCell(FIELD_LABELS[f])).join(",");
+  const lines: string[] = [header];
+
+  for (const [groupName, groupStreamsList] of groupStreams(streams, grouping)) {
+    if (grouping !== "None") {
+      lines.push(`# ${escapeCsvCell(groupName || "Ungrouped")}`);
+    }
+    for (const s of groupStreamsList) {
+      lines.push(fields.map((f) => escapeCsvCell(fieldValue(s, f))).join(","));
+    }
+  }
+
+  return lines.join("\n");
+}
+
+function triggerBlobDownload(blob: Blob, fileName: string): void {
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = fileName;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+
+/** Downloads the report as a CSV file. */
+export function downloadReportCSV(
+  streams: Stream[],
+  fields: Field[],
+  grouping: Grouping,
+  fileNamePrefix: string = "Fluxora-Treasury-Report"
+): void {
+  const csv = buildReportCSV(streams, fields, grouping);
+  const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+  triggerBlobDownload(blob, `${fileNamePrefix}-${Date.now()}.csv`);
+}
+
+/**
+ * Opens a print-friendly rendering of the report in a new window and invokes
+ * the browser print dialog, letting the user save it as a PDF. This avoids
+ * pulling in a client-side PDF library for a report that is already a plain
+ * table.
+ */
+export function printReportAsPDF(
+  streams: Stream[],
+  fields: Field[],
+  grouping: Grouping
+): void {
+  const printWindow = window.open("", "_blank", "width=900,height=700");
+  if (!printWindow) return;
+
+  const rows = groupStreams(streams, grouping)
+    .map(([groupName, groupStreamsList]) => {
+      const groupHeader =
+        grouping !== "None"
+          ? `<tr><td colspan="${fields.length}" style="font-weight:bold;padding:8px 4px;">${
+              groupName || "Ungrouped"
+            }</td></tr>`
+          : "";
+      const dataRows = groupStreamsList
+        .map(
+          (s) =>
+            `<tr>${fields
+              .map((f) => `<td style="padding:4px 8px;border-top:1px solid #ddd;">${fieldValue(s, f)}</td>`)
+              .join("")}</tr>`
+        )
+        .join("");
+      return groupHeader + dataRows;
+    })
+    .join("");
+
+  const headerCells = fields.map((f) => `<th style="text-align:left;padding:4px 8px;">${FIELD_LABELS[f]}</th>`).join("");
+
+  printWindow.document.write(`
+    <html>
+      <head>
+        <title>Fluxora Treasury Report</title>
+        <style>
+          body { font-family: -apple-system, BlinkMacSystemFont, sans-serif; color: #111; }
+          table { border-collapse: collapse; width: 100%; }
+          h1 { font-size: 18px; }
+        </style>
+      </head>
+      <body>
+        <h1>Fluxora Treasury Report</h1>
+        <table><thead><tr>${headerCells}</tr></thead><tbody>${rows}</tbody></table>
+      </body>
+    </html>
+  `);
+  printWindow.document.close();
+  printWindow.focus();
+  printWindow.print();
+}


### PR DESCRIPTION
Closes #1012

The ReportBuilderPanel UI already existed but export was simulated (setTimeout + toast, no file produced) and the date-range/grouping controls didn't actually filter anything.

**What changed:**
- New `src/utils/reportExporter.ts`: real date-range filtering, grouping by Recipient/Status, CSV generation (Blob download, following the existing `receiptGenerator.ts` pattern), and a print-friendly PDF export (no new dependency).
- `ReportBuilderPanel.tsx` now uses this for both the live preview and the actual export.

**Tested:** added `reportExporter.test.ts` (9 unit tests). Existing `ReportBuilderPanel.test.tsx` passes unmodified. Note: `main`'s full test suite has ~135 pre-existing failing tests unrelated to this change (e.g. compile errors in `Recipient.tsx`); none touch the files in this PR.