### PR TITLE
test(StreamRow): add outside-click, toggle, and navigation menu tests

### DIFF
--- a/src/components/treasuryOverviewPage/__tests__/StreamRow.test.tsx
+++ b/src/components/treasuryOverviewPage/__tests__/StreamRow.test.tsx
@@ -166,5 +166,44 @@ describe("StreamRow", () => {
     const pauseCancelItem = screen.getByRole("menuitem", { name: /pause\/cancel/i });
     expect(pauseCancelItem).toBeDisabled();
   });
+
+  it("closes the menu when clicking outside it", async () => {
+    renderRow();
+    const trigger = screen.getByRole("button", { name: `Actions for stream ${stream.name}` });
+    const user = await import("@testing-library/user-event").then((m) => m.default.setup());
+
+    await user.click(trigger);
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+
+    // Click outside the menu and trigger
+    await user.click(document.body);
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("toggles the menu closed when the trigger is clicked a second time", async () => {
+    renderRow();
+    const trigger = screen.getByRole("button", { name: `Actions for stream ${stream.name}` });
+    const user = await import("@testing-library/user-event").then((m) => m.default.setup());
+
+    await user.click(trigger);
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+
+    await user.click(trigger);
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+
+  it("'View details' menu item navigates to the stream detail route", async () => {
+    renderRow();
+    const trigger = screen.getByRole("button", { name: `Actions for stream ${stream.name}` });
+    const user = await import("@testing-library/user-event").then((m) => m.default.setup());
+
+    await user.click(trigger);
+    await user.click(screen.getByRole("menuitem", { name: /view details/i }));
+
+    // Menu should close after selection
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
 });
 


### PR DESCRIPTION
## Summary

Extends the `StreamRow` context-menu test suite with three missing interaction
tests. The component itself was fully implemented in PR #890; this PR adds
test coverage for the interaction paths that were not yet verified.

closes #1014

## Changes

- **#1014 — StreamRow context-menu tests**: Three new test cases added to
  `src/components/treasuryOverviewPage/__tests__/StreamRow.test.tsx`:

  1. **Outside-click dismissal** — opens the menu, fires a click on
     `document.body`, and asserts the menu is removed from the DOM and
     `aria-expanded` returns to `"false"`.
  2. **Trigger toggle** — clicks the ellipsis trigger twice and asserts the
     menu is closed on the second click and `aria-expanded` is `"false"`.
  3. **View details navigation** — opens the menu, clicks the "View details"
     menu item, and asserts the menu closes (navigation itself is handled
     inside the component via React Router).

  All tests use `@testing-library/user-event` setup for realistic pointer
  events, consistent with the existing test style in the file.

## Test plan

- `pnpm test` / `vitest run` — all new and existing `StreamRow` tests should
  pass.
- No production code changed; only the test file was modified.