### PR TITLE
fix: restore --interactive-focus-ring on cleanup in applyThemeConfigSafely (#946)

### DIFF
--- a/src/lib/__tests__/embedThemeParser.test.ts
+++ b/src/lib/__tests__/embedThemeParser.test.ts
@@ -219,5 +219,22 @@ describe('embedThemeParser', () => {
       expect(document.documentElement.getAttribute('data-theme')).toBeNull();
       expect(document.documentElement.style.getPropertyValue('--color-accent-primary')).toBe('');
     });
+
+    it('restores pre-existing --interactive-focus-ring value on cleanup', () => {
+      document.documentElement.style.setProperty('--interactive-focus-ring', '#ABCDEF');
+
+      const config: ThemeConfig = {
+        theme: null,
+        accentColor: '#FF0000'
+      };
+
+      const cleanup = applyThemeConfigSafely(config);
+
+      expect(document.documentElement.style.getPropertyValue('--interactive-focus-ring')).toBe('#FF0000');
+
+      cleanup();
+
+      expect(document.documentElement.style.getPropertyValue('--interactive-focus-ring')).toBe('#ABCDEF');
+    });
   });
 });

--- a/src/lib/embedThemeParser.ts
+++ b/src/lib/embedThemeParser.ts
@@ -103,6 +103,7 @@ export function applyThemeConfigSafely(config: ThemeConfig): () => void {
   const html = document.documentElement;
   const originalTheme = html.getAttribute("data-theme");
   const originalAccentColor = html.style.getPropertyValue("--color-accent-primary");
+  const originalFocusRing = html.style.getPropertyValue("--interactive-focus-ring");
   
   try {
     // Apply theme
@@ -135,6 +136,12 @@ export function applyThemeConfigSafely(config: ThemeConfig): () => void {
         html.style.setProperty("--color-accent-primary", originalAccentColor);
       } else {
         html.style.removeProperty("--color-accent-primary");
+      }
+
+      // Restore original focus ring
+      if (originalFocusRing) {
+        html.style.setProperty("--interactive-focus-ring", originalFocusRing);
+      } else {
         html.style.removeProperty("--interactive-focus-ring");
       }
     } catch (error) {


### PR DESCRIPTION
Closes #946

## Problem
In `applyThemeConfigSafely`, the original `--interactive-focus-ring` value was never captured before being overwritten. On cleanup, if no pre-existing `--color-accent-primary` was present, both properties were unconditionally removed -- permanently destroying any pre-existing `--interactive-focus-ring` value.

## Fix
- Capture `--interactive-focus-ring` alongside `--color-accent-primary` before applying overrides
- On cleanup, restore `--interactive-focus-ring` from its captured value (set if present, remove only if genuinely absent)

## Test
Added a test that pre-sets `--interactive-focus-ring` to a distinct value, applies a theme config override, runs cleanup, and asserts the original value is restored.
