### PR TITLE
fix: treat non-default accrualRate/duration as meaningful for stream …

### DIFF
--- a/src/components/CreateStreamModal.tsx
+++ b/src/components/CreateStreamModal.tsx
@@ -31,7 +31,11 @@ import ColumnMappingStep from './csv-upload/ColumnMappingStep';
 import PreviewValidateStep from './csv-upload/PreviewValidateStep';
 import { parseAndValidateCsv } from './csv-upload/csvParser';
 import type { CsvRow, ParseResult, ColumnMapping, BulkStep } from './csv-upload/types';
-import type { StreamDraftSnapshot } from '../lib/streamsSessionRecovery';
+import {
+  DEFAULT_STREAM_DRAFT_ACCRUAL_RATE,
+  DEFAULT_STREAM_DRAFT_DURATION,
+  type StreamDraftSnapshot,
+} from '../lib/streamsSessionRecovery';
 import {
   evaluateContrast,
   THEME_BACKGROUNDS,
@@ -207,8 +211,8 @@ export default function CreateStreamModal({
   // ── Single-stream state ───────────────────────────────────────────────────
   const [recipient, setRecipient] = useState("");
   const [depositAmount, setDepositAmount] = useState("");
-  const [accrualRate, setAccrualRate] = useState("38.62");
-  const [duration, setDuration] = useState("1");
+  const [accrualRate, setAccrualRate] = useState(DEFAULT_STREAM_DRAFT_ACCRUAL_RATE);
+  const [duration, setDuration] = useState(DEFAULT_STREAM_DRAFT_DURATION);
   const [startTimeOption, setStartTimeOption] = useState<"now" | "custom">(
     "now",
   );

--- a/src/lib/__tests__/streamsSessionRecovery.test.ts
+++ b/src/lib/__tests__/streamsSessionRecovery.test.ts
@@ -341,6 +341,38 @@ describe("streamsSessionRecovery", () => {
         }),
       ).toBe(true);
     });
+
+    it("is true when a non-default accrual rate is set with all other values default", () => {
+      expect(
+        isDraftMeaningful({
+          step: 1,
+          recipient: "",
+          depositAmount: "",
+          accrualRate: "40.00",
+          duration: "1",
+          startTimeOption: "now",
+          customStartDate: "",
+          cliffEnabled: false,
+          cliffDate: "",
+        }),
+      ).toBe(true);
+    });
+
+    it("is true when a non-default duration is set with all other values default", () => {
+      expect(
+        isDraftMeaningful({
+          step: 1,
+          recipient: "",
+          depositAmount: "",
+          accrualRate: "38.62",
+          duration: "2",
+          startTimeOption: "now",
+          customStartDate: "",
+          cliffEnabled: false,
+          cliffDate: "",
+        }),
+      ).toBe(true);
+    });
   });
 
   describe("isFilterSnapshotMeaningful", () => {

--- a/src/lib/streamsSessionRecovery.ts
+++ b/src/lib/streamsSessionRecovery.ts
@@ -51,6 +51,9 @@ export const DEFAULT_STREAMS_FILTERS: StreamsFilterSnapshot = {
   itemsPerPage: 10,
 };
 
+export const DEFAULT_STREAM_DRAFT_ACCRUAL_RATE = "38.62";
+export const DEFAULT_STREAM_DRAFT_DURATION = "1";
+
 function getLocalStorage(): Storage | null {
   if (typeof window === "undefined") {
     return null;
@@ -70,6 +73,8 @@ export function isDraftMeaningful(
   return (
     draft.recipient.trim() !== "" ||
     draft.depositAmount.trim() !== "" ||
+    draft.accrualRate.trim() !== DEFAULT_STREAM_DRAFT_ACCRUAL_RATE ||
+    draft.duration.trim() !== DEFAULT_STREAM_DRAFT_DURATION ||
     draft.cliffEnabled ||
     draft.customStartDate.trim() !== "" ||
     draft.startTimeOption === "custom"
@@ -133,8 +138,12 @@ function parseSnapshot(raw: string): StreamsSessionSnapshot | null {
       recipient: typeof d.recipient === "string" ? d.recipient : "",
       depositAmount:
         typeof d.depositAmount === "string" ? d.depositAmount : "",
-      accrualRate: typeof d.accrualRate === "string" ? d.accrualRate : "38.62",
-      duration: typeof d.duration === "string" ? d.duration : "1",
+      accrualRate:
+        typeof d.accrualRate === "string"
+          ? d.accrualRate
+          : DEFAULT_STREAM_DRAFT_ACCRUAL_RATE,
+      duration:
+        typeof d.duration === "string" ? d.duration : DEFAULT_STREAM_DRAFT_DURATION,
       startTimeOption: d.startTimeOption === "custom" ? "custom" : "now",
       customStartDate:
         typeof d.customStartDate === "string" ? d.customStartDate : "",


### PR DESCRIPTION
# fix: treat non-default accrualRate/duration as meaningful for stream draft recovery

Body:
- Updated streamsSessionRecovery.ts so `isDraftMeaningful` also considers `accrualRate` and `duration` changes meaningful when they differ from the actual form defaults.
- Shared default values between `CreateStreamModal` and session recovery via exported constants.
- Added regression tests in streamsSessionRecovery.test.ts covering:
  - non-default accrual rate only
  - non-default duration only

Closes: #949