### PR TITLE
fix(receipt): use configured network and full explorer URL in PNG receipts

### DIFF
--- a/src/components/Streams/StreamCreatedModal.tsx
+++ b/src/components/Streams/StreamCreatedModal.tsx
@@ -5,6 +5,7 @@ import { useModalAccessibility } from "../useModalAccessibility";
 import { useOptionalTheme } from "../../theme/ThemeProvider";
 import { TransactionReceiptPreview } from "../receipt/TransactionReceiptPreview";
 import { useClipboard } from "../../hooks/useClipboard";
+import { config } from "../../lib/config";
 
 interface StreamCreatedModalProps {
   isOpen: boolean;
@@ -274,6 +275,7 @@ export default function StreamCreatedModal({
               timestamp: new Date().toISOString(),
               txHash: txHash || null,
               status: txHash ? "confirmed" : "pending",
+              network: config.networkLabel,
             }}
           />
         </div>

--- a/src/pages/Recipient.tsx
+++ b/src/pages/Recipient.tsx
@@ -12,6 +12,7 @@ import { withdraw } from "../lib/stellar/tx";
 import { getStreamStatusNotificationContent } from "../components/ToastNotification";
 import { TransactionReceiptPreview } from "../components/receipt/TransactionReceiptPreview";
 import type { ReceiptData } from "../utils/receiptGenerator";
+import { config } from "../lib/config";
 import { Shield, Fingerprint, Lock, Key, CheckCircle2, XCircle, AlertCircle, X } from "lucide-react";
 import RecipientMonthlySummary from "../components/recipient/RecipientMonthlySummary";
 import "./Streams.css";
@@ -560,7 +561,7 @@ export default function Recipient() {
         timestamp: new Date().toISOString(),
         txHash: typeof txRes === "string" ? txRes : null,
         status: typeof txRes === "string" ? "confirmed" : "pending",
-        network: wallet.network || "Stellar Testnet",
+        network: config.networkLabel,
       };
       setReceiptData(newReceipt);
       setShowReceiptModal(true);

--- a/src/utils/__tests__/receiptGenerator.test.ts
+++ b/src/utils/__tests__/receiptGenerator.test.ts
@@ -3,8 +3,32 @@ import {
   maskAddress,
   formatTimestamp,
   drawReceiptToCanvas,
+  buildReceiptExplorerUrl,
+  resolveReceiptNetworkLabel,
+  resolveReceiptExplorerSegment,
   ReceiptData,
 } from "../receiptGenerator";
+
+function createMockContext() {
+  return {
+    fillRect: vi.fn(),
+    strokeRect: vi.fn(),
+    beginPath: vi.fn(),
+    arc: vi.fn(),
+    fill: vi.fn(),
+    fillText: vi.fn(),
+    stroke: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    rect: vi.fn(),
+    measureText: vi.fn((text: string) => ({ width: text.length * 7 })),
+    fillStyle: "",
+    strokeStyle: "",
+    lineWidth: 0,
+    font: "",
+    textAlign: "",
+  } as unknown as CanvasRenderingContext2D;
+}
 
 describe("receiptGenerator utility", () => {
   it("formats maskAddress for compact display", () => {
@@ -20,25 +44,22 @@ describe("receiptGenerator utility", () => {
     expect(ts).toBe("2026-07-23 17:48:21 UTC");
   });
 
-  it("draws receipt to canvas for confirmed and pending states without throwing", () => {
-    const mockContext = {
-      fillRect: vi.fn(),
-      strokeRect: vi.fn(),
-      beginPath: vi.fn(),
-      arc: vi.fn(),
-      fill: vi.fn(),
-      fillText: vi.fn(),
-      stroke: vi.fn(),
-      moveTo: vi.fn(),
-      lineTo: vi.fn(),
-      rect: vi.fn(),
-      fillStyle: "",
-      strokeStyle: "",
-      lineWidth: 0,
-      font: "",
-      textAlign: "",
-    } as unknown as CanvasRenderingContext2D;
+  it("resolves network label and explorer segment from configured values", () => {
+    expect(resolveReceiptNetworkLabel("Public Network (Mainnet)")).toBe(
+      "Public Network (Mainnet)",
+    );
+    expect(resolveReceiptExplorerSegment("PUBLIC")).toBe("public");
+    expect(resolveReceiptExplorerSegment("Public Network (Mainnet)")).toBe(
+      "public",
+    );
+    expect(resolveReceiptExplorerSegment("Testnet")).toBe("testnet");
+    expect(
+      buildReceiptExplorerUrl("abc123hash", "Public Network (Mainnet)"),
+    ).toBe("https://stellar.expert/explorer/public/tx/abc123hash");
+  });
 
+  it("draws receipt to canvas for confirmed and pending states without throwing", () => {
+    const mockContext = createMockContext();
     const canvas = document.createElement("canvas");
     vi.spyOn(canvas, "getContext").mockReturnValue(mockContext);
 
@@ -67,5 +88,71 @@ describe("receiptGenerator utility", () => {
 
     expect(() => drawReceiptToCanvas(canvas, confirmedData)).not.toThrow();
     expect(() => drawReceiptToCanvas(canvas, pendingData)).not.toThrow();
+  });
+
+  it("draws the configured network label and a complete explorer URL with tx hash", () => {
+    const mockContext = createMockContext();
+    const fillText = mockContext.fillText as ReturnType<typeof vi.fn>;
+    const canvas = document.createElement("canvas");
+    vi.spyOn(canvas, "getContext").mockReturnValue(mockContext);
+
+    const txHash =
+      "c7b91a8f902183b271a1b2c3d4e5f678901234567890abcdef1234567890ab";
+    const confirmedData: ReceiptData = {
+      streamId: "STR-101",
+      type: "Creation",
+      sender: "GAB12345678901234567890123456789012345678901234567890123",
+      recipient: "GCD12345678901234567890123456789012345678901234567890123",
+      amount: "10,000.00 USDC",
+      rate: "0.0261 USDC/sec",
+      timestamp: "2026-07-23T17:48:21Z",
+      txHash,
+      status: "confirmed",
+      network: "Public Network (Mainnet)",
+    };
+
+    drawReceiptToCanvas(canvas, confirmedData);
+
+    const drawnText = fillText.mock.calls.map((call) => String(call[0]));
+    expect(drawnText).toContain("Public Network (Mainnet)");
+    expect(drawnText).toContain(
+      `Explorer: https://stellar.expert/explorer/public/tx/${txHash}`,
+    );
+    expect(drawnText.some((t) => t.includes("Stellar Testnet"))).toBe(false);
+    expect(
+      drawnText.some(
+        (t) =>
+          t.startsWith("Explorer:") &&
+          t.includes("/tx/") &&
+          !t.includes(txHash),
+      ),
+    ).toBe(false);
+  });
+
+  it("uses the app-configured network label when callers omit data.network", () => {
+    const mockContext = createMockContext();
+    const fillText = mockContext.fillText as ReturnType<typeof vi.fn>;
+    const canvas = document.createElement("canvas");
+    vi.spyOn(canvas, "getContext").mockReturnValue(mockContext);
+
+    const txHash = "deadbeefcafe0123456789";
+    drawReceiptToCanvas(canvas, {
+      streamId: "STR-103",
+      type: "Withdrawal",
+      sender: "Treasury",
+      recipient: "GCD12345678901234567890123456789012345678901234567890123",
+      amount: "100 USDC",
+      timestamp: "2026-07-23T17:48:21Z",
+      txHash,
+      status: "confirmed",
+    });
+
+    const drawnText = fillText.mock.calls.map((call) => String(call[0]));
+    const expectedNetwork = resolveReceiptNetworkLabel();
+    const expectedSegment = resolveReceiptExplorerSegment();
+    expect(drawnText).toContain(expectedNetwork);
+    expect(drawnText).toContain(
+      `Explorer: https://stellar.expert/explorer/${expectedSegment}/tx/${txHash}`,
+    );
   });
 });

--- a/src/utils/receiptGenerator.ts
+++ b/src/utils/receiptGenerator.ts
@@ -9,6 +9,13 @@
  * - Handles hash-pending ("Pending confirmation") and hash-confirmed states.
  */
 
+import {
+  getExpectedStellarNetwork,
+  getNetworkExplorerPath,
+  normalizeStellarNetwork,
+} from "../lib/stellarNetwork";
+import { getNetworkLabel } from "../lib/config";
+
 export interface ReceiptData {
   streamId: string;
   type: "Creation" | "Withdrawal";
@@ -20,6 +27,49 @@ export interface ReceiptData {
   txHash?: string | null;
   status: "confirmed" | "pending";
   network?: string;
+}
+
+/**
+ * Resolves the human-readable network label shown on the receipt.
+ * Prefer an explicit `data.network` from callers; otherwise use the app config.
+ */
+export function resolveReceiptNetworkLabel(
+  network?: string | null,
+): string {
+  const trimmed = network?.trim();
+  if (trimmed) return trimmed;
+  return getNetworkLabel(getExpectedStellarNetwork());
+}
+
+/**
+ * Maps a receipt network value (code or label) to a stellar.expert path segment.
+ */
+export function resolveReceiptExplorerSegment(
+  network?: string | null,
+): string {
+  const normalized = normalizeStellarNetwork(network);
+  if (normalized) return getNetworkExplorerPath(normalized);
+
+  const label = network?.trim().toLowerCase() ?? "";
+  if (label.includes("public") || label.includes("mainnet")) {
+    return getNetworkExplorerPath("PUBLIC");
+  }
+  if (label.includes("test")) {
+    return getNetworkExplorerPath("TESTNET");
+  }
+
+  return getNetworkExplorerPath(getExpectedStellarNetwork());
+}
+
+/**
+ * Builds a complete stellar.expert transaction explorer URL for receipt text.
+ */
+export function buildReceiptExplorerUrl(
+  txHash: string,
+  network?: string | null,
+): string {
+  const segment = resolveReceiptExplorerSegment(network);
+  return `https://stellar.expert/explorer/${segment}/tx/${txHash}`;
 }
 
 export function formatTimestamp(isoOrTimestamp?: string): string {
@@ -171,7 +221,7 @@ export function drawReceiptToCanvas(
 
   drawRow(415, "Sender Account", data.sender);
   drawRow(475, "Recipient Beneficiary", data.recipient);
-  drawRow(535, "Network / Ledger", data.network || "Stellar Testnet");
+  drawRow(535, "Network / Ledger", resolveReceiptNetworkLabel(data.network));
 
   // 5. TRANSACTION HASH VERIFICATION BLOCK
   ctx.fillStyle = "#94A3B8";
@@ -205,8 +255,12 @@ export function drawReceiptToCanvas(
     ctx.fillText(data.txHash || "—", 90, 695);
 
     ctx.fillStyle = "#94A3B8";
-    ctx.font = "12px -apple-system, BlinkMacSystemFont, sans-serif";
-    ctx.fillText("Explorer: https://stellar.expert/explorer/testnet/tx/", 90, 725);
+    ctx.font = "11px monospace";
+    ctx.fillText(
+      `Explorer: ${buildReceiptExplorerUrl(data.txHash || "", data.network)}`,
+      90,
+      725,
+    );
   }
 
   // 6. FOOTER & DISCLAIMER


### PR DESCRIPTION
## Overview

This PR fixes hardcoded network and incomplete explorer URL text in downloadable PNG receipts generated by `receiptGenerator.ts`.

## Related Issue

Closes #937

## Changes

### 🧾 Receipt generator

* **[MODIFY]** `src/utils/receiptGenerator.ts`
  * Resolve the "Network / Ledger" row from `ReceiptData.network` (or app config fallback) instead of hardcoding `"Stellar Testnet"`.
  * Print a complete stellar.expert transaction URL that interpolates the configured network segment and `data.txHash`.
  * Add helpers: `resolveReceiptNetworkLabel`, `resolveReceiptExplorerSegment`, `buildReceiptExplorerUrl`.

* **[MODIFY]** `src/components/Streams/StreamCreatedModal.tsx`
  * Populate `ReceiptData.network` from `config.networkLabel` before download.

* **[MODIFY]** `src/pages/Recipient.tsx`
  * Populate withdrawal receipt `network` from `config.networkLabel` instead of wallet network fallback.

* **[ADD]** `src/utils/__tests__/receiptGenerator.test.ts`
  * Assert canvas drawing includes the real network label and full explorer URL with tx hash.

## Verification Results

```
npx vitest run src/utils/__tests__/receiptGenerator.test.ts
✅ 6/6 passed
```

| Acceptance Criteria | Status |
| --- | --- |
| Generated receipt network label reflects configured network | ✅ Uses `config.networkLabel` from callers + config fallback |
| Explorer text includes real transaction hash as complete URL | ✅ `buildReceiptExplorerUrl` interpolates network + hash |
| Test covers both fixes | ✅ Canvas `fillText` assertions in receiptGenerator tests |

Made with [Cursor](https://cursor.com)