### PR TITLE
test: add home breakpoint regression coverage

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -2,6 +2,10 @@ import React, { lazy, Suspense, useEffect, useRef, useState } from "react";
 import HeroSection from "../components/landing-page/HeroSection";
 import Footer from "../components/Footer";
 import { Skeleton } from "../components/Skeleton";
+import {
+  isMobileViewport,
+  VIEWPORT_RESIZE_DEBOUNCE_MS,
+} from "../lib/breakpoints";
 import { useTheme } from "../theme/ThemeProvider";
 
 // Below-the-fold landing sections are split into separate chunks via React.lazy
@@ -65,6 +69,41 @@ function LazySection({ children, label }: LazySectionProps) {
 
 export default function Home() {
   const { theme } = useTheme();
+  const [isMobileLayout, setIsMobileLayout] = useState(() => {
+    if (typeof window === "undefined") {
+      return false;
+    }
+
+    return isMobileViewport();
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    let timeoutId: ReturnType<typeof window.setTimeout> | undefined;
+
+    const handleResize = () => {
+      if (timeoutId) {
+        window.clearTimeout(timeoutId);
+      }
+
+      timeoutId = window.setTimeout(() => {
+        setIsMobileLayout(isMobileViewport());
+      }, VIEWPORT_RESIZE_DEBOUNCE_MS);
+    };
+
+    handleResize();
+    window.addEventListener("resize", handleResize);
+
+    return () => {
+      window.removeEventListener("resize", handleResize);
+      if (timeoutId) {
+        window.clearTimeout(timeoutId);
+      }
+    };
+  }, []);
 
   return (
     <div
@@ -75,7 +114,11 @@ export default function Home() {
         flexDirection: "column",
       }}
     >
-      <main id="main-content" style={{ flex: 1 }}>
+      <main
+        id="main-content"
+        data-mobile-layout={isMobileLayout ? "mobile" : "desktop"}
+        style={{ flex: 1 }}
+      >
         <HeroSection theme={theme as "light" | "dark"} />
         <LazySection label="value proposition section">
           <ValuePropositionSection />

--- a/src/pages/__tests__/Home.test.tsx
+++ b/src/pages/__tests__/Home.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { axe } from "vitest-axe";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -13,6 +13,15 @@ function renderHome() {
       </MemoryRouter>
     </ThemeProvider>,
   );
+}
+
+function setViewportWidth(width: number) {
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    writable: true,
+    value: width,
+  });
+  window.dispatchEvent(new Event("resize"));
 }
 
 describe("Home canonical landing page", () => {
@@ -48,6 +57,48 @@ describe("Home canonical landing page", () => {
         name: /stay updated on stellar ecosystem streaming/i,
       }),
     ).toBeInTheDocument();
+  });
+});
+
+describe("Home responsive viewport behavior", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  it("tracks mobile and desktop layout decisions with debounced viewport changes", () => {
+    setViewportWidth(1280);
+    renderHome();
+
+    expect(screen.getByRole("main")).toHaveAttribute("data-mobile-layout", "desktop");
+
+    setViewportWidth(375);
+    expect(screen.getByRole("main")).toHaveAttribute("data-mobile-layout", "desktop");
+
+    act(() => {
+      vi.advanceTimersByTime(149);
+    });
+    expect(screen.getByRole("main")).toHaveAttribute("data-mobile-layout", "desktop");
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(screen.getByRole("main")).toHaveAttribute("data-mobile-layout", "mobile");
+
+    setViewportWidth(1280);
+    act(() => {
+      vi.advanceTimersByTime(149);
+    });
+    expect(screen.getByRole("main")).toHaveAttribute("data-mobile-layout", "mobile");
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(screen.getByRole("main")).toHaveAttribute("data-mobile-layout", "desktop");
   });
 });
 


### PR DESCRIPTION
closes #1172 
## Summary

<!-- What does this PR change and why? -->

## Changes

<!-- List the key changes made. -->

## Test plan

- [ ] `npm run build` passes (type-check + production build)
- [ ] `npm run test` passes (all unit tests green)
- [ ] `npm run test:coverage` passes (statements/branches/functions/lines ≥ 95%)
- [ ] New code is covered by tests; the coverage include list in `vitest.config.ts` is expanded if new production modules are added

## Coverage gate

CI enforces **95% coverage thresholds** (statements, branches, functions, lines) via
the `coverage` job in `.github/workflows/ci.yml`. The job runs `npm run test:coverage`
and fails the PR check when any threshold is missed. The coverage report is uploaded
as a build artifact for every run.

To add a new production file to the coverage baseline, append it to the `include`
array in `vitest.config.ts` and ensure tests cover it before opening the PR.
