### PR TITLE
fix(presence): tighten tooltip/popover timing and add edge-case tests

### DIFF
--- a/src/components/presence/Presence.css
+++ b/src/components/presence/Presence.css
@@ -180,6 +180,15 @@
   flex-shrink: 0;
 }
 
+/* Fading-out row: viewer is leaving soon — muted appearance */
+.presence-viewer-row--fading {
+  opacity: 0.5;
+}
+
+.presence-viewer-dot--fading {
+  background-color: var(--color-text-tertiary, #718096) !important;
+}
+
 .presence-viewer-name {
   flex-grow: 1;
   overflow: hidden;

--- a/src/components/presence/PresenceBadge.tsx
+++ b/src/components/presence/PresenceBadge.tsx
@@ -97,8 +97,15 @@ export default function PresenceBadge({ viewers }: PresenceBadgeProps) {
   const totalCount = activeCount + 1; // including local user
   const viewersToRender = viewers.slice(0, 3);
 
+  // The container listens for Escape so that closing the popover via the
+  // outer badge container still returns focus to the trigger. The list
+  // component handles its own inner Escape scope first (and calls onClose),
+  // which in turn calls setIsOpen(false) + focus(). This handler covers the
+  // case where focus is on the trigger button itself and the popover is open
+  // (e.g., the user re-focuses the trigger after opening but before moving
+  // into the list).
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === "Escape") {
+    if (e.key === "Escape" && isOpen) {
       setIsOpen(false);
       triggerRef.current?.focus();
     }
@@ -117,7 +124,7 @@ export default function PresenceBadge({ viewers }: PresenceBadgeProps) {
       <button
         ref={triggerRef}
         onClick={() => setIsOpen((prev) => !prev)}
-        aria-haspopup="listbox"
+        aria-haspopup="true"
         aria-expanded={isOpen}
         aria-label={`${totalCount} active viewers. Click to view list.`}
         className="presence-badge-trigger"

--- a/src/components/presence/PresenceViewerList.tsx
+++ b/src/components/presence/PresenceViewerList.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import { Viewer } from "../../hooks/usePresenceViewers";
 import { maskAddress } from "../../lib/stellar";
 import { useTickingNow } from "../../hooks/useTickingNow";
@@ -6,9 +6,29 @@ import { useTickingNow } from "../../hooks/useTickingNow";
 interface PresenceViewerListProps {
   viewers: Viewer[];
   onClose: () => void;
+  /**
+   * When true, the list container receives focus on mount so that the
+   * keyboard Escape handler is reachable without any extra clicks.
+   * PresenceBadge sets this whenever it opens the popover.
+   */
+  autoFocus?: boolean;
 }
 
-export default function PresenceViewerList({ viewers, onClose }: PresenceViewerListProps) {
+export default function PresenceViewerList({
+  viewers,
+  onClose,
+  autoFocus = true,
+}: PresenceViewerListProps) {
+  const listRef = useRef<HTMLDivElement>(null);
+
+  // Auto-focus the container so the Escape key handler is live immediately
+  // after the popover opens, without requiring the user to tab into the list.
+  useEffect(() => {
+    if (autoFocus) {
+      listRef.current?.focus();
+    }
+  }, [autoFocus]);
+
   // Reactive "now" timestamp that ticks on a coarse cadence (useTickingNow)
   // so the "last seen N seconds ago" text stays live while the list is open
   // without requiring a viewers prop change (Issue #955).
@@ -33,13 +53,22 @@ export default function PresenceViewerList({ viewers, onClose }: PresenceViewerL
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === "Escape") {
+      // Stop the event here so parent Escape handlers do not fire a second
+      // time (PresenceBadge also listens on the container). Both would close
+      // the popover, but a double call is confusing and the list owns the
+      // inner Escape scope.
+      e.stopPropagation();
       onClose();
     }
   };
 
   return (
     <div
+      ref={listRef}
       role="list"
+      // tabIndex makes the container programmatically focusable so the
+      // keyboard Escape handler is reachable as soon as the popover opens.
+      tabIndex={-1}
       className="presence-viewer-list"
       aria-label="Current active viewers"
       onKeyDown={handleKeyDown}
@@ -51,10 +80,15 @@ export default function PresenceViewerList({ viewers, onClose }: PresenceViewerL
           <div
             key={viewer.id}
             role="listitem"
-            className="presence-viewer-row"
+            className={`presence-viewer-row${viewer.fadingOut ? " presence-viewer-row--fading" : ""}`}
+            aria-label={
+              viewer.fadingOut
+                ? `${getDisplayName(viewer)}, leaving`
+                : getDisplayName(viewer)
+            }
           >
             <span
-              className="presence-viewer-dot"
+              className={`presence-viewer-dot${viewer.fadingOut ? " presence-viewer-dot--fading" : ""}`}
               style={{ backgroundColor: viewer.color }}
               aria-hidden="true"
             />

--- a/src/components/presence/__tests__/PresenceBadge.test.tsx
+++ b/src/components/presence/__tests__/PresenceBadge.test.tsx
@@ -217,10 +217,10 @@ describe("PresenceBadge", () => {
   it("handles Escape key press when list is already closed", () => {
     render(<PresenceBadge viewers={[mockViewer1]} />);
     const trigger = screen.getByRole("button");
+    // Escape on a closed popover: the container handler is guarded by `isOpen`,
+    // so nothing happens — the list stays absent, no error thrown.
     fireEvent.keyDown(trigger, { key: "Escape" });
-    // Should still be closed and trigger focused
     expect(screen.queryByRole("list")).not.toBeInTheDocument();
-    expect(document.activeElement).toBe(trigger);
   });
 
   it("does not close list when clicking inside the list component", () => {
@@ -285,5 +285,171 @@ describe("PresenceBadge", () => {
     const { container } = render(<PresenceBadge viewers={[noColorViewer]} />);
     const avatar = container.querySelector(".presence-avatar") as HTMLElement;
     expect(avatar.style.backgroundColor).toBe("rgb(185, 28, 28)");
+  });
+
+  // -------------------------------------------------------------------------
+  // Tooltip: role and content
+  // -------------------------------------------------------------------------
+
+  describe("tooltip role and accessibility", () => {
+    it("tooltip spans carry role='tooltip'", () => {
+      render(<PresenceBadge viewers={[mockViewer1, mockViewer2]} />);
+      // Tooltips live inside aria-hidden="true" (avatar stack), so query with hidden:true
+      const tooltips = screen.getAllByRole("tooltip", { hidden: true });
+      // One tooltip per rendered avatar (up to 3)
+      expect(tooltips.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("each tooltip contains the viewer's displayName", () => {
+      render(<PresenceBadge viewers={[mockViewer1, mockViewer2]} />);
+      const tooltips = screen.getAllByRole("tooltip", { hidden: true });
+      const texts = tooltips.map((t) => t.textContent);
+      expect(texts).toContain("Alice Smith");
+      expect(texts).toContain("Bob Jones");
+    });
+
+    it("tooltip contains 'Anonymous Viewer' when displayName is null", () => {
+      const anonViewer: Viewer = {
+        id: "G99",
+        displayName: null,
+        initials: "??",
+        color: "#b91c1c",
+        lastSeen: Date.now(),
+      };
+      render(<PresenceBadge viewers={[anonViewer]} />);
+      expect(screen.getByRole("tooltip", { hidden: true })).toHaveTextContent("Anonymous Viewer");
+    });
+
+    it("tooltip is inside an aria-hidden avatar stack so it does not appear in the accessible name tree of the trigger", () => {
+      const { container } = render(<PresenceBadge viewers={[mockViewer1]} />);
+      const stack = container.querySelector(".presence-avatar-stack");
+      expect(stack).toHaveAttribute("aria-hidden", "true");
+    });
+
+    it("tooltip pointer-events are disabled (CSS class check)", () => {
+      render(<PresenceBadge viewers={[mockViewer1]} />);
+      const tooltip = screen.getByRole("tooltip", { hidden: true });
+      expect(tooltip).toHaveClass("presence-tooltip");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // aria-haspopup and aria-expanded
+  // -------------------------------------------------------------------------
+
+  describe("trigger ARIA attributes", () => {
+    it("trigger has aria-haspopup='true'", () => {
+      render(<PresenceBadge viewers={[mockViewer1]} />);
+      const trigger = screen.getByRole("button");
+      expect(trigger).toHaveAttribute("aria-haspopup", "true");
+    });
+
+    it("trigger aria-expanded is false when popover is closed", () => {
+      render(<PresenceBadge viewers={[mockViewer1]} />);
+      expect(screen.getByRole("button")).toHaveAttribute("aria-expanded", "false");
+    });
+
+    it("trigger aria-expanded is true when popover is open", () => {
+      render(<PresenceBadge viewers={[mockViewer1]} />);
+      fireEvent.click(screen.getByRole("button"));
+      expect(screen.getByRole("button")).toHaveAttribute("aria-expanded", "true");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Dual Escape scope: list-level then badge-level
+  // -------------------------------------------------------------------------
+
+  describe("Escape key scope handling", () => {
+    it("Escape on the list closes the popover and returns focus to the trigger", () => {
+      render(<PresenceBadge viewers={[mockViewer1, mockViewer2]} />);
+      const trigger = screen.getByRole("button");
+
+      fireEvent.click(trigger);
+      expect(screen.getByRole("list")).toBeInTheDocument();
+
+      // Escape fired on the list element (inner scope)
+      fireEvent.keyDown(screen.getByRole("list"), { key: "Escape" });
+
+      expect(screen.queryByRole("list")).not.toBeInTheDocument();
+      expect(document.activeElement).toBe(trigger);
+    });
+
+    it("Escape on the trigger button (outer scope) closes the popover when already open", () => {
+      render(<PresenceBadge viewers={[mockViewer1]} />);
+      const trigger = screen.getByRole("button");
+
+      fireEvent.click(trigger);
+      expect(screen.getByRole("list")).toBeInTheDocument();
+
+      // Escape on the trigger itself (outer container scope)
+      fireEvent.keyDown(trigger, { key: "Escape" });
+
+      expect(screen.queryByRole("list")).not.toBeInTheDocument();
+    });
+
+    it("Escape on the trigger when popover is closed does nothing", () => {
+      render(<PresenceBadge viewers={[mockViewer1]} />);
+      const trigger = screen.getByRole("button");
+
+      fireEvent.keyDown(trigger, { key: "Escape" });
+      expect(screen.queryByRole("list")).not.toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Popover stays open on viewer list update
+  // -------------------------------------------------------------------------
+
+  describe("popover stability on viewer list update", () => {
+    it("stays open when viewers prop changes while popover is open", () => {
+      const { rerender } = render(
+        <PresenceBadge viewers={[mockViewer1, mockViewer2]} />
+      );
+      const trigger = screen.getByRole("button");
+      fireEvent.click(trigger);
+      expect(screen.getByRole("list")).toBeInTheDocument();
+
+      // A new viewer joins
+      rerender(
+        <PresenceBadge viewers={[mockViewer1, mockViewer2, mockViewer3]} />
+      );
+      // Popover must still be mounted
+      expect(screen.getByRole("list")).toBeInTheDocument();
+    });
+
+    it("shows the updated viewer in the list when a new viewer joins while open", () => {
+      const { rerender } = render(
+        <PresenceBadge viewers={[mockViewer1]} />
+      );
+      fireEvent.click(screen.getByRole("button"));
+
+      rerender(<PresenceBadge viewers={[mockViewer1, mockViewer2]} />);
+
+      // Scope assertion to the viewer list to avoid collision with the avatar tooltip
+      const list = screen.getByRole("list");
+      expect(list).toBeInTheDocument();
+      expect(within(list).getByText("Bob Jones")).toBeInTheDocument();
+    });
+
+    it("reflects fadingOut state of a viewer while popover is open", () => {
+      const { rerender } = render(
+        <PresenceBadge viewers={[mockViewer1, mockViewer2]} />
+      );
+      fireEvent.click(screen.getByRole("button"));
+      expect(screen.getByRole("list")).toBeInTheDocument();
+
+      // Viewer starts fading
+      rerender(
+        <PresenceBadge viewers={[mockViewer1, { ...mockViewer2, fadingOut: true }]} />
+      );
+
+      // Popover still open; fading viewer row carries the CSS modifier
+      const rows = screen.getAllByRole("listitem");
+      const fadingRow = rows.find((r) =>
+        r.className.includes("presence-viewer-row--fading")
+      );
+      expect(fadingRow).toBeTruthy();
+    });
   });
 });

--- a/src/components/presence/__tests__/PresenceViewerList.test.tsx
+++ b/src/components/presence/__tests__/PresenceViewerList.test.tsx
@@ -3,7 +3,11 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import PresenceViewerList from "../PresenceViewerList";
 import { Viewer } from "../../../hooks/usePresenceViewers";
 
-const mockViewer1: Viewer = {
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const baseViewer: Viewer = {
   id: "G1",
   displayName: "Alice Smith",
   initials: "AS",
@@ -11,88 +15,147 @@ const mockViewer1: Viewer = {
   lastSeen: Date.now(),
 };
 
-describe("PresenceViewerList", () => {
-  it("renders empty message when there are no viewers", () => {
+const viewerWithAddress: Viewer = {
+  id: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+  displayName: null,
+  initials: "??",
+  color: "#1d4ed8",
+  lastSeen: Date.now(),
+};
+
+// ---------------------------------------------------------------------------
+// Basic rendering
+// ---------------------------------------------------------------------------
+
+describe("PresenceViewerList – basic rendering", () => {
+  it("renders empty-state message when viewers is empty", () => {
     render(<PresenceViewerList viewers={[]} onClose={vi.fn()} />);
     expect(screen.getByText("No other viewers")).toBeInTheDocument();
   });
 
-  it("calls onClose when Escape key is pressed inside the list", () => {
-    const handleClose = vi.fn();
-    render(<PresenceViewerList viewers={[mockViewer1]} onClose={handleClose} />);
-
-    const listElement = screen.getByRole("list");
-    fireEvent.keyDown(listElement, { key: "Escape" });
-    
-    expect(handleClose).toHaveBeenCalledTimes(1);
+  it("renders the correct number of viewer rows", () => {
+    const viewers: Viewer[] = [
+      baseViewer,
+      { ...baseViewer, id: "G2", displayName: "Bob Jones", initials: "BJ", color: "#c2410c" },
+    ];
+    render(<PresenceViewerList viewers={viewers} onClose={vi.fn()} />);
+    expect(screen.getAllByRole("listitem")).toHaveLength(2);
   });
 
-  it("does not call onClose when other keys are pressed", () => {
-    const handleClose = vi.fn();
-    render(<PresenceViewerList viewers={[mockViewer1]} onClose={handleClose} />);
-
-    const listElement = screen.getByRole("list");
-    fireEvent.keyDown(listElement, { key: "Enter" });
-    
-    expect(handleClose).not.toHaveBeenCalled();
+  it("renders viewer displayName when provided", () => {
+    render(<PresenceViewerList viewers={[baseViewer]} onClose={vi.fn()} />);
+    expect(screen.getByText("Alice Smith")).toBeInTheDocument();
   });
 
-  it("renders viewer rows without tabIndex so they are not keyboard-focusable", () => {
-    render(<PresenceViewerList viewers={[mockViewer1]} onClose={vi.fn()} />);
+  it("has role='list' and aria-label on the container", () => {
+    render(<PresenceViewerList viewers={[baseViewer]} onClose={vi.fn()} />);
+    const list = screen.getByRole("list");
+    expect(list).toHaveAttribute("aria-label", "Current active viewers");
+  });
 
-    const rows = screen.getAllByRole("listitem");
-    expect(rows).toHaveLength(1);
-    rows.forEach((row) => {
+  it("container has tabIndex=-1 so it is programmatically focusable", () => {
+    render(<PresenceViewerList viewers={[baseViewer]} onClose={vi.fn()} />);
+    const list = screen.getByRole("list");
+    expect(list).toHaveAttribute("tabindex", "-1");
+  });
+
+  it("viewer rows do not have a tabIndex (not individually keyboard-focusable)", () => {
+    render(<PresenceViewerList viewers={[baseViewer]} onClose={vi.fn()} />);
+    screen.getAllByRole("listitem").forEach((row) => {
       expect(row).not.toHaveAttribute("tabindex");
     });
   });
 
-  it("renders raw id if not a Stellar address and displayName is null", () => {
-    const mockViewer: Viewer = {
-      id: "G-short",
-      displayName: null,
-      initials: "??",
-      color: "#b91c1c",
-      lastSeen: Date.now(),
-    };
-    render(<PresenceViewerList viewers={[mockViewer]} onClose={vi.fn()} />);
-    expect(screen.getByText("G-short")).toBeInTheDocument();
+  it("renders colour dot as aria-hidden", () => {
+    const { container } = render(
+      <PresenceViewerList viewers={[baseViewer]} onClose={vi.fn()} />
+    );
+    const dot = container.querySelector(".presence-viewer-dot");
+    expect(dot).toHaveAttribute("aria-hidden", "true");
   });
 
-  it("renders raw id if starts with another letter and displayName is null", () => {
-    const mockViewer: Viewer = {
-      id: "A1111111111111111111111111111111111111111111111111111111",
-      displayName: null,
-      initials: "??",
-      color: "#b91c1c",
-      lastSeen: Date.now(),
-    };
-    render(<PresenceViewerList viewers={[mockViewer]} onClose={vi.fn()} />);
-    expect(screen.getByText("A1111111111111111111111111111111111111111111111111111111")).toBeInTheDocument();
+  it("applies the viewer color to the dot via inline style", () => {
+    const { container } = render(
+      <PresenceViewerList viewers={[baseViewer]} onClose={vi.fn()} />
+    );
+    const dot = container.querySelector<HTMLElement>(".presence-viewer-dot");
+    expect(dot?.style.backgroundColor).toBe("rgb(185, 28, 28)");
   });
 });
 
-describe("PresenceViewerList elapsed time updates", () => {
-  beforeEach(() => {
-    vi.useFakeTimers();
+// ---------------------------------------------------------------------------
+// Address masking
+// ---------------------------------------------------------------------------
+
+describe("PresenceViewerList – address masking", () => {
+  it("masks a 56-char Stellar address starting with G when displayName is null", () => {
+    render(<PresenceViewerList viewers={[viewerWithAddress]} onClose={vi.fn()} />);
+    // maskAddress(id, 6, 4): first 6 chars + '...' + last 4 chars
+    expect(screen.getByText("GAAAAA...AWHF")).toBeInTheDocument();
   });
 
-  afterEach(() => {
-    vi.useRealTimers();
-  });
-
-  it("updates elapsed seconds text over time without a viewers prop change (Issue #955)", () => {
-    const fixedLastSeen = Date.now() - 5_000;
-    const mockViewer: Viewer = {
-      id: "G1",
-      displayName: "Alice",
-      initials: "AS",
-      color: "#b91c1c",
-      lastSeen: fixedLastSeen,
+  it("renders raw id when it starts with G but is shorter than 56 chars", () => {
+    const viewer: Viewer = {
+      ...baseViewer,
+      id: "G-short",
+      displayName: null,
     };
+    render(<PresenceViewerList viewers={[viewer]} onClose={vi.fn()} />);
+    expect(screen.getByText("G-short")).toBeInTheDocument();
+  });
 
-    render(<PresenceViewerList viewers={[mockViewer]} onClose={vi.fn()} />);
+  it("renders raw id when it does not start with G", () => {
+    const viewer: Viewer = {
+      ...baseViewer,
+      id: "A1111111111111111111111111111111111111111111111111111111",
+      displayName: null,
+    };
+    render(<PresenceViewerList viewers={[viewer]} onClose={vi.fn()} />);
+    expect(
+      screen.getByText("A1111111111111111111111111111111111111111111111111111111")
+    ).toBeInTheDocument();
+  });
 
+  it("prefers displayName over masked address when both are present", () => {
+    const viewer: Viewer = { ...viewerWithAddress, displayName: "Named User" };
+    render(<PresenceViewerList viewers={[viewer]} onClose={vi.fn()} />);
+    expect(screen.getByText("Named User")).toBeInTheDocument();
+    expect(screen.queryByText(/\.\.\./)).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Elapsed time display
+// ---------------------------------------------------------------------------
+
+describe("PresenceViewerList – elapsed time display", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("shows '0 seconds ago' when lastSeen is now (within the same tick)", () => {
+    const viewer: Viewer = { ...baseViewer, lastSeen: Date.now() };
+    render(<PresenceViewerList viewers={[viewer]} onClose={vi.fn()} />);
+    expect(screen.getByText("last seen 0 seconds ago")).toBeInTheDocument();
+  });
+
+  it("shows correct elapsed seconds for a viewer seen 5 seconds ago", () => {
+    const viewer: Viewer = { ...baseViewer, lastSeen: Date.now() - 5_000 };
+    render(<PresenceViewerList viewers={[viewer]} onClose={vi.fn()} />);
+    expect(screen.getByText("last seen 5 seconds ago")).toBeInTheDocument();
+  });
+
+  it("does not show negative elapsed (clamps at 0)", () => {
+    // lastSeen slightly in the future (clock skew)
+    const viewer: Viewer = { ...baseViewer, lastSeen: Date.now() + 1_000 };
+    render(<PresenceViewerList viewers={[viewer]} onClose={vi.fn()} />);
+    expect(screen.getByText("last seen 0 seconds ago")).toBeInTheDocument();
+  });
+
+  it("updates elapsed seconds text after 30s without a viewers prop change (Issue #955)", () => {
+    const fixedLastSeen = Date.now() - 5_000;
+    const viewer: Viewer = { ...baseViewer, lastSeen: fixedLastSeen };
+
+    render(<PresenceViewerList viewers={[viewer]} onClose={vi.fn()} />);
     expect(screen.getByText(/last seen 5 seconds ago/i)).toBeInTheDocument();
 
     act(() => {
@@ -100,5 +163,189 @@ describe("PresenceViewerList elapsed time updates", () => {
     });
 
     expect(screen.getByText(/last seen 35 seconds ago/i)).toBeInTheDocument();
+  });
+
+  it("reflects an updated lastSeen value when the viewers prop changes while open", () => {
+    const viewer: Viewer = { ...baseViewer, lastSeen: Date.now() - 10_000 };
+    const { rerender } = render(
+      <PresenceViewerList viewers={[viewer]} onClose={vi.fn()} />
+    );
+    expect(screen.getByText("last seen 10 seconds ago")).toBeInTheDocument();
+
+    // Simulate viewer becoming active again (lastSeen reset to now)
+    const updatedViewer: Viewer = { ...viewer, lastSeen: Date.now() };
+    rerender(<PresenceViewerList viewers={[updatedViewer]} onClose={vi.fn()} />);
+
+    expect(screen.getByText("last seen 0 seconds ago")).toBeInTheDocument();
+  });
+
+  it("uses the 60 s reduced-motion tick cadence when prefers-reduced-motion is set", () => {
+    // Stub matchMedia to report reduced-motion: reduce
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: (query: string) => ({
+        matches: query === "(prefers-reduced-motion: reduce)",
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      }),
+    });
+
+    const fixedLastSeen = Date.now() - 5_000;
+    const viewer: Viewer = { ...baseViewer, lastSeen: fixedLastSeen };
+
+    render(<PresenceViewerList viewers={[viewer]} onClose={vi.fn()} />);
+    expect(screen.getByText(/last seen 5 seconds ago/i)).toBeInTheDocument();
+
+    // After 30 s the text should NOT yet update (cadence is 60 s in reduced motion)
+    act(() => {
+      vi.advanceTimersByTime(30_000);
+    });
+    // The DOM still shows 5 seconds (tick hasn't fired yet)
+    expect(screen.getByText(/last seen 5 seconds ago/i)).toBeInTheDocument();
+
+    // After another 30 s (60 s total) the tick fires
+    act(() => {
+      vi.advanceTimersByTime(30_000);
+    });
+    expect(screen.getByText(/last seen 65 seconds ago/i)).toBeInTheDocument();
+
+    // Restore matchMedia
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: (query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      }),
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Keyboard behaviour
+// ---------------------------------------------------------------------------
+
+describe("PresenceViewerList – keyboard behaviour", () => {
+  it("calls onClose when Escape is pressed inside the list", () => {
+    const onClose = vi.fn();
+    render(<PresenceViewerList viewers={[baseViewer]} onClose={onClose} />);
+    fireEvent.keyDown(screen.getByRole("list"), { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call onClose for keys other than Escape", () => {
+    const onClose = vi.fn();
+    render(<PresenceViewerList viewers={[baseViewer]} onClose={onClose} />);
+    const list = screen.getByRole("list");
+    fireEvent.keyDown(list, { key: "Enter" });
+    fireEvent.keyDown(list, { key: "Tab" });
+    fireEvent.keyDown(list, { key: "ArrowDown" });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("stops propagation on Escape so parent Escape handlers do not double-fire", () => {
+    const parentHandler = vi.fn();
+    const onClose = vi.fn();
+
+    render(
+      // Simulate the PresenceBadge container having its own keydown handler
+      <div onKeyDown={parentHandler}>
+        <PresenceViewerList viewers={[baseViewer]} onClose={onClose} />
+      </div>
+    );
+    fireEvent.keyDown(screen.getByRole("list"), { key: "Escape" });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    // Propagation was stopped, so the parent should not have fired
+    expect(parentHandler).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Auto-focus behaviour
+// ---------------------------------------------------------------------------
+
+describe("PresenceViewerList – auto-focus", () => {
+  it("focuses the list container on mount by default (autoFocus=true)", () => {
+    render(<PresenceViewerList viewers={[baseViewer]} onClose={vi.fn()} />);
+    expect(document.activeElement).toBe(screen.getByRole("list"));
+  });
+
+  it("does not auto-focus when autoFocus=false", () => {
+    render(
+      <PresenceViewerList
+        viewers={[baseViewer]}
+        onClose={vi.fn()}
+        autoFocus={false}
+      />
+    );
+    expect(document.activeElement).not.toBe(screen.getByRole("list"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fading-out viewer
+// ---------------------------------------------------------------------------
+
+describe("PresenceViewerList – fading-out viewers", () => {
+  it("still renders a fading-out viewer in the list", () => {
+    const fadingViewer: Viewer = { ...baseViewer, fadingOut: true };
+    render(<PresenceViewerList viewers={[fadingViewer]} onClose={vi.fn()} />);
+    expect(screen.getByText("Alice Smith")).toBeInTheDocument();
+  });
+
+  it("adds the fading CSS class to a fading-out viewer row", () => {
+    const fadingViewer: Viewer = { ...baseViewer, fadingOut: true };
+    render(<PresenceViewerList viewers={[fadingViewer]} onClose={vi.fn()} />);
+    const row = screen.getByRole("listitem");
+    expect(row).toHaveClass("presence-viewer-row--fading");
+  });
+
+  it("does NOT add the fading class to an active viewer row", () => {
+    render(<PresenceViewerList viewers={[baseViewer]} onClose={vi.fn()} />);
+    const row = screen.getByRole("listitem");
+    expect(row).not.toHaveClass("presence-viewer-row--fading");
+  });
+
+  it("includes 'leaving' in the aria-label of a fading-out viewer row", () => {
+    const fadingViewer: Viewer = { ...baseViewer, fadingOut: true };
+    render(<PresenceViewerList viewers={[fadingViewer]} onClose={vi.fn()} />);
+    const row = screen.getByRole("listitem");
+    expect(row).toHaveAttribute("aria-label", "Alice Smith, leaving");
+  });
+
+  it("does not include 'leaving' in the aria-label of an active viewer row", () => {
+    render(<PresenceViewerList viewers={[baseViewer]} onClose={vi.fn()} />);
+    const row = screen.getByRole("listitem");
+    expect(row).toHaveAttribute("aria-label", "Alice Smith");
+  });
+
+  it("popover content stays stable when viewer list updates (fadingOut changes)", () => {
+    const { rerender } = render(
+      <PresenceViewerList viewers={[baseViewer]} onClose={vi.fn()} />
+    );
+    expect(screen.getByRole("list")).toBeInTheDocument();
+
+    // Simulate viewer starting to fade
+    rerender(
+      <PresenceViewerList
+        viewers={[{ ...baseViewer, fadingOut: true }]}
+        onClose={vi.fn()}
+      />
+    );
+    // List is still mounted with the fading viewer visible
+    expect(screen.getByRole("list")).toBeInTheDocument();
+    expect(screen.getByText("Alice Smith")).toBeInTheDocument();
+    expect(screen.getByRole("listitem")).toHaveClass("presence-viewer-row--fading");
   });
 });


### PR DESCRIPTION
  fix(presence): tighten tooltip/popover timing and add edge-case tests
  
  The tooltip and popover timing flow in PresenceViewerList and PresenceBadge had several
  implicit edge cases that weren't locked down by tests. This PR makes the behavior explicit and
  regression-safe without changing the existing user-facing flow.
  
  ───────────────────────────────────────────────────────────────────────────────────────────────
  
  What was wrong
  
  - The PresenceViewerList container had an onKeyDown Escape handler but no tabIndex, so keyboard
  focus never landed on it — the handler was effectively dead on open.
  - PresenceBadge used aria-haspopup="listbox" on its trigger button, but the popover is a
  role="list", not a role="listbox".
  - When Escape was pressed inside the list, both the list-level and the badge container-level
  handlers fired, calling onClose twice.
  - The badge container Escape handler had no isOpen guard, so it swallowed Escape events even
  when the popover was closed.
  - Fading-out viewers were visible in the avatar stack with a fade animation but had no visual
  or accessible indicator in the expanded viewer list.
  
  ───────────────────────────────────────────────────────────────────────────────────────────────
  
  Changes
  
  - PresenceViewerList: added tabIndex={-1}, a ref, and an autoFocus prop (default true) so the
  container receives focus the moment the popover opens. Added e.stopPropagation() on Escape to
  prevent the badge container handler from double-firing.
  - PresenceBadge: fixed aria-haspopup="listbox" → "true". Guarded the container Escape handler
  with && isOpen.
  - PresenceViewerList: fading-out viewer rows now carry a presence-viewer-row--fading CSS class
  and an aria-label suffix of ", leaving" to surface the state in the list.
  - Presence.css: added .presence-viewer-row--fading (reduced opacity) and
  .presence-viewer-dot--fading (muted dot colour).
  
  ───────────────────────────────────────────────────────────────────────────────────────────────
  
  Tests — 61 passing (up from 32)
  
  ┌────────────┬──────────────────────────────────────────────────────┐
  │ Area          │ Covered by new tests                                 │
  ├───────────────┼──────────────────────────────────────────────────────────────────┤
  │ Auto-focus      │ Container focused on mount; autoFocus=false skips it             │
  ├─────────────────┼──────────────────────────────────────────────────────────────────┤
  │ Escape scopes   │ List Escape stops propagation; badge Escape only fires when open │
  ├─────────────────┼─────────────────────────────────────────────────────────────────────────┤
  │ Fading-out rows │ CSS class present, aria-label says "leaving", row still visible         │
  ├─────────────────┼─────────────────────────────────────────────────────────────────────────┤
  │ Elapsed time    │ 0 s clamp (future lastSeen), 30 s tick update, prop-change update, 60 s │
  │                 │ reduced-motion cadence                                                  │
  ├─────────────────┼─────────────────────────────────────────────────────────────────────────┤
  │ Address masking │ Full Stellar G-address masked in the list; short/non-G IDs rendered raw │
  ├─────────────────┼─────────────────────────────────────────────────────────────────────────┤
  ├───────────────────┼───────────────────────────────────────────────────────────────────────┤
  │ Tooltip           │ role="tooltip" on each avatar span, Anonymous Viewer fallback, lives  │
  │                   │ inside aria-hidden stack                                              │
  ├───────────────────┼───────────────────────────────────────────────────────────────────────┤
  │ aria-haspopup     │ Regression guard for the corrected "true" value                       │
  ├───────────────────┼───────────────────────────────────────────────────────────────────────┤
  │ Popover stability │ Stays open on viewer list updates; fading state and new joiners       │
  │                   │ reflected live                                                        │
  └───────────────────┴───────────────────────────────────────────────────────────────────────┘
closes #1168