### PR TITLE
fix: trap focus in voice confirm modal

### DIFF
--- a/src/components/voice/VoiceConfirmModal.tsx
+++ b/src/components/voice/VoiceConfirmModal.tsx
@@ -11,6 +11,7 @@ export const VoiceConfirmModal: React.FC = () => {
   } = useVoiceContext();
 
   const confirmBtnRef = useRef<HTMLButtonElement>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
 
   const isOpen =
     state === "confirming-destructive" && pendingDestructiveCommand !== null;
@@ -24,24 +25,80 @@ export const VoiceConfirmModal: React.FC = () => {
     }
   }, [isOpen]);
 
-  // Escape key handler
   useEffect(() => {
     if (!isOpen) return;
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        event.stopPropagation();
         cancelDestructiveAction();
       }
     };
+
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [isOpen, cancelDestructiveAction]);
 
   if (!isOpen || !pendingDestructiveCommand) return null;
 
+  const handleDialogKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      event.stopPropagation();
+      cancelDestructiveAction();
+      return;
+    }
+
+    if (event.key !== "Tab") return;
+
+    const focusableElements = Array.from(
+      dialogRef.current?.querySelectorAll<HTMLElement>(
+        "button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex='-1'])",
+      ) ?? [],
+    ).filter((element) => {
+      const style = window.getComputedStyle(element);
+      return !element.hasAttribute("disabled") && element.tabIndex !== -1 && style.display !== "none" && style.visibility !== "hidden";
+    });
+
+    if (focusableElements.length === 0) {
+      event.preventDefault();
+      event.stopPropagation();
+      return;
+    }
+
+    const activeElement = document.activeElement as HTMLElement | null;
+    const currentIndex = focusableElements.indexOf(activeElement as HTMLElement);
+
+    if (activeElement && !dialogRef.current?.contains(activeElement)) {
+      event.preventDefault();
+      event.stopPropagation();
+      focusableElements[0].focus();
+      return;
+    }
+
+    const nextIndex = event.shiftKey
+      ? (currentIndex - 1 + focusableElements.length) % focusableElements.length
+      : (currentIndex + 1) % focusableElements.length;
+
+    if (currentIndex === -1) {
+      event.preventDefault();
+      event.stopPropagation();
+      focusableElements[0].focus();
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    focusableElements[nextIndex].focus();
+  };
+
   return (
     <div
+      ref={dialogRef}
       role="dialog"
       aria-modal="true"
+      onKeyDownCapture={handleDialogKeyDown}
       aria-labelledby="voice-confirm-heading"
       aria-describedby="voice-confirm-desc"
       className="fixed inset-0 z-[100] flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm animate-fade-in"

--- a/src/components/voice/__tests__/VoiceConfirmModal.test.tsx
+++ b/src/components/voice/__tests__/VoiceConfirmModal.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { VoiceConfirmModal } from "../VoiceConfirmModal";
 import { VoiceContextValue, VoiceState, VoiceCommandDef } from "../voiceTypes";
 
@@ -116,12 +117,12 @@ describe("VoiceConfirmModal", () => {
       cancelDestructiveAction: cancelFn,
     });
     const { unmount } = render(<VoiceConfirmModal />);
-    // First Escape while mounted — should fire
+    // First Escape while mounted ï¿½ should fire
     window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
     expect(cancelFn).toHaveBeenCalledTimes(1);
 
     unmount();
-    // Second Escape after unmount — should not fire
+    // Second Escape after unmount ï¿½ should not fire
     window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
     expect(cancelFn).toHaveBeenCalledTimes(1);
   });
@@ -150,5 +151,43 @@ describe("VoiceConfirmModal", () => {
     render(<VoiceConfirmModal />);
     screen.getByText("Cancel").click();
     expect(cancelFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("wraps focus between the dialog actions when tabbing forward and backward", async () => {
+    const user = userEvent.setup();
+    mockContext = buildContext({
+      state: "confirming-destructive",
+      pendingDestructiveCommand: destructiveCmd,
+    });
+
+    render(<VoiceConfirmModal />);
+
+    const dialog = screen.getByRole("dialog");
+    const closeButton = screen.getByRole("button", { name: /cancel destructive action/i });
+    const confirmButton = screen.getByRole("button", { name: /confirm action/i });
+    const cancelButton = screen.getByRole("button", { name: /^Cancel$/i });
+
+    closeButton.focus();
+    expect(closeButton).toHaveFocus();
+
+    await user.tab();
+    expect(confirmButton).toHaveFocus();
+
+    await user.tab();
+    expect(cancelButton).toHaveFocus();
+
+    await user.tab();
+    expect(closeButton).toHaveFocus();
+
+    await user.tab({ shift: true });
+    expect(cancelButton).toHaveFocus();
+
+    await user.tab({ shift: true });
+    expect(confirmButton).toHaveFocus();
+
+    await user.tab({ shift: true });
+    expect(closeButton).toHaveFocus();
+
+    expect(dialog).toContainElement(document.activeElement);
   });
 });


### PR DESCRIPTION
# fix: trap focus in voice confirm modal

Body:
## Summary
- Added keyboard focus trapping to the voice confirmation dialog so Tab and Shift+Tab stay within the modal while it is open.
- Preserved the existing Escape-to-cancel and auto-focus-on-open behavior.
- Added a regression test covering forward and backward focus wrapping.

## Testing
- pnpm vitest run VoiceConfirmModal.test.tsx

Closes: #940