### PR TITLE
fix: strip thousands separators from CSV numeric fields during validation and submission

### DIFF
--- a/src/components/CreateStreamModal.tsx
+++ b/src/components/CreateStreamModal.tsx
@@ -29,7 +29,7 @@ import { useI18n } from '../i18n';
 import CsvDropZone from './csv-upload/CsvDropZone';
 import ColumnMappingStep from './csv-upload/ColumnMappingStep';
 import PreviewValidateStep from './csv-upload/PreviewValidateStep';
-import { parseAndValidateCsv } from './csv-upload/csvParser';
+import { parseAndValidateCsv, parseCsvNumber } from './csv-upload/csvParser';
 import type { CsvRow, ParseResult, ColumnMapping, BulkStep } from './csv-upload/types';
 import {
   DEFAULT_STREAM_DRAFT_ACCRUAL_RATE,
@@ -1157,10 +1157,10 @@ export default function CreateStreamModal({
       try {
         const sender = wallet.address!;
         const amountStr = Math.floor(
-          (parseFloat(row.depositAmount.replace(/,/g, '')) || 0) * 10_000_000,
+          (parseCsvNumber(row.depositAmount) || 0) * 10_000_000,
         ).toString();
         const start = Math.floor(Date.now() / 1000);
-        const end = start + Math.floor(parseFloat(row.durationDays) * 86_400);
+        const end = start + Math.floor(parseCsvNumber(row.durationDays) * 86_400);
         await createStream(sender, row.recipient.trim(), amountStr, start, end);
         successCount++;
       } catch {

--- a/src/components/csv-upload/__tests__/csvParser.test.ts
+++ b/src/components/csv-upload/__tests__/csvParser.test.ts
@@ -11,6 +11,7 @@ import {
   splitCsvLine,
   stripBom,
   normaliseLineEndings,
+  parseCsvNumber,
   validateRow,
   markDuplicates,
   parseAndValidateCsv,
@@ -71,6 +72,44 @@ describe('stripBom', () => {
   });
   it('handles an empty string', () => {
     expect(stripBom('')).toBe('');
+  });
+});
+
+describe('parseCsvNumber', () => {
+  it('parses a simple integer', () => {
+    expect(parseCsvNumber('1234')).toBe(1234);
+  });
+
+  it('parses a number with thousands separator', () => {
+    expect(parseCsvNumber('1,825')).toBe(1825);
+  });
+
+  it('parses a number with multiple thousands separators', () => {
+    expect(parseCsvNumber('1,234,567')).toBe(1234567);
+  });
+
+  it('parses a decimal number with thousands separator', () => {
+    expect(parseCsvNumber('1,234.56')).toBe(1234.56);
+  });
+
+  it('parses a decimal number without commas', () => {
+    expect(parseCsvNumber('1234.56')).toBe(1234.56);
+  });
+
+  it('parses a large number with thousands separators', () => {
+    expect(parseCsvNumber('100,000')).toBe(100000);
+  });
+
+  it('parses a number with leading/trailing whitespace', () => {
+    expect(parseCsvNumber('  1,234  ')).toBe(1234);
+  });
+
+  it('returns NaN for an empty string', () => {
+    expect(parseCsvNumber('')).toBeNaN();
+  });
+
+  it('returns NaN for a non-numeric string', () => {
+    expect(parseCsvNumber('abc')).toBeNaN();
   });
 });
 

--- a/src/components/csv-upload/csvParser.ts
+++ b/src/components/csv-upload/csvParser.ts
@@ -107,6 +107,14 @@ export function stripBom(text: string): string {
 }
 
 /**
+ * Parses a numeric CSV value by stripping thousands-separator commas first.
+ * Returns NaN for empty, whitespace-only, or non-numeric input.
+ */
+export function parseCsvNumber(value: string): number {
+  return parseFloat(value.replace(/,/g, ''));
+}
+
+/**
  * Normalises line endings to `\n` so we can split on a single character.
  */
 export function normaliseLineEndings(text: string): string {
@@ -132,7 +140,7 @@ export function validateRow(row: Omit<CsvRow, 'id' | 'rowNumber' | 'status' | 'f
   }
 
   // deposit_amount
-  const deposit = parseFloat(row.depositAmount);
+  const deposit = parseCsvNumber(row.depositAmount);
   if (!row.depositAmount.trim() || isNaN(deposit) || deposit <= 0) {
     errors.deposit_amount = 'Deposit must be a positive number';
   } else if (deposit > MAX_DEPOSIT_AMOUNT) {
@@ -146,7 +154,7 @@ export function validateRow(row: Omit<CsvRow, 'id' | 'rowNumber' | 'status' | 'f
   }
 
   // accrual_rate_per_day
-  const rate = parseFloat(row.accrualRatePerDay);
+  const rate = parseCsvNumber(row.accrualRatePerDay);
   if (!row.accrualRatePerDay.trim() || isNaN(rate) || rate <= 0) {
     errors.accrual_rate_per_day = 'Rate must be a positive number';
   } else if (rate > 100_000) {
@@ -154,7 +162,7 @@ export function validateRow(row: Omit<CsvRow, 'id' | 'rowNumber' | 'status' | 'f
   }
 
   // duration_days
-  const duration = parseFloat(row.durationDays);
+  const duration = parseCsvNumber(row.durationDays);
   if (!row.durationDays.trim() || isNaN(duration) || !Number.isInteger(duration) || duration < 1) {
     errors.duration_days = 'Duration must be 1–3,650 days';
   } else if (duration > 3_650) {


### PR DESCRIPTION
Closes #971

## Summary
- Added shared parseCsvNumber helper in csvParser.ts that strips thousands-separator commas before parsing, preventing values like 1,825 from being silently truncated to 1.
- Updated validateRow to use parseCsvNumber for all three numeric fields (depositAmount, accrualRatePerDay, durationDays) for consistent parsing.
- Updated handleBulkSubmit in CreateStreamModal.tsx to use parseCsvNumber for durationDays and depositAmount.

## Testing
- Added unit tests for parseCsvNumber covering commas, decimals, whitespace, NaN edge cases.
- All 82 CSV parser tests pass.