### PR TITLE
fix(embed): stabilize responsiveness and lock down edge cases with tests

### DIFF
--- a/src/components/embed/EmbedWidgetLayouts.css
+++ b/src/components/embed/EmbedWidgetLayouts.css
@@ -49,6 +49,13 @@
   border-color: var(--color-info, #3b82f6);
 }
 
+/* Fallback badge for status values not yet recognised by the frontend */
+.embed-widget-status-badge--unknown {
+  background-color: var(--color-surface-elevated, #f0f3f7);
+  color: var(--color-text-secondary, #4a5565);
+  border-color: var(--color-border-default, #e0e6ed);
+}
+
 .embed-widget-metric {
   display: flex;
   flex-direction: column;
@@ -118,7 +125,10 @@
   border-radius: 12px;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
   max-width: 420px;
-  min-width: 300px;
+  /* min-width uses min() so it never exceeds the available container width.
+     At 300px+ the preferred floor applies; in very narrow embed iframes the
+     card flexes down to 100% instead of overflowing its parent. */
+  min-width: min(300px, 100%);
   width: 100%;
 }
 
@@ -199,7 +209,12 @@
   background: var(--color-surface-default, #fafbfc);
   border: 1px solid var(--color-border-default, #e0e6ed);
   border-radius: 8px;
-  min-width: 500px;
+  /* Preferred floor of 500px, but never wider than the container.
+     This lets the banner fit inside any embed iframe without triggering
+     horizontal scroll, while preserving the horizontal layout intention
+     at real 500px+ widths. The ≤640px media query below switches to
+     flex-direction: column and drops min-width entirely for very narrow frames. */
+  min-width: min(500px, 100%);
   max-width: 800px;
   width: 100%;
 }
@@ -270,7 +285,9 @@
   background: var(--color-surface-default, #fafbfc);
   border: 1px solid var(--color-border-default, #e0e6ed);
   border-radius: 8px;
-  min-width: 200px;
+  /* Preferred floor of 200px, capped at 100% so the compact widget never
+     overflows its iframe container in very tight embed slots. */
+  min-width: min(200px, 100%);
   max-width: 300px;
   width: 100%;
 }
@@ -380,5 +397,54 @@
   .embed-widget-card__attribution,
   .embed-widget-compact__attribution {
     color: #000;
+  }
+}
+
+/* ============================================================================
+   Banner Skeleton Layout
+   Mirrors the real banner's responsive structure so there is no layout shift
+   on load: stacked (column) by default, row at ≥640 px.
+   ============================================================================ */
+
+.embed-widget-banner-skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1rem;
+  background: var(--color-surface-default, #fafbfc);
+  border: 1px solid var(--color-border-default, #e0e6ed);
+  border-radius: 8px;
+  width: 100%;
+}
+
+.embed-widget-banner-skeleton__info,
+.embed-widget-banner-skeleton__timeline,
+.embed-widget-banner-skeleton__metrics {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+@media (min-width: 641px) {
+  .embed-widget-banner-skeleton {
+    flex-direction: row;
+    align-items: center;
+    gap: 1.5rem;
+    padding: 0.75rem 1rem;
+  }
+
+  .embed-widget-banner-skeleton__info {
+    min-width: 120px;
+    flex-shrink: 0;
+  }
+
+  .embed-widget-banner-skeleton__timeline {
+    flex: 1;
+    min-width: 200px;
+  }
+
+  .embed-widget-banner-skeleton__metrics {
+    min-width: 120px;
+    flex-shrink: 0;
   }
 }

--- a/src/components/embed/EmbedWidgetLayouts.tsx
+++ b/src/components/embed/EmbedWidgetLayouts.tsx
@@ -264,30 +264,43 @@ interface StatusBadgeProps {
   compact?: boolean;
 }
 
-function StatusBadge({ status, compact = false }: StatusBadgeProps) {
-  const statusConfig = {
-    Active: {
-      label: "Active",
-      className: "embed-widget-status-badge--active",
-      ariaLabel: "Stream status: Active"
-    },
-    Paused: {
-      label: "Paused",
-      className: "embed-widget-status-badge--paused",
-      ariaLabel: "Stream status: Paused"
-    },
-    Completed: {
-      label: "Completed",
-      className: "embed-widget-status-badge--completed",
-      ariaLabel: "Stream status: Completed"
-    }
-  };
+const STATUS_CONFIG: Record<
+  string,
+  { label: string; className: string; ariaLabel: string }
+> = {
+  Active: {
+    label: "Active",
+    className: "embed-widget-status-badge--active",
+    ariaLabel: "Stream status: Active"
+  },
+  Paused: {
+    label: "Paused",
+    className: "embed-widget-status-badge--paused",
+    ariaLabel: "Stream status: Paused"
+  },
+  Completed: {
+    label: "Completed",
+    className: "embed-widget-status-badge--completed",
+    ariaLabel: "Stream status: Completed"
+  }
+};
 
-  const config = statusConfig[status];
+/**
+ * StatusBadge renders a labelled pill for a stream status.
+ *
+ * Unknown status values fall back to a neutral "Unknown" badge so the widget
+ * never crashes if the API introduces a new status the frontend hasn't seen yet.
+ */
+function StatusBadge({ status, compact = false }: StatusBadgeProps) {
+  const config = STATUS_CONFIG[status] ?? {
+    label: String(status),
+    className: "embed-widget-status-badge--unknown",
+    ariaLabel: `Stream status: ${String(status)}`
+  };
 
   return (
     <span
-      className={`embed-widget-status-badge ${config.className} ${compact ? 'compact' : ''}`}
+      className={`embed-widget-status-badge ${config.className} ${compact ? "compact" : ""}`}
       role="status"
       aria-label={config.ariaLabel}
     >

--- a/src/components/embed/__tests__/EmbedWidgetLayouts.test.tsx
+++ b/src/components/embed/__tests__/EmbedWidgetLayouts.test.tsx
@@ -231,7 +231,10 @@ describe('EmbedWidgetLayouts', () => {
     it('card layout has responsive metrics grid', () => {
       render(<EmbedWidgetLayoutCard {...commonProps} />);
 
-      const metricsContainer = screen.getByText('$5,000/month').closest('.embed-widget-card__metrics');
+      // formatNumber does not prefix a dollar sign; asset label follows the number.
+      const metricsContainer = screen
+        .getByText('5,000 USDC/month')
+        .closest('.embed-widget-card__metrics');
       expect(metricsContainer).toBeInTheDocument();
     });
 
@@ -271,9 +274,163 @@ describe('EmbedWidgetLayouts', () => {
         <EmbedWidgetLayoutCard {...commonProps} stream={largeStream} />
       );
 
-      expect(screen.getByText(/9,007,199,254,740,991/)).toBeInTheDocument();
+      // Card has 3 metric values that all contain the MAX_SAFE_INTEGER digits
+      const cardMatches = screen.getAllByText(/9,007,199,254,740,991/);
+      expect(cardMatches.length).toBeGreaterThanOrEqual(1);
+
       rerender(<EmbedWidgetLayoutBanner {...commonProps} stream={largeStream} />);
-      expect(screen.getByText(/9,007,199,254,740,991/)).toBeInTheDocument();
+      const bannerMatches = screen.getAllByText(/9,007,199,254,740,991/);
+      expect(bannerMatches.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('StatusBadge unknown status fallback', () => {
+    it('renders a neutral badge for an unrecognised status without crashing', () => {
+      // Cast through unknown to simulate a future API value the frontend
+      // has not mapped yet.
+      const unknownStream = {
+        ...mockStream,
+        status: 'Cancelled' as unknown as typeof mockStream.status,
+      };
+      render(<EmbedWidgetLayoutCard {...commonProps} stream={unknownStream} />);
+
+      const badge = screen.getByRole('status');
+      expect(badge).toBeInTheDocument();
+      expect(badge).toHaveTextContent('Cancelled');
+      expect(badge).toHaveAttribute('aria-label', 'Stream status: Cancelled');
+      expect(badge).toHaveClass('embed-widget-status-badge--unknown');
+    });
+
+    it('compact mode renders first character of unknown status', () => {
+      const unknownStream = {
+        ...mockStream,
+        status: 'Cancelled' as unknown as typeof mockStream.status,
+      };
+      render(<EmbedWidgetLayoutCompact {...commonProps} stream={unknownStream} />);
+
+      const badge = screen.getByRole('status');
+      expect(badge).toHaveTextContent('C');
+      expect(badge).toHaveClass('embed-widget-status-badge--unknown');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Progress boundary values: 0% and 100%
+  // -------------------------------------------------------------------------
+  describe('Progress boundary values', () => {
+    it('card layout renders 0% progress without crashing', () => {
+      render(<EmbedWidgetLayoutCard {...commonProps} stream={{ ...mockStream, progress: 0 }} />);
+      expect(screen.getByText('0%')).toBeInTheDocument();
+      const progressBar = screen.getByRole('progressbar');
+      expect(progressBar).toHaveAttribute('aria-valuenow', '0');
+      const fill = progressBar.querySelector('[class*="progress-fill"]');
+      expect(fill).toHaveStyle({ width: '0%' });
+    });
+
+    it('card layout renders 100% progress without crashing', () => {
+      render(<EmbedWidgetLayoutCard {...commonProps} stream={{ ...mockStream, progress: 100 }} />);
+      expect(screen.getByText('100%')).toBeInTheDocument();
+      const progressBar = screen.getByRole('progressbar');
+      expect(progressBar).toHaveAttribute('aria-valuenow', '100');
+      const fill = progressBar.querySelector('[class*="progress-fill"]');
+      expect(fill).toHaveStyle({ width: '100%' });
+    });
+
+    it('banner layout renders 0% progress without crashing', () => {
+      render(<EmbedWidgetLayoutBanner {...commonProps} stream={{ ...mockStream, progress: 0 }} />);
+      expect(screen.getByText('0%')).toBeInTheDocument();
+      const progressBar = screen.getByRole('progressbar');
+      expect(progressBar).toHaveAttribute('aria-valuenow', '0');
+    });
+
+    it('banner layout renders 100% progress without crashing', () => {
+      render(<EmbedWidgetLayoutBanner {...commonProps} stream={{ ...mockStream, progress: 100 }} />);
+      expect(screen.getByText('100%')).toBeInTheDocument();
+      const progressBar = screen.getByRole('progressbar');
+      expect(progressBar).toHaveAttribute('aria-valuenow', '100');
+    });
+
+    it('compact layout renders 0% progress without crashing', () => {
+      render(<EmbedWidgetLayoutCompact {...commonProps} stream={{ ...mockStream, progress: 0 }} />);
+      expect(screen.getByText('0%')).toBeInTheDocument();
+      const progressBar = screen.getByRole('progressbar');
+      expect(progressBar).toHaveAttribute('aria-valuenow', '0');
+    });
+
+    it('compact layout renders 100% progress without crashing', () => {
+      render(<EmbedWidgetLayoutCompact {...commonProps} stream={{ ...mockStream, progress: 100 }} />);
+      expect(screen.getByText('100%')).toBeInTheDocument();
+      const progressBar = screen.getByRole('progressbar');
+      expect(progressBar).toHaveAttribute('aria-valuenow', '100');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // cliffDate absent (undefined) — optional field must not crash any layout
+  // -------------------------------------------------------------------------
+  describe('Optional cliffDate field', () => {
+    const streamWithoutCliff = { ...mockStream, cliffDate: undefined as unknown as string };
+
+    it('card layout does not crash when cliffDate is undefined', () => {
+      expect(() =>
+        render(<EmbedWidgetLayoutCard {...commonProps} stream={streamWithoutCliff} />)
+      ).not.toThrow();
+      expect(screen.getByRole('article')).toBeInTheDocument();
+    });
+
+    it('banner layout does not crash when cliffDate is undefined', () => {
+      expect(() =>
+        render(<EmbedWidgetLayoutBanner {...commonProps} stream={streamWithoutCliff} />)
+      ).not.toThrow();
+      expect(screen.getByRole('article')).toBeInTheDocument();
+    });
+
+    it('compact layout does not crash when cliffDate is undefined', () => {
+      expect(() =>
+        render(<EmbedWidgetLayoutCompact {...commonProps} stream={streamWithoutCliff} />)
+      ).not.toThrow();
+      expect(screen.getByRole('article')).toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Deterministic CSS class names — regression guard for layout identity
+  // -------------------------------------------------------------------------
+  describe('Layout CSS class stability', () => {
+    it('card root element has class embed-widget-card', () => {
+      render(<EmbedWidgetLayoutCard {...commonProps} />);
+      expect(screen.getByRole('article')).toHaveClass('embed-widget-card');
+    });
+
+    it('banner root element has class embed-widget-banner', () => {
+      render(<EmbedWidgetLayoutBanner {...commonProps} />);
+      expect(screen.getByRole('article')).toHaveClass('embed-widget-banner');
+    });
+
+    it('compact root element has class embed-widget-compact', () => {
+      render(<EmbedWidgetLayoutCompact {...commonProps} />);
+      expect(screen.getByRole('article')).toHaveClass('embed-widget-compact');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Completed status renders correctly across presets
+  // -------------------------------------------------------------------------
+  describe('Completed stream status across all presets', () => {
+    const completedStream = { ...mockStream, status: 'Completed' as const, progress: 100 };
+
+    it('card layout shows Completed status badge and 100%', () => {
+      render(<EmbedWidgetLayoutCard {...commonProps} stream={completedStream} />);
+      const badge = screen.getByText('Completed');
+      expect(badge).toHaveClass('embed-widget-status-badge--completed');
+      expect(screen.getByText('100%')).toBeInTheDocument();
+    });
+
+    it('banner layout shows compact Completed status badge (C) and 100%', () => {
+      render(<EmbedWidgetLayoutBanner {...commonProps} stream={completedStream} />);
+      const badge = screen.getByText('C');
+      expect(badge).toHaveClass('embed-widget-status-badge--completed');
+      expect(screen.getByText('100%')).toBeInTheDocument();
     });
   });
 });

--- a/src/pages/EmbedStreamWidget.tsx
+++ b/src/pages/EmbedStreamWidget.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useMemo } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useParams, useSearchParams } from "react-router-dom";
 import { Skeleton } from "../components/Skeleton";
 import { useTickingNow } from "../hooks/useTickingNow";
@@ -27,7 +27,7 @@ import { useEmbedAccessibility } from "../hooks/useEmbedAccessibility";
  * - Three responsive widget presets
  * - Theme query parameter support
  * - Accessible document structure
- * - All UI states (loading, live, paused, completed, error)
+ * - All UI states (loading, live, paused, completed, error, retry)
  * 
  * Security:
  * - Validates theme/accent query parameters
@@ -40,8 +40,22 @@ export default function EmbedStreamWidget() {
   const [stream, setStream] = useState<StreamRecord | null | undefined>(undefined);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
-  const currentDate = useTickingNow();
-  
+  // retryCount is bumped by the retry button and used as a useEffect dependency
+  // so a re-fetch is triggered without remounting the component.
+  const [retryCount, setRetryCount] = useState(0);
+
+  const tickingNow = useTickingNow();
+
+  /**
+   * Derive a stable YYYY-MM-DD date string from the ticking timestamp.
+   * Memoized so the value only changes when the underlying date actually
+   * crosses a day boundary — not on every render.
+   */
+  const currentDate = useMemo(
+    () => new Date(tickingNow).toISOString().split("T")[0],
+    [tickingNow]
+  );
+
   // Parse theme configuration from query parameters
   const themeConfig = useMemo<ThemeConfig>(() => ({
     theme: parseThemeFromQuery(searchParams.get("theme")),
@@ -59,8 +73,13 @@ export default function EmbedStreamWidget() {
   useEffect(() => {
     return applyThemeConfigSafely(themeConfig);
   }, [themeConfig]);
+
+  // Stable retry callback — does not close over changing state.
+  const handleRetry = useCallback(() => {
+    setRetryCount((n) => n + 1);
+  }, []);
   
-  // Fetch stream data
+  // Fetch stream data; re-runs when streamId changes or user clicks retry.
   useEffect(() => {
     if (!streamId) {
       setStream(null);
@@ -95,7 +114,9 @@ export default function EmbedStreamWidget() {
       cancelled = true;
       controller.abort();
     };
-  }, [streamId]);
+    // retryCount intentionally included so clicking retry re-runs the fetch.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [streamId, retryCount]);
   
   // Setup embed accessibility
   useEmbedAccessibility({
@@ -112,22 +133,24 @@ export default function EmbedStreamWidget() {
     );
   }
   
-  // Error state (invalid stream ID)
+  // Error state (invalid stream ID or network error)
   if (error || !stream) {
     return (
       <EmbedWidgetContainer widgetPreset={widgetPreset} themeConfig={themeConfig}>
         <EmbedWidgetErrorState 
           error={error || "Stream not found"}
           widgetPreset={widgetPreset}
+          // Only offer a retry when we have a streamId to retry against.
+          onRetry={streamId ? handleRetry : undefined}
         />
       </EmbedWidgetContainer>
     );
   }
   
-  // Success state - render appropriate widget layout
+  // Success state — render appropriate widget layout
   const widgetProps = {
     stream,
-    currentDate: new Date(currentDate).toISOString().split("T")[0],
+    currentDate,
     themeConfig
   };
   
@@ -144,13 +167,24 @@ export default function EmbedStreamWidget() {
   );
 }
 
-// Container component for embed widget
+// ---------------------------------------------------------------------------
+// Container
+// ---------------------------------------------------------------------------
+
 interface EmbedWidgetContainerProps {
   children: React.ReactNode;
   widgetPreset: "card" | "banner" | "compact";
   themeConfig: ThemeConfig;
 }
 
+/**
+ * Outer wrapper for every widget state (loading / error / success).
+ *
+ * Width constraints are intentionally kept in CSS (EmbedWidgetLayouts.css) so
+ * that media-query overrides work correctly.  Only non-dimension, non-layout
+ * properties that can't be expressed in static CSS are applied here as inline
+ * styles.
+ */
 function EmbedWidgetContainer({ 
   children, 
   widgetPreset, 
@@ -160,19 +194,15 @@ function EmbedWidgetContainer({
     <div 
       className="embed-widget-container"
       data-widget-preset={widgetPreset}
-      data-theme={themeConfig.theme}
+      data-theme={themeConfig.theme ?? undefined}
       data-accent-color={themeConfig.accentColor ? "custom" : "default"}
       style={{
-        // Ensure container is at least as wide as the widget needs
-        minWidth: widgetPreset === "card" ? "300px" : 
-                  widgetPreset === "compact" ? "200px" : "500px",
-        // Allow responsive scaling
+        // width: 100% lets the inner layout element own its own min/max-width
+        // rules via CSS, avoiding inline-style vs. stylesheet specificity fights.
         width: "100%",
         height: "auto",
-        // Apply theme-aware background
         backgroundColor: "var(--color-bg-primary, #ffffff)",
         color: "var(--color-text-primary, #1a1f36)",
-        // Ensure proper isolation
         isolation: "isolate"
       }}
     >
@@ -181,15 +211,31 @@ function EmbedWidgetContainer({
   );
 }
 
+// ---------------------------------------------------------------------------
 // Skeleton loading state
+// ---------------------------------------------------------------------------
+
 interface EmbedWidgetSkeletonProps {
   widgetPreset: "card" | "banner" | "compact";
 }
 
+/**
+ * Skeleton placeholders that mirror the real layout's structure so there is no
+ * visible layout shift on load.
+ *
+ * The banner preset stacks vertically on narrow screens (≤640 px) in CSS, so
+ * the skeleton matches that stacked structure by default and lets CSS handle
+ * the flex-row reflow at wider widths — the same strategy the real banner uses.
+ */
 function EmbedWidgetSkeleton({ widgetPreset }: EmbedWidgetSkeletonProps) {
   if (widgetPreset === "compact") {
     return (
-      <div role="status" aria-label="Loading stream widget" aria-busy="true">
+      <div
+        role="status"
+        aria-label="Loading stream widget"
+        aria-busy="true"
+        data-testid="embed-skeleton-compact"
+      >
         <Skeleton width="100%" height={80} borderRadius={8} />
       </div>
     );
@@ -197,12 +243,28 @@ function EmbedWidgetSkeleton({ widgetPreset }: EmbedWidgetSkeletonProps) {
   
   if (widgetPreset === "banner") {
     return (
-      <div role="status" aria-label="Loading stream widget" aria-busy="true">
-        <div style={{ display: "flex", gap: "1rem", alignItems: "center" }}>
-          <Skeleton width={120} height={20} />
-          <Skeleton width={80} height={20} />
+      <div
+        role="status"
+        aria-label="Loading stream widget"
+        aria-busy="true"
+        data-testid="embed-skeleton-banner"
+        // Stack vertically by default; CSS widens to a flex-row at ≥640 px,
+        // matching the real banner's responsive behaviour.
+        className="embed-widget-banner-skeleton"
+      >
+        {/* Info column */}
+        <div className="embed-widget-banner-skeleton__info">
+          <Skeleton width="60%" height={14} />
+          <Skeleton width={40} height={20} borderRadius={9999} />
+        </div>
+        {/* Timeline column */}
+        <div className="embed-widget-banner-skeleton__timeline">
           <Skeleton width="100%" height={40} />
-          <Skeleton width={60} height={20} />
+        </div>
+        {/* Metrics column */}
+        <div className="embed-widget-banner-skeleton__metrics">
+          <Skeleton width={80} height={14} />
+          <Skeleton width="100%" height={6} borderRadius={3} />
         </div>
       </div>
     );
@@ -210,7 +272,12 @@ function EmbedWidgetSkeleton({ widgetPreset }: EmbedWidgetSkeletonProps) {
   
   // Card preset (default)
   return (
-    <div role="status" aria-label="Loading stream widget" aria-busy="true">
+    <div
+      role="status"
+      aria-label="Loading stream widget"
+      aria-busy="true"
+      data-testid="embed-skeleton-card"
+    >
       <Skeleton width="80%" height={24} style={{ marginBottom: "0.75rem" }} />
       <Skeleton width="60%" height={16} style={{ marginBottom: "1.5rem" }} />
       <Skeleton width="100%" height={80} style={{ marginBottom: "1rem" }} />
@@ -223,19 +290,25 @@ function EmbedWidgetSkeleton({ widgetPreset }: EmbedWidgetSkeletonProps) {
   );
 }
 
-// Error state component
+// ---------------------------------------------------------------------------
+// Error state
+// ---------------------------------------------------------------------------
+
 interface EmbedWidgetErrorStateProps {
   error: string;
   widgetPreset: "card" | "banner" | "compact";
+  /** When provided, a retry button is rendered. */
+  onRetry?: () => void;
 }
 
-function EmbedWidgetErrorState({ error, widgetPreset }: EmbedWidgetErrorStateProps) {
+function EmbedWidgetErrorState({ error, widgetPreset, onRetry }: EmbedWidgetErrorStateProps) {
   const isCompact = widgetPreset === "compact";
   
   return (
     <div 
       role="alert" 
       aria-live="assertive"
+      data-testid="embed-error-state"
       style={{
         padding: isCompact ? "0.5rem" : "1rem",
         backgroundColor: "var(--color-error-bg, #fef2f2)",
@@ -263,9 +336,31 @@ function EmbedWidgetErrorState({ error, widgetPreset }: EmbedWidgetErrorStatePro
         </svg>
         <span>Stream unavailable: {error}</span>
       </div>
+
+      {/* Retry button — only shown when a retry handler is provided */}
+      {onRetry && !isCompact && (
+        <div style={{ marginTop: "0.75rem" }}>
+          <button
+            onClick={onRetry}
+            style={{
+              padding: "0.375rem 0.75rem",
+              fontSize: "0.875rem",
+              fontWeight: 600,
+              borderRadius: "6px",
+              border: "1px solid var(--color-error-border, #dc2626)",
+              backgroundColor: "transparent",
+              color: "var(--color-error-text, #b91c1c)",
+              cursor: "pointer",
+            }}
+          >
+            Try again
+          </button>
+        </div>
+      )}
+
       {!isCompact && (
         <div style={{ 
-          marginTop: "0.5rem", 
+          marginTop: onRetry ? "0.25rem" : "0.5rem",
           fontSize: "0.875rem",
           opacity: 0.8 
         }}>

--- a/src/pages/__tests__/EmbedStreamWidget.test.tsx
+++ b/src/pages/__tests__/EmbedStreamWidget.test.tsx
@@ -437,4 +437,509 @@ describe('EmbedStreamWidget', () => {
       });
     });
   });
+
+  // -------------------------------------------------------------------------
+  // Missing streamId (undefined) path
+  // -------------------------------------------------------------------------
+  describe('Missing streamId', () => {
+    it('shows error state immediately when streamId is absent — no fetch is attempted', async () => {
+      // Render the route without a :streamId segment
+      render(
+        <MemoryRouter initialEntries={['/embed/streams/']}>
+          <Routes>
+            {/* Route without :streamId — component receives undefined */}
+            <Route path="/embed/streams/" element={<EmbedStreamWidget />} />
+          </Routes>
+        </MemoryRouter>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toBeInTheDocument();
+        expect(screen.getByText(/Stream unavailable/)).toBeInTheDocument();
+      });
+
+      // getStreamById must not have been called
+      expect(getStreamById).not.toHaveBeenCalled();
+    });
+
+    it('does not show a retry button when streamId is absent', async () => {
+      render(
+        <MemoryRouter initialEntries={['/embed/streams/']}>
+          <Routes>
+            <Route path="/embed/streams/" element={<EmbedStreamWidget />} />
+          </Routes>
+        </MemoryRouter>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toBeInTheDocument();
+      });
+
+      expect(screen.queryByRole('button', { name: /try again/i })).not.toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Retry button
+  // -------------------------------------------------------------------------
+  describe('Retry behaviour', () => {
+    it('shows a retry button after a fetch failure', async () => {
+      (getStreamById as any).mockRejectedValue(new Error('Network error'));
+
+      renderEmbedWidget('STR-001');
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
+      });
+    });
+
+    it('retries the fetch when the retry button is clicked', async () => {
+      // First call fails, second call succeeds
+      (getStreamById as any)
+        .mockRejectedValueOnce(new Error('Temporary error'))
+        .mockResolvedValueOnce(mockStream);
+
+      const { userEvent: user } = await import('@testing-library/user-event').then(
+        (m) => ({ userEvent: m.default })
+      );
+      const ue = user.setup();
+
+      renderEmbedWidget('STR-001');
+
+      // Wait for error state
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toBeInTheDocument();
+      });
+
+      // Click retry
+      await ue.click(screen.getByRole('button', { name: /try again/i }));
+
+      // Widget should eventually show success
+      await waitFor(() => {
+        expect(screen.getByRole('article')).toBeInTheDocument();
+        expect(screen.getByText('Test Stream')).toBeInTheDocument();
+      });
+
+      expect(getStreamById).toHaveBeenCalledTimes(2);
+    });
+
+    it('compact error state does not show a retry button', async () => {
+      (getStreamById as any).mockRejectedValue(new Error('Not found'));
+
+      renderEmbedWidget('STR-001', 'preset=compact');
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toBeInTheDocument();
+      });
+
+      // Compact error state intentionally hides the retry button
+      expect(screen.queryByRole('button', { name: /try again/i })).not.toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // currentDate is stable / deterministic across rerenders
+  // -------------------------------------------------------------------------
+  describe('currentDate stability', () => {
+    it('passes a stable YYYY-MM-DD string to the widget layout on rerenders', async () => {
+      // useTickingNow is mocked to return a fixed date, so currentDate should
+      // never change between renders within the same test.
+      (getStreamById as any).mockResolvedValue(mockStream);
+
+      const { rerender } = renderEmbedWidget('STR-001');
+
+      await waitFor(() => {
+        expect(screen.getByRole('article')).toBeInTheDocument();
+      });
+
+      // Force a rerender
+      rerender(
+        <MemoryRouter initialEntries={['/embed/streams/STR-001']}>
+          <Routes>
+            <Route path="/embed/streams/:streamId" element={<EmbedStreamWidget />} />
+          </Routes>
+        </MemoryRouter>
+      );
+
+      // Stream should still be rendered (no extra fetches)
+      expect(screen.getByRole('article')).toBeInTheDocument();
+      // getStreamById called exactly once — no spurious re-fetches
+      expect(getStreamById).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Skeleton variants
+  // -------------------------------------------------------------------------
+  describe('Skeleton data-testid attributes', () => {
+    it('card skeleton has data-testid="embed-skeleton-card"', () => {
+      (getStreamById as any).mockImplementation(() => new Promise(() => {}));
+      renderEmbedWidget('STR-001');
+      expect(screen.getByTestId('embed-skeleton-card')).toBeInTheDocument();
+    });
+
+    it('banner skeleton has data-testid="embed-skeleton-banner"', () => {
+      (getStreamById as any).mockImplementation(() => new Promise(() => {}));
+      renderEmbedWidget('STR-001', 'preset=banner');
+      expect(screen.getByTestId('embed-skeleton-banner')).toBeInTheDocument();
+    });
+
+    it('compact skeleton has data-testid="embed-skeleton-compact"', () => {
+      (getStreamById as any).mockImplementation(() => new Promise(() => {}));
+      renderEmbedWidget('STR-001', 'preset=compact');
+      expect(screen.getByTestId('embed-skeleton-compact')).toBeInTheDocument();
+    });
+
+    it('banner skeleton structure mirrors the stacked banner layout', () => {
+      (getStreamById as any).mockImplementation(() => new Promise(() => {}));
+      renderEmbedWidget('STR-001', 'preset=banner');
+
+      const skeleton = screen.getByTestId('embed-skeleton-banner');
+      // Three structural sub-sections present
+      expect(skeleton.querySelector('.embed-widget-banner-skeleton__info')).toBeInTheDocument();
+      expect(skeleton.querySelector('.embed-widget-banner-skeleton__timeline')).toBeInTheDocument();
+      expect(skeleton.querySelector('.embed-widget-banner-skeleton__metrics')).toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Error state data-testid
+  // -------------------------------------------------------------------------
+  describe('Error state data-testid', () => {
+    it('error state has data-testid="embed-error-state"', async () => {
+      (getStreamById as any).mockRejectedValue(new Error('Server error'));
+      renderEmbedWidget('STR-001');
+
+      await waitFor(() => {
+        expect(screen.getByTestId('embed-error-state')).toBeInTheDocument();
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Preset attribute on container
+  // -------------------------------------------------------------------------
+  describe('Container preset attribute', () => {
+    it.each([
+      ['card', undefined],
+      ['banner', 'preset=banner'],
+      ['compact', 'preset=compact'],
+    ] as const)('%s preset sets data-widget-preset="%s"', async (preset, qs) => {
+      (getStreamById as any).mockResolvedValue(mockStream);
+      renderEmbedWidget('STR-001', qs);
+
+      await waitFor(() => {
+        const container = document.querySelector('.embed-widget-container');
+        expect(container).toHaveAttribute('data-widget-preset', preset);
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Progress boundary values — 0% and 100%
+  // -------------------------------------------------------------------------
+  describe('Progress boundary values', () => {
+    it('card preset renders 0% progress correctly', async () => {
+      (getStreamById as any).mockResolvedValue({ ...mockStream, progress: 0 });
+      renderEmbedWidget('STR-001');
+
+      await waitFor(() => {
+        expect(screen.getByRole('article')).toBeInTheDocument();
+        expect(screen.getByText('0%')).toBeInTheDocument();
+      });
+
+      const progressBar = screen.getByRole('progressbar', { name: /stream progress/i });
+      expect(progressBar).toHaveAttribute('aria-valuenow', '0');
+      // The fill element should have width: 0%
+      const fill = progressBar.querySelector('[class*="progress-fill"]');
+      expect(fill).toHaveStyle({ width: '0%' });
+    });
+
+    it('card preset renders 100% progress correctly', async () => {
+      (getStreamById as any).mockResolvedValue({ ...mockStream, progress: 100 });
+      renderEmbedWidget('STR-001');
+
+      await waitFor(() => {
+        expect(screen.getByText('100%')).toBeInTheDocument();
+      });
+
+      const progressBar = screen.getByRole('progressbar', { name: /stream progress/i });
+      expect(progressBar).toHaveAttribute('aria-valuenow', '100');
+      const fill = progressBar.querySelector('[class*="progress-fill"]');
+      expect(fill).toHaveStyle({ width: '100%' });
+    });
+
+    it('banner preset renders 0% progress correctly', async () => {
+      (getStreamById as any).mockResolvedValue({ ...mockStream, progress: 0 });
+      renderEmbedWidget('STR-001', 'preset=banner');
+
+      await waitFor(() => {
+        expect(screen.getByRole('article')).toBeInTheDocument();
+        expect(screen.getByText('0%')).toBeInTheDocument();
+      });
+
+      const progressBar = screen.getByRole('progressbar', { name: /stream progress/i });
+      expect(progressBar).toHaveAttribute('aria-valuenow', '0');
+    });
+
+    it('banner preset renders 100% progress correctly', async () => {
+      (getStreamById as any).mockResolvedValue({ ...mockStream, progress: 100 });
+      renderEmbedWidget('STR-001', 'preset=banner');
+
+      await waitFor(() => {
+        expect(screen.getByText('100%')).toBeInTheDocument();
+      });
+
+      const progressBar = screen.getByRole('progressbar', { name: /stream progress/i });
+      expect(progressBar).toHaveAttribute('aria-valuenow', '100');
+    });
+
+    it('compact preset renders 0% progress correctly', async () => {
+      (getStreamById as any).mockResolvedValue({ ...mockStream, progress: 0 });
+      renderEmbedWidget('STR-001', 'preset=compact');
+
+      await waitFor(() => {
+        expect(screen.getByText('0%')).toBeInTheDocument();
+      });
+
+      const progressBar = screen.getByRole('progressbar', { name: /stream progress/i });
+      expect(progressBar).toHaveAttribute('aria-valuenow', '0');
+    });
+
+    it('compact preset renders 100% progress correctly', async () => {
+      (getStreamById as any).mockResolvedValue({ ...mockStream, progress: 100 });
+      renderEmbedWidget('STR-001', 'preset=compact');
+
+      await waitFor(() => {
+        expect(screen.getByText('100%')).toBeInTheDocument();
+      });
+
+      const progressBar = screen.getByRole('progressbar', { name: /stream progress/i });
+      expect(progressBar).toHaveAttribute('aria-valuenow', '100');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // cliffDate absent — optional field should not crash any preset
+  // -------------------------------------------------------------------------
+  describe('Stream without cliffDate', () => {
+    const streamWithoutCliff = { ...mockStream, cliffDate: undefined as unknown as string };
+
+    it('card preset renders without crashing when cliffDate is undefined', async () => {
+      (getStreamById as any).mockResolvedValue(streamWithoutCliff);
+      renderEmbedWidget('STR-001');
+
+      await waitFor(() => {
+        expect(screen.getByRole('article')).toBeInTheDocument();
+        expect(screen.getByText('Test Stream')).toBeInTheDocument();
+      });
+    });
+
+    it('banner preset renders without crashing when cliffDate is undefined', async () => {
+      (getStreamById as any).mockResolvedValue(streamWithoutCliff);
+      renderEmbedWidget('STR-001', 'preset=banner');
+
+      await waitFor(() => {
+        expect(screen.getByRole('article')).toBeInTheDocument();
+        expect(screen.getByText('Test Stream')).toBeInTheDocument();
+      });
+    });
+
+    it('compact preset renders without crashing when cliffDate is undefined', async () => {
+      (getStreamById as any).mockResolvedValue(streamWithoutCliff);
+      renderEmbedWidget('STR-001', 'preset=compact');
+
+      await waitFor(() => {
+        expect(screen.getByRole('article')).toBeInTheDocument();
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Unknown / unrecognised preset defaults to card
+  // -------------------------------------------------------------------------
+  describe('Preset fallback for unrecognised values', () => {
+    it('unknown preset falls back to card layout', async () => {
+      (getStreamById as any).mockResolvedValue(mockStream);
+      renderEmbedWidget('STR-001', 'preset=unknown');
+
+      await waitFor(() => {
+        const container = document.querySelector('.embed-widget-container');
+        // Defaults to card
+        expect(container).toHaveAttribute('data-widget-preset', 'card');
+        // Card-specific content is rendered
+        expect(screen.getByText('Powered by Fluxora')).toBeInTheDocument();
+      });
+    });
+
+    it('empty preset string falls back to card layout', async () => {
+      (getStreamById as any).mockResolvedValue(mockStream);
+      renderEmbedWidget('STR-001', 'preset=');
+
+      await waitFor(() => {
+        const container = document.querySelector('.embed-widget-container');
+        expect(container).toHaveAttribute('data-widget-preset', 'card');
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Case-insensitive preset parameter
+  // -------------------------------------------------------------------------
+  describe('Case-insensitive preset parameter', () => {
+    it.each([
+      ['BANNER', 'banner'],
+      ['Banner', 'banner'],
+      ['COMPACT', 'compact'],
+      ['Compact', 'compact'],
+      ['CARD', 'card'],
+      ['Card', 'card'],
+    ])('preset=%s resolves to %s', async (inputPreset, expectedPreset) => {
+      (getStreamById as any).mockResolvedValue(mockStream);
+      renderEmbedWidget('STR-001', `preset=${inputPreset}`);
+
+      await waitFor(() => {
+        const container = document.querySelector('.embed-widget-container');
+        expect(container).toHaveAttribute('data-widget-preset', expectedPreset);
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // data-accent-color="default" when no accent is provided
+  // -------------------------------------------------------------------------
+  describe('data-accent-color attribute', () => {
+    it('sets data-accent-color="default" when no accent-color param is provided', async () => {
+      (getStreamById as any).mockResolvedValue(mockStream);
+      renderEmbedWidget('STR-001');
+
+      await waitFor(() => {
+        const container = document.querySelector('.embed-widget-container');
+        expect(container).toHaveAttribute('data-accent-color', 'default');
+      });
+    });
+
+    it('sets data-accent-color="default" when accent-color param is invalid', async () => {
+      (getStreamById as any).mockResolvedValue(mockStream);
+      renderEmbedWidget('STR-001', 'accent-color=not-a-hex');
+
+      await waitFor(() => {
+        const container = document.querySelector('.embed-widget-container');
+        expect(container).toHaveAttribute('data-accent-color', 'default');
+      });
+    });
+
+    it('sets data-accent-color="custom" when a valid hex accent-color is provided', async () => {
+      (getStreamById as any).mockResolvedValue(mockStream);
+      renderEmbedWidget('STR-001', 'accent-color=%2300b8d4');
+
+      await waitFor(() => {
+        const container = document.querySelector('.embed-widget-container');
+        expect(container).toHaveAttribute('data-accent-color', 'custom');
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // AbortController / fetch cancellation on unmount
+  // -------------------------------------------------------------------------
+  describe('AbortController on unmount', () => {
+    it('aborts in-flight fetch when the component unmounts during loading', async () => {
+      let capturedSignal: AbortSignal | undefined;
+
+      (getStreamById as any).mockImplementation(
+        (_id: string, signal: AbortSignal) => {
+          capturedSignal = signal;
+          // Never resolves — simulates a slow network request
+          return new Promise(() => {});
+        }
+      );
+
+      const { unmount } = renderEmbedWidget('STR-001');
+
+      // Skeleton should be showing
+      expect(screen.getByTestId('embed-skeleton-card')).toBeInTheDocument();
+
+      // Unmount while the fetch is still in flight
+      unmount();
+
+      // The signal passed to getStreamById should now be aborted
+      expect(capturedSignal).toBeDefined();
+      expect(capturedSignal!.aborted).toBe(true);
+    });
+
+    it('does not update state after unmount (no setState after abort)', async () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error');
+
+      let resolveRequest!: (value: typeof mockStream) => void;
+      (getStreamById as any).mockImplementation(() =>
+        new Promise<typeof mockStream>((res) => {
+          resolveRequest = res;
+        })
+      );
+
+      const { unmount } = renderEmbedWidget('STR-001');
+
+      // Unmount before the fetch resolves
+      unmount();
+
+      // Resolve after unmount — should not trigger a React setState warning
+      resolveRequest(mockStream);
+
+      // Give React a tick to process
+      await new Promise((r) => setTimeout(r, 50));
+
+      // No "Can't perform a React state update on an unmounted component" errors
+      expect(consoleErrorSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('unmounted component')
+      );
+      consoleErrorSpy.mockRestore();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Responsive container CSS class stabilisation
+  // -------------------------------------------------------------------------
+  describe('Responsive layout CSS classes', () => {
+    beforeEach(() => {
+      (getStreamById as any).mockResolvedValue(mockStream);
+    });
+
+    it('card layout root has class embed-widget-card', async () => {
+      renderEmbedWidget('STR-001');
+      await waitFor(() => {
+        expect(screen.getByRole('article')).toHaveClass('embed-widget-card');
+      });
+    });
+
+    it('banner layout root has class embed-widget-banner', async () => {
+      renderEmbedWidget('STR-001', 'preset=banner');
+      await waitFor(() => {
+        expect(screen.getByRole('article')).toHaveClass('embed-widget-banner');
+      });
+    });
+
+    it('compact layout root has class embed-widget-compact', async () => {
+      renderEmbedWidget('STR-001', 'preset=compact');
+      await waitFor(() => {
+        expect(screen.getByRole('article')).toHaveClass('embed-widget-compact');
+      });
+    });
+
+    it('container always renders with width:100% inline style', async () => {
+      renderEmbedWidget('STR-001');
+      await waitFor(() => {
+        const container = document.querySelector('.embed-widget-container') as HTMLElement;
+        expect(container.style.width).toBe('100%');
+      });
+    });
+
+    it('container always renders with isolation:isolate inline style', async () => {
+      renderEmbedWidget('STR-001');
+      await waitFor(() => {
+        const container = document.querySelector('.embed-widget-container') as HTMLElement;
+        expect(container.style.isolation).toBe('isolate');
+      });
+    });
+  });
 });


### PR DESCRIPTION
- Replace static min-width on card (300px), banner (500px), and compact (200px) with min(X, 100%) so layouts never overflow narrow embed iframes
- Existing mobile ≤640px media query already resets banner min-width to unset; the min() approach now also handles mid-range narrow containers
- Add tests for progress=0 and progress=100 across all three presets
- Add tests for missing cliffDate (undefined) across all three presets
- Add tests for unknown/empty preset falling back to card layout
- Add tests for case-insensitive preset param (BANNER, Banner, etc.)
- Add tests for data-accent-color=default when no accent is provided
- Add AbortController abort-on-unmount and no-setState-after-unmount tests
- Add responsive CSS class stability and container style regression guards
- All existing tests remain green; no breaking changes to public API

## Summary

<!-- What does this PR change and why? -->

## Changes

<!-- List the key changes made. -->

## Test plan

- [ ] `npm run build` passes (type-check + production build)
- [ ] `npm run test` passes (all unit tests green)
- [ ] `npm run test:coverage` passes (statements/branches/functions/lines ≥ 95%)
- [ ] New code is covered by tests; the coverage include list in `vitest.config.ts` is expanded if new production modules are added

## Coverage gate

CI enforces **95% coverage thresholds** (statements, branches, functions, lines) via
the `coverage` job in `.github/workflows/ci.yml`. The job runs `npm run test:coverage`
and fails the PR check when any threshold is missed. The coverage report is uploaded
as a build artifact for every run.

To add a new production file to the coverage baseline, append it to the `include`
array in `vitest.config.ts` and ensure tests cover it before opening the PR.

closes #1120 