### PR TITLE
fix: auto-focus Cancel instead of destructive Confirm Action in VoiceConfirmModal

### DIFF
--- a/src/components/voice/VoiceConfirmModal.tsx
+++ b/src/components/voice/VoiceConfirmModal.tsx
@@ -11,16 +11,18 @@ export const VoiceConfirmModal: React.FC = () => {
   } = useVoiceContext();
 
   const confirmBtnRef = useRef<HTMLButtonElement>(null);
+  const cancelBtnRef = useRef<HTMLButtonElement>(null);
   const dialogRef = useRef<HTMLDivElement>(null);
 
   const isOpen =
     state === "confirming-destructive" && pendingDestructiveCommand !== null;
 
-  // Auto focus confirm button when opened
+  // Auto focus Cancel button when opened (safe default — prevents accidental
+  // destructive action via reflexive Enter/Space press)
   useEffect(() => {
     if (isOpen) {
       setTimeout(() => {
-        confirmBtnRef.current?.focus();
+        cancelBtnRef.current?.focus();
       }, 50);
     }
   }, [isOpen]);
@@ -159,6 +161,7 @@ export const VoiceConfirmModal: React.FC = () => {
             Confirm Action
           </button>
           <button
+            ref={cancelBtnRef}
             type="button"
             onClick={cancelDestructiveAction}
             className="py-3 px-4 rounded-xl bg-[var(--surface-sunken)] border border-[var(--border-neutral)] text-[var(--text-vivid)] hover:bg-[var(--surface-elevated)] font-semibold text-sm transition-colors outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"

--- a/src/components/voice/__tests__/VoiceConfirmModal.test.tsx
+++ b/src/components/voice/__tests__/VoiceConfirmModal.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { VoiceConfirmModal } from "../VoiceConfirmModal";
 import { VoiceContextValue, VoiceCommandDef } from "../voiceTypes";
@@ -127,6 +127,33 @@ describe("VoiceConfirmModal", () => {
     expect(cancelFn).toHaveBeenCalledTimes(1);
   });
 
+  // -- Initial focus on Cancel button (safe default) ---------------------
+
+  it("focuses the Cancel button when the modal opens", async () => {
+    vi.useFakeTimers();
+    mockContext = buildContext({
+      state: "confirming-destructive",
+      pendingDestructiveCommand: destructiveCmd,
+    });
+
+    render(<VoiceConfirmModal />);
+
+    // The modal uses a setTimeout(..., 50) to focus the Cancel button
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    const cancelButton = screen.getByRole("button", { name: /^Cancel$/i });
+    expect(cancelButton).toHaveFocus();
+
+    // Confirm Action should still be reachable via Tab
+    const confirmButton = screen.getByRole("button", { name: /confirm action/i });
+    expect(confirmButton).toBeInTheDocument();
+    expect(confirmButton).not.toHaveFocus();
+
+    vi.useRealTimers();
+  });
+
   // -- Confirm/Cancel buttons --------------------------------------------
 
   it("calls confirmDestructiveAction on confirm button click", () => {
@@ -161,6 +188,10 @@ describe("VoiceConfirmModal", () => {
     });
 
     render(<VoiceConfirmModal />);
+
+    // Wait for the auto-focus setTimeout to fire, then manually place focus
+    // on the close button to start a deterministic tab sequence
+    await new Promise((r) => setTimeout(r, 100));
 
     const dialog = screen.getByRole("dialog");
     const closeButton = screen.getByRole("button", { name: /cancel destructive action/i });

--- a/src/components/voice/__tests__/VoiceConfirmModal.test.tsx
+++ b/src/components/voice/__tests__/VoiceConfirmModal.test.tsx
@@ -117,12 +117,12 @@ describe("VoiceConfirmModal", () => {
       cancelDestructiveAction: cancelFn,
     });
     const { unmount } = render(<VoiceConfirmModal />);
-    // First Escape while mounted � should fire
+    // First Escape while mounted — should fire
     window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
     expect(cancelFn).toHaveBeenCalledTimes(1);
 
     unmount();
-    // Second Escape after unmount � should not fire
+    // Second Escape after unmount — should not fire
     window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
     expect(cancelFn).toHaveBeenCalledTimes(1);
   });
@@ -181,7 +181,9 @@ describe("VoiceConfirmModal", () => {
   });
 
   it("wraps focus between the dialog actions when tabbing forward and backward", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
     const user = userEvent.setup();
+
     mockContext = buildContext({
       state: "confirming-destructive",
       pendingDestructiveCommand: destructiveCmd,
@@ -189,9 +191,9 @@ describe("VoiceConfirmModal", () => {
 
     render(<VoiceConfirmModal />);
 
-    // Wait for the auto-focus setTimeout to fire, then manually place focus
-    // on the close button to start a deterministic tab sequence
-    await new Promise((r) => setTimeout(r, 100));
+    // advanceTimersByTimeAsync flushes microtasks between each tick,
+    // so the auto-focus setTimeout fires deterministically before we start
+    await vi.advanceTimersByTimeAsync(100);
 
     const dialog = screen.getByRole("dialog");
     const closeButton = screen.getByRole("button", { name: /cancel destructive action/i });
@@ -220,5 +222,7 @@ describe("VoiceConfirmModal", () => {
     expect(closeButton).toHaveFocus();
 
     expect(dialog as HTMLElement).toContainElement(document.activeElement as HTMLElement);
+
+    vi.useRealTimers();
   });
 });


### PR DESCRIPTION
Closes #975

## Summary
- Changed auto-focus target from confirmBtnRef to cancelBtnRef so the safe Cancel button receives initial focus when the confirmation dialog opens.
- Confirm Action remains reachable and functional via Tab.
- Added regression test verifying Cancel receives initial focus while Confirm remains reachable.

## Testing
- All 12 VoiceConfirmModal tests pass.