### PR TITLE
fix: wrap localStorage.setItem in saveLayout with try/catch

### DIFF
--- a/src/components/treasuryOverviewPage/__tests__/useWidgetLayout.test.tsx
+++ b/src/components/treasuryOverviewPage/__tests__/useWidgetLayout.test.tsx
@@ -127,6 +127,45 @@ describe("useWidgetLayout hook", () => {
     consoleWarnSpy.mockRestore();
   });
 
+  it("recovers from localStorage.setItem failure in saveLayout", () => {
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const setItemSpy = vi.spyOn(localStorage, "setItem").mockImplementation(() => {
+      throw new Error("QuotaExceededError");
+    });
+
+    const { result } = renderHook(() => useWidgetLayout(mockMetrics));
+
+    // reorderWidgets should update in-memory state without throwing
+    act(() => {
+      const reordered = [
+        result.current.layout.widgets[2],
+        result.current.layout.widgets[0],
+        result.current.layout.widgets[1],
+      ];
+      expect(() => result.current.reorderWidgets(reordered)).not.toThrow();
+    });
+    expect(result.current.layout.widgets[0].id).toBe("pending-claims");
+
+    // updateWidgetSize should update in-memory state without throwing
+    act(() => {
+      expect(() =>
+        result.current.updateWidgetSize("total-balance", "2x1")
+      ).not.toThrow();
+    });
+    expect(result.current.layout.widgets[1].size).toBe("2x1");
+
+    // resetLayout should also not throw
+    act(() => {
+      expect(() => result.current.resetLayout()).not.toThrow();
+    });
+    expect(result.current.layout.widgets[0].id).toBe("total-balance");
+
+    expect(consoleWarnSpy).toHaveBeenCalled();
+
+    consoleWarnSpy.mockRestore();
+    setItemSpy.mockRestore();
+  });
+
   it("merges incoming new metrics that are missing from stored layout", () => {
     // Stored layout only has 2 of the widgets
     const storedLayout = {

--- a/src/components/treasuryOverviewPage/useWidgetLayout.ts
+++ b/src/components/treasuryOverviewPage/useWidgetLayout.ts
@@ -95,7 +95,11 @@ export function useWidgetLayout(metrics: Metric[]) {
 
   const saveLayout = useCallback((newLayout: WidgetLayout) => {
     setLayout(newLayout);
-    localStorage.setItem(storageKey, JSON.stringify(newLayout));
+    try {
+      localStorage.setItem(storageKey, JSON.stringify(newLayout));
+    } catch (e) {
+      console.warn("Failed to persist layout to localStorage.", e);
+    }
   }, [storageKey]);
 
   const reorderWidgets = useCallback((newWidgets: WidgetConfig[]) => {


### PR DESCRIPTION
Closes #944

## Summary
- Wrapped localStorage.setItem in saveLayout with a try/catch block to prevent uncaught exceptions from breaking user interactions (drag-and-drop, resizing, resetting).
- Failures are logged via console.warn, matching the pattern already used by loadLayout.
- In-memory layout state updates successfully even when persistence fails.

## Testing
- Added regression test that mocks localStorage.setItem to throw and verifies reorderWidgets, updateWidgetSize, and resetLayout all update in-memory state without throwing.