### PR TITLE
fix: make VoiceCommandPanel command rows keyboard operable

### DIFF
--- a/src/components/voice/VoiceCommandPanel.tsx
+++ b/src/components/voice/VoiceCommandPanel.tsx
@@ -246,10 +246,11 @@ export const VoiceCommandPanel: React.FC = () => {
                 </div>
                 <div className="space-y-1">
                   {catCmds.map((cmd) => (
-                    <div
+                    <button
                       key={cmd.id}
+                      type="button"
                       className={clsx(
-                        "p-2 rounded-lg border text-xs flex flex-col gap-0.5 transition-all cursor-pointer hover:border-[var(--color-accent-primary)]/50",
+                        "p-2 rounded-lg border text-xs flex flex-col gap-0.5 transition-all text-left outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] hover:border-[var(--color-accent-primary)]/50",
                         recognizedCommand?.command.id === cmd.id
                           ? "bg-[var(--color-accent-primary)]/10 border-[var(--color-accent-primary)] text-[var(--text-vivid)]"
                           : "bg-[var(--surface-sunken)] border-[var(--border-subtle)] text-[var(--text-secondary)]"
@@ -271,7 +272,7 @@ export const VoiceCommandPanel: React.FC = () => {
                       <div className="text-[10px] text-[var(--text-disabled)] font-mono mt-0.5">
                         Aliases: {cmd.aliases.map((a) => `"${a}"`).join(", ")}
                       </div>
-                    </div>
+                    </button>
                   ))}
                 </div>
               </div>

--- a/src/components/voice/__tests__/VoiceCommandPanel.test.tsx
+++ b/src/components/voice/__tests__/VoiceCommandPanel.test.tsx
@@ -18,6 +18,7 @@
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { VoiceCommandPanel } from "../VoiceCommandPanel";
 import * as VoiceContextModule from "../VoiceContext";
 import type { VoiceContextValue, VoiceState, VoiceCommandDef } from "../voiceTypes";
@@ -236,9 +237,21 @@ describe("VoiceCommandPanel — category filtering", () => {
       buildCtx({ availableCommands: [NAV_CMD], processSpokenPhrase })
     );
     render(<VoiceCommandPanel />);
-    // The command row has a title attribute
     const row = screen.getByTitle('Click to test phrase "Go to dashboard"');
     fireEvent.click(row);
+    expect(processSpokenPhrase).toHaveBeenCalledWith("Go to dashboard");
+  });
+
+  it("focusable command rows activate processSpokenPhrase with Enter key", async () => {
+    const processSpokenPhrase = vi.fn(() => true);
+    mockUseVoiceContext(
+      buildCtx({ availableCommands: [NAV_CMD], processSpokenPhrase })
+    );
+    render(<VoiceCommandPanel />);
+    const row = screen.getByTitle('Click to test phrase "Go to dashboard"');
+    row.focus();
+    expect(row).toHaveFocus();
+    await userEvent.keyboard("{Enter}");
     expect(processSpokenPhrase).toHaveBeenCalledWith("Go to dashboard");
   });
 });


### PR DESCRIPTION
# fix: make VoiceCommandPanel command rows keyboard operable

Body:
- Converted each VoiceCommandPanel command row into a semantic `button` element.
- Preserved styling, click behavior, and phrase testing functionality.
- Ensures keyboard users can focus rows and activate them with Enter/Space.
- Added regression coverage to VoiceCommandPanel.test.tsx.

Closes: #959 