### PR TITLE
feat(recipient): tighten loading/empty/retry state flow and test cove…

### DIFF
--- a/src/pages/Recipient.test.tsx
+++ b/src/pages/Recipient.test.tsx
@@ -178,6 +178,12 @@ describe("Recipient wallet source", () => {
 
     renderRecipient();
 
+    // jsdom's document.hasFocus() is environment-dependent. Dispatch a focus
+    // event first to guarantee isTabFocused=true before asserting the clean title.
+    act(() => {
+      window.dispatchEvent(new Event("focus"));
+    });
+
     expect(document.title).toBe("Fluxora — Recipient portal");
 
     act(() => {

--- a/src/pages/Recipient.tsx
+++ b/src/pages/Recipient.tsx
@@ -235,7 +235,10 @@ export default function Recipient() {
   ];
 
   const liveStreams = recipientStreams.streams;
-  const hasLiveStreams = liveStreams.length > 0;
+  // A service error means we cannot confirm the recipient has no streams —
+  // treat it the same as "no streams yet" so we show the error+retry path
+  // instead of silently falling through to demo balance values.
+  const hasLiveStreams = liveStreams.length > 0 && !recipientStreams.error;
 
   const demoWithdrawStream: WithdrawStreamCandidate = {
     id: "1",
@@ -592,7 +595,12 @@ export default function Recipient() {
 
   if (loading) return <RecipientLoading />;
 
-  if (!walletConnected || !hasStreams) {
+  // Show empty-state path when:
+  //   - wallet is disconnected, OR
+  //   - no active streams for the connected wallet (including service errors,
+  //     where we must not silently fall through to demo-balance values)
+  const serviceError = walletConnected ? recipientStreams.error : null;
+  if (!walletConnected || !hasStreams || serviceError) {
     return (
       <main aria-labelledby="recipient-page-title">
         <h1
@@ -604,7 +612,12 @@ export default function Recipient() {
         <p style={{ color: "var(--muted)", marginBottom: "2rem" }}>
           View your incoming streams and withdraw accrued USDC at any time.
         </p>
-        <RecipientEmptyState walletConnected={walletConnected} />
+        <RecipientEmptyState
+          walletConnected={walletConnected}
+          loading={walletConnected ? recipientStreams.loading : false}
+          error={walletConnected ? recipientStreams.error : null}
+          onRetry={walletConnected ? recipientStreams.refetch : undefined}
+        />
 
         {/* ── Local Security Gate (shown even without streams) ── */}
         {walletConnected && (

--- a/src/pages/__tests__/Recipient.notification.test.tsx
+++ b/src/pages/__tests__/Recipient.notification.test.tsx
@@ -8,7 +8,12 @@ vi.mock("../../components/wallet-connect/Walletcontext", () => ({
   useWallet: () => ({ connected: true, address: "GABC", network: "TESTNET", isNetworkMismatch: false, expectedNetworkLabel: "Testnet" }),
 }));
 vi.mock("../../components/treasuryOverviewPage/useTreasury", () => ({
-  useRecipientStreams: () => ({ streams: [{ id: "1", status: "Active", withdrawableAmount: 10, streamedAmount: 20 }]}),
+  useRecipientStreams: () => ({
+    streams: [{ id: "1", status: "Active", withdrawableAmount: 10, streamedAmount: 20 }],
+    loading: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
 }));
 vi.mock("../../lib/stellar/tx", () => ({ withdraw: vi.fn() }));
 
@@ -35,10 +40,12 @@ describe("Recipient notification permission UX", () => {
     act(() => vi.advanceTimersByTime(2000));
 
     expect(requestPermission).not.toHaveBeenCalled();
-    fireEvent.click(await screen.findByRole("button", { name: "Notify me" }));
-    expect(await screen.findByRole("dialog")).toBeInTheDocument();
+    // Component is fully rendered after the timer flush — use synchronous getByRole
+    fireEvent.click(screen.getByRole("button", { name: "Notify me" }));
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
     expect(requestPermission).not.toHaveBeenCalled();
-    fireEvent.click(await screen.findByRole("button", { name: /allow stream alerts/i }));
+    fireEvent.click(screen.getByRole("button", { name: /allow stream alerts/i }));
+    await act(async () => { await Promise.resolve(); });
     expect(requestPermission).toHaveBeenCalledTimes(1);
   });
 
@@ -57,12 +64,15 @@ describe("Recipient notification permission UX", () => {
     fireEvent.click(screen.getByRole("button", { name: "Not now" }));
     expect(screen.queryByRole("dialog")).toBeNull();
 
+    // Open priming dialog again, then allow — dialog must open before the allow button is accessible
+    fireEvent.click(screen.getByRole("button", { name: "Notify me" }));
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
     await act(async () => {
-      fireEvent.click(await screen.findByRole("button", { name: "Notify me" }));
-      fireEvent.click(await screen.findByRole("button", { name: /allow stream alerts/i }));
+      fireEvent.click(screen.getByRole("button", { name: /allow stream alerts/i }));
       await Promise.resolve();
     });
 
-    expect(await screen.findByText(/Permission is blocked by your browser/i)).toBeInTheDocument();
+    expect(screen.getByText(/Permission is blocked by your browser/i)).toBeInTheDocument();
   });
 });

--- a/src/pages/__tests__/Recipient.states.test.tsx
+++ b/src/pages/__tests__/Recipient.states.test.tsx
@@ -1,0 +1,556 @@
+/**
+ * Recipient page — loading / empty / retry / edge-case states
+ *
+ * Covers the explicit state transitions and edge behaviours that are not
+ * already exercised by Recipient.test.tsx or Recipient.empty.test.tsx:
+ *
+ *  1. Initial loading skeleton (page-level 2 s timeout)
+ *  2. loading → empty transition when service loading clears with no streams
+ *  3. Service error shows error banner inside RecipientEmptyState
+ *  4. Error → retry: clicking Retry calls refetch
+ *  5. Error state never falls through to demo-balance values
+ *  6. Service still loading after page timeout → RecipientEmptyState receives loading=true
+ *  7. Zero-accrual banner shown when connected + streams exist + balance === 0
+ *  8. Zero-accrual banner absent when balance > 0
+ *  9. Network mismatch disables the withdraw button
+ * 10. Wallet-address change resets txState / errorMsg
+ * 11. Keyboard (Enter / Space) activates the withdraw button
+ * 12. Withdraw button has an accessible name
+ */
+
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ToastProvider } from "../../components/toast/ToastProvider";
+import Recipient from "../Recipient";
+
+// ── Shared mutable wallet state ───────────────────────────────────────────────
+
+const walletState = {
+  address: "GATDOSCZNJ5YZHNOX7IOD4QDCQSTMR2YNF5IXHFNX3H6B4ICCMSDLOWN",
+  network: "TESTNET",
+  connected: true,
+  loading: false,
+  error: null as string | null,
+  expectedNetwork: "TESTNET",
+  expectedNetworkLabel: "Testnet",
+  isNetworkMismatch: false,
+  connect: vi.fn(),
+  disconnect: vi.fn(),
+};
+
+vi.mock("../../components/wallet-connect/Walletcontext", () => ({
+  useWallet: () => walletState,
+  WalletProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+// ── Shared mutable streams state ──────────────────────────────────────────────
+
+const streamsState = {
+  streams: [] as {
+    id: string;
+    status: string;
+    withdrawableAmount: number;
+    streamedAmount: number;
+  }[],
+  loading: false,
+  error: null as string | null,
+  refetch: vi.fn(),
+};
+
+vi.mock("../../components/treasuryOverviewPage/useTreasury", () => ({
+  useRecipientStreams: () => streamsState,
+}));
+
+vi.mock("../../lib/stellar/tx", () => ({
+  withdraw: vi.fn().mockResolvedValue("TX_HASH_123"),
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeStream(
+  overrides: Partial<typeof streamsState.streams[0]> = {},
+) {
+  return {
+    id: "1",
+    name: "Test Stream",
+    recipientName: "Alice",
+    recipientAddress: walletState.address,
+    treasuryName: "Treasury",
+    treasuryAddress: "GTREASURY",
+    asset: "USDC",
+    status: "Active",
+    monthlyRate: 1000,
+    depositAmount: 12000,
+    streamedAmount: 5000,
+    withdrawableAmount: 3000,
+    remainingAmount: 7000,
+    progress: 42,
+    startDate: "2026-01-01",
+    endDate: "2026-12-31",
+    summary: "",
+    health: "Healthy" as const,
+    healthNote: "",
+    auditNote: "",
+    tags: [],
+    timeline: [],
+    ...overrides,
+  };
+}
+
+function renderRecipient() {
+  return render(
+    <ToastProvider>
+      <Recipient />
+    </ToastProvider>,
+  );
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("Recipient page — loading state", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // Reset to defaults
+    walletState.connected = true;
+    walletState.address = "GATDOSCZNJ5YZHNOX7IOD4QDCQSTMR2YNF5IXHFNX3H6B4ICCMSDLOWN";
+    walletState.network = "TESTNET";
+    walletState.isNetworkMismatch = false;
+    streamsState.streams = [];
+    streamsState.loading = false;
+    streamsState.error = null;
+    streamsState.refetch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("shows the loading skeleton immediately on mount", () => {
+    renderRecipient();
+
+    expect(
+      screen.getByRole("status", { name: /loading recipient portal/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("hides the loading skeleton once the 2-second page timeout fires", () => {
+    renderRecipient();
+
+    expect(
+      screen.getByRole("status", { name: /loading recipient portal/i }),
+    ).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(
+      screen.queryByRole("status", { name: /loading recipient portal/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders RecipientEmptyState (not the loaded portal) after timer when there are no streams", () => {
+    renderRecipient();
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(
+      screen.getByRole("region", { name: "Recipient empty state" }),
+    ).toBeInTheDocument();
+    // The full portal (hero section) must not be visible
+    expect(
+      screen.queryByText("Recipient Portal"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the full portal (hero section) after timer when streams exist", () => {
+    streamsState.streams = [makeStream()];
+
+    renderRecipient();
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(
+      screen.queryByRole("region", { name: "Recipient empty state" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("Recipient Portal")).toBeInTheDocument();
+  });
+
+  it("passes loading=true to RecipientEmptyState while the service fetch is still in flight after the page timeout", () => {
+    // Service hasn't resolved yet when the page timer fires
+    streamsState.loading = true;
+    streamsState.streams = [];
+
+    renderRecipient();
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    // RecipientEmptyState with loading=true renders EmptyState's LoadingSkeleton
+    // which has role="status" aria-label="Loading content"
+    expect(
+      screen.getByRole("status", { name: /loading content/i }),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("Recipient page — service error and retry", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    walletState.connected = true;
+    walletState.address = "GATDOSCZNJ5YZHNOX7IOD4QDCQSTMR2YNF5IXHFNX3H6B4ICCMSDLOWN";
+    walletState.network = "TESTNET";
+    walletState.isNetworkMismatch = false;
+    streamsState.streams = [];
+    streamsState.loading = false;
+    streamsState.error = null;
+    streamsState.refetch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("shows the error message inside the empty-state region when the service fails", () => {
+    streamsState.error = "Unable to load recipient streams.";
+
+    renderRecipient();
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(
+      screen.getByRole("region", { name: "Recipient empty state" }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole("alert"),
+    ).toHaveTextContent("Unable to load recipient streams.");
+  });
+
+  it("exposes a Retry button when the service fails", () => {
+    streamsState.error = "Service unavailable.";
+
+    renderRecipient();
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(
+      screen.getByRole("button", { name: /retry loading data/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("calls refetch when Retry is clicked", () => {
+    streamsState.error = "Service unavailable.";
+
+    renderRecipient();
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /retry loading data/i }));
+
+    expect(streamsState.refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT fall through to demo-balance values when the service returns an error", () => {
+    streamsState.error = "Service unavailable.";
+
+    renderRecipient();
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    // The hero section with withdraw button (showing DEMO_BALANCE 22,600 USDC) must not appear
+    expect(
+      screen.queryByRole("button", { name: /withdraw 22,600 usdc/i }),
+    ).not.toBeInTheDocument();
+    // The error empty-state must be shown instead
+    expect(
+      screen.getByRole("region", { name: "Recipient empty state" }),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("Recipient page — zero-accrual banner", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    walletState.connected = true;
+    walletState.address = "GATDOSCZNJ5YZHNOX7IOD4QDCQSTMR2YNF5IXHFNX3H6B4ICCMSDLOWN";
+    walletState.network = "TESTNET";
+    walletState.isNetworkMismatch = false;
+    streamsState.streams = [];
+    streamsState.loading = false;
+    streamsState.error = null;
+    streamsState.refetch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("shows the zero-accrual banner when connected, has active streams, but withdrawable balance is 0", () => {
+    streamsState.streams = [
+      makeStream({ status: "Active", withdrawableAmount: 0, streamedAmount: 100 }),
+    ];
+
+    renderRecipient();
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    // ZeroAccrualBanner has role="status" with aria-label matching the pattern
+    expect(
+      screen.getByRole("status", { name: /zero accrual notice/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("does NOT show the zero-accrual banner when there is a withdrawable balance", () => {
+    streamsState.streams = [
+      makeStream({ status: "Active", withdrawableAmount: 500, streamedAmount: 1000 }),
+    ];
+
+    renderRecipient();
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(
+      screen.queryByRole("status", { name: /zero accrual notice/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does NOT show the zero-accrual banner when not connected", () => {
+    walletState.connected = false;
+    walletState.address = null as any;
+    streamsState.streams = [];
+
+    renderRecipient();
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(
+      screen.queryByRole("status", { name: /zero accrual notice/i }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("Recipient page — network mismatch", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    walletState.connected = true;
+    walletState.address = "GATDOSCZNJ5YZHNOX7IOD4QDCQSTMR2YNF5IXHFNX3H6B4ICCMSDLOWN";
+    walletState.network = "PUBLIC";
+    walletState.isNetworkMismatch = true;
+    streamsState.streams = [];
+    streamsState.loading = false;
+    streamsState.error = null;
+    streamsState.refetch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("disables the withdraw button when the wallet network does not match the expected network", () => {
+    renderRecipient();
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    // The page renders the full portal (wallet is connected and we're using demo data)
+    const withdrawButton = screen.getByRole("button", {
+      name: /withdraw 22,600 usdc/i,
+    });
+    expect(withdrawButton).toBeDisabled();
+  });
+
+  it("shows a network-mismatch error message when the wallet is on the wrong network", () => {
+    renderRecipient();
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(
+      screen.getByRole("alert"),
+    ).toHaveTextContent(/wrong network/i);
+  });
+});
+
+describe("Recipient page — wallet address change resets tx state", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    walletState.connected = true;
+    walletState.address = "GATDOSCZNJ5YZHNOX7IOD4QDCQSTMR2YNF5IXHFNX3H6B4ICCMSDLOWN";
+    walletState.network = "TESTNET";
+    walletState.isNetworkMismatch = false;
+    streamsState.streams = [];
+    streamsState.loading = false;
+    streamsState.error = null;
+    streamsState.refetch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("resets txState when the wallet address changes", async () => {
+    const withdrawMock = await import("../../lib/stellar/tx");
+    vi.mocked(withdrawMock.withdraw).mockRejectedValueOnce(new Error("Rejected"));
+
+    const { rerender } = renderRecipient();
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    // Trigger a failed withdrawal
+    fireEvent.click(
+      screen.getByRole("button", { name: /withdraw 22,600 usdc/i }),
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(
+      screen.getByRole("button", { name: /withdrawal failed/i }),
+    ).toBeInTheDocument();
+
+    // Simulate wallet address change
+    walletState.address = "GBDIFFERENTADDRESSNEWWALLET2345678ABCDEF";
+
+    rerender(
+      <ToastProvider>
+        <Recipient />
+      </ToastProvider>,
+    );
+
+    // txState should have reset — withdraw button shows the normal label
+    expect(
+      screen.getByRole("button", { name: /withdraw 22,600 usdc/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /withdrawal failed/i }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("Recipient page — withdraw button keyboard activation", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    walletState.connected = true;
+    walletState.address = "GATDOSCZNJ5YZHNOX7IOD4QDCQSTMR2YNF5IXHFNX3H6B4ICCMSDLOWN";
+    walletState.network = "TESTNET";
+    walletState.isNetworkMismatch = false;
+    streamsState.streams = [];
+    streamsState.loading = false;
+    streamsState.error = null;
+    streamsState.refetch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("activates the withdraw button on Enter key press", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const withdrawMock = await import("../../lib/stellar/tx");
+    vi.mocked(withdrawMock.withdraw).mockResolvedValue("TX_HASH" as any);
+
+    renderRecipient();
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    const withdrawButton = screen.getByRole("button", {
+      name: /withdraw 22,600 usdc/i,
+    });
+
+    withdrawButton.focus();
+    await user.keyboard("{Enter}");
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(withdrawMock.withdraw).toHaveBeenCalled();
+  });
+
+  it("activates the withdraw button on Space key press", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const withdrawMock = await import("../../lib/stellar/tx");
+    vi.mocked(withdrawMock.withdraw).mockResolvedValue("TX_HASH" as any);
+
+    renderRecipient();
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    const withdrawButton = screen.getByRole("button", {
+      name: /withdraw 22,600 usdc/i,
+    });
+
+    withdrawButton.focus();
+    await user.keyboard(" ");
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(withdrawMock.withdraw).toHaveBeenCalled();
+  });
+
+  it("withdraw button has an accessible role and name", () => {
+    renderRecipient();
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    const withdrawButton = screen.getByRole("button", {
+      name: /withdraw 22,600 usdc/i,
+    });
+
+    expect(withdrawButton).toBeInTheDocument();
+    expect(withdrawButton).toHaveAttribute("type", "button");
+  });
+
+  it("withdraw button is not focusable in the disabled (disconnected) state", () => {
+    walletState.connected = false;
+    walletState.address = null as any;
+
+    renderRecipient();
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    // In disconnected state the page shows RecipientEmptyState — no withdraw button
+    expect(
+      screen.queryByRole("button", { name: /withdraw/i }),
+    ).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
…rage

- Wire recipientStreams.loading, error, and refetch into RecipientEmptyState so service failures show an actionable error+retry path instead of silently falling through to demo-balance values
- hasLiveStreams now guards on recipientStreams.error so an error never reaches the demo data path
- Add Recipient.states.test.tsx: 19 new tests covering initial loading skeleton, loading→empty transition, service error→retry, zero-accrual banner, network mismatch, wallet address change resets tx state, and keyboard/a11y on the withdraw button
- Fix blur/focus document title test: dispatch focus first to account for jsdom hasFocus() environment variance
- Fix notification tests: add missing useRecipientStreams mock and replace findByRole with getByRole to avoid async timer deadlock with fake timers

## Summary

<!-- What does this PR change and why? -->

## Changes

<!-- List the key changes made. -->

## Test plan

- [ ] `npm run build` passes (type-check + production build)
- [ ] `npm run test` passes (all unit tests green)
- [ ] `npm run test:coverage` passes (statements/branches/functions/lines ≥ 95%)
- [ ] New code is covered by tests; the coverage include list in `vitest.config.ts` is expanded if new production modules are added

## Coverage gate

CI enforces **95% coverage thresholds** (statements, branches, functions, lines) via
the `coverage` job in `.github/workflows/ci.yml`. The job runs `npm run test:coverage`
and fails the PR check when any threshold is missed. The coverage report is uploaded
as a build artifact for every run.

To add a new production file to the coverage baseline, append it to the `include`
array in `vitest.config.ts` and ensure tests cover it before opening the PR.

closes #1118