### PR TITLE
Fix #1119: Harden embed widget responsiveness for edge cases

### DIFF
--- a/src/pages/EmbedStreamWidget.tsx
+++ b/src/pages/EmbedStreamWidget.tsx
@@ -235,6 +235,7 @@ function EmbedWidgetSkeleton({ widgetPreset }: EmbedWidgetSkeletonProps) {
         aria-label="Loading stream widget"
         aria-busy="true"
         data-testid="embed-skeleton-compact"
+        className="embed-widget-compact"
       >
         <Skeleton width="100%" height={80} borderRadius={8} />
       </div>
@@ -250,7 +251,8 @@ function EmbedWidgetSkeleton({ widgetPreset }: EmbedWidgetSkeletonProps) {
         data-testid="embed-skeleton-banner"
         // Stack vertically by default; CSS widens to a flex-row at ≥640 px,
         // matching the real banner's responsive behaviour.
-        className="embed-widget-banner-skeleton"
+        className="embed-widget-banner-skeleton embed-widget-banner"
+        style={{ padding: "1rem", backgroundColor: "var(--color-surface-default, #fafbfc)" }}
       >
         {/* Info column */}
         <div className="embed-widget-banner-skeleton__info">
@@ -277,6 +279,7 @@ function EmbedWidgetSkeleton({ widgetPreset }: EmbedWidgetSkeletonProps) {
       aria-label="Loading stream widget"
       aria-busy="true"
       data-testid="embed-skeleton-card"
+      className="embed-widget-card"
     >
       <Skeleton width="80%" height={24} style={{ marginBottom: "0.75rem" }} />
       <Skeleton width="60%" height={16} style={{ marginBottom: "1.5rem" }} />
@@ -309,12 +312,15 @@ function EmbedWidgetErrorState({ error, widgetPreset, onRetry }: EmbedWidgetErro
       role="alert" 
       aria-live="assertive"
       data-testid="embed-error-state"
+      className={`embed-widget-${widgetPreset}`}
       style={{
-        padding: isCompact ? "0.5rem" : "1rem",
         backgroundColor: "var(--color-error-bg, #fef2f2)",
-        border: "1px solid var(--color-error-border, #dc2626)",
-        borderRadius: "8px",
-        color: "var(--color-error-text, #b91c1c)"
+        borderColor: "var(--color-error-border, #dc2626)",
+        color: "var(--color-error-text, #b91c1c)",
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "center",
+        alignItems: "flex-start",
       }}
     >
       <div style={{ 
@@ -342,6 +348,7 @@ function EmbedWidgetErrorState({ error, widgetPreset, onRetry }: EmbedWidgetErro
         <div style={{ marginTop: "0.75rem" }}>
           <button
             onClick={onRetry}
+            className="embed-widget-metric"
             style={{
               padding: "0.375rem 0.75rem",
               fontSize: "0.875rem",

--- a/src/pages/__tests__/EmbedStreamWidget.test.tsx
+++ b/src/pages/__tests__/EmbedStreamWidget.test.tsx
@@ -78,6 +78,7 @@ describe('EmbedStreamWidget', () => {
       expect(screen.getByRole('status')).toBeInTheDocument();
       expect(screen.getByLabelText('Loading stream widget')).toBeInTheDocument();
       expect(screen.getByRole('status')).toHaveAttribute('aria-busy', 'true');
+      expect(screen.getByRole('status')).toHaveClass('embed-widget-card');
     });
 
     it('shows card preset skeleton by default', () => {
@@ -87,6 +88,7 @@ describe('EmbedStreamWidget', () => {
       
       // Card skeleton has title skeleton and metrics grid
       expect(screen.getByRole('status')).toBeInTheDocument();
+      expect(screen.getByRole('status')).toHaveClass('embed-widget-card');
     });
 
     it('shows banner preset skeleton', () => {
@@ -95,6 +97,7 @@ describe('EmbedStreamWidget', () => {
       renderEmbedWidget('STR-001', 'preset=banner');
       
       expect(screen.getByRole('status')).toBeInTheDocument();
+      expect(screen.getByRole('status')).toHaveClass('embed-widget-banner-skeleton embed-widget-banner');
     });
 
     it('shows compact preset skeleton', () => {
@@ -103,6 +106,7 @@ describe('EmbedStreamWidget', () => {
       renderEmbedWidget('STR-001', 'preset=compact');
       
       expect(screen.getByRole('status')).toBeInTheDocument();
+      expect(screen.getByRole('status')).toHaveClass('embed-widget-compact');
     });
   });
 
@@ -114,6 +118,7 @@ describe('EmbedStreamWidget', () => {
 
       await waitFor(() => {
         expect(screen.getByRole('alert')).toBeInTheDocument();
+        expect(screen.getByRole('alert')).toHaveClass('embed-widget-card');
         expect(screen.getByText(/Stream unavailable/)).toBeInTheDocument();
         expect(screen.getByText(/Powered by Fluxora/)).toBeInTheDocument();
       });
@@ -137,6 +142,7 @@ describe('EmbedStreamWidget', () => {
 
       await waitFor(() => {
         expect(screen.getByRole('alert')).toBeInTheDocument();
+        expect(screen.getByRole('alert')).toHaveClass('embed-widget-compact');
         expect(screen.getByText(/Not found/)).toBeInTheDocument();
         // Compact shouldn't have "Powered by Fluxora" in the error
         expect(screen.queryByText(/Powered by Fluxora/)).not.toBeInTheDocument();


### PR DESCRIPTION
## Summary

Closes #1119 

<!-- What does this PR change and why? -->

## Changes

<!-- List the key changes made. -->

## Test plan

- [ ] `npm run build` passes (type-check + production build)
- [ ] `npm run test` passes (all unit tests green)
- [ ] `npm run test:coverage` passes (statements/branches/functions/lines ≥ 95%)
- [ ] New code is covered by tests; the coverage include list in `vitest.config.ts` is expanded if new production modules are added

## Coverage gate

CI enforces **95% coverage thresholds** (statements, branches, functions, lines) via
the `coverage` job in `.github/workflows/ci.yml`. The job runs `npm run test:coverage`
and fails the PR check when any threshold is missed. The coverage report is uploaded
as a build artifact for every run.

To add a new production file to the coverage baseline, append it to the `include`
array in `vitest.config.ts` and ensure tests cover it before opening the PR.
