### PR TITLE
fix(presence): properly type usePresenceViewers return value

### DIFF
--- a/src/hooks/__tests__/usePresenceViewers.test.ts
+++ b/src/hooks/__tests__/usePresenceViewers.test.ts
@@ -15,11 +15,8 @@ describe("usePresenceViewers", () => {
   it("returns empty array initially", () => {
     const { result } = renderHook(() => usePresenceViewers("STR-123"));
     
-    // Test both tuple and object styles
     expect(result.current.viewers).toEqual([]);
-    expect(result.current[0]).toEqual([]);
     expect(result.current.viewerCount).toBe(0);
-    expect(result.current[2]).toBe(0);
   });
 
   it("exposes an explicit unavailable state for real stream IDs without mock viewers", () => {

--- a/src/hooks/usePresenceViewers.ts
+++ b/src/hooks/usePresenceViewers.ts
@@ -91,13 +91,11 @@ export function usePresenceViewers(
 
   const viewerCount = viewers.filter(v => !v.fadingOut).length;
 
-  // Support both tuple [viewers, markActive, viewerCount] and object destructuring { viewers, markActive, viewerCount }
-  const result = [viewers, markActive, viewerCount] as any;
-  result.viewers = viewers;
-  result.markActive = markActive;
-  result.viewerCount = viewerCount;
-  result.isPresenceEnabled = isPresenceEnabled;
-  result.presenceStatus = presenceStatus;
-
-  return result;
+  return {
+    viewers,
+    markActive,
+    viewerCount,
+    isPresenceEnabled,
+    presenceStatus,
+  };
 }


### PR DESCRIPTION
Closes #947


This PR fixes an issue where `usePresenceViewers` returned an array cast to `any` to support both tuple and object destructuring, which bypassed TypeScript's type checking on the hook's return value.

After auditing the call sites, only the object access pattern is used (`const { viewers, isPresenceEnabled } = usePresenceViewers(...)`). Thus, the hook has been simplified to return a strongly-typed object, removing the `as any` cast completely. The related tests have been updated accordingly to no longer check for tuple array indexes.

## Acceptance Criteria
- [x] `usePresenceViewers` no longer casts its return value through `as any`.
- [x] Both consumer access patterns (whichever are genuinely used) are properly typed.
- [x] Existing presence tests continue to pass.