### PR TITLE
fix(navbar): harden keyboard navigation and add regression tests

### DIFF
--- a/src/components/navigation/AppNavbar.tsx
+++ b/src/components/navigation/AppNavbar.tsx
@@ -316,12 +316,26 @@ const location = useLocation();
 
   const closeMobile = () => setMobileMenuOpen(false);
 
+  const handleHeaderKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
+    if (e.key === "Escape" && mobileMenuOpen) {
+      closeMobile();
+    }
+  };
+
   return (
     <header
       role="banner"
       aria-label="Global navigation"
+      onKeyDown={handleHeaderKeyDown}
       className="sticky top-0 z-50 w-full border-b border-[var(--navbar-border)] bg-[var(--navbar-bg)]/80 backdrop-blur-md"
     >
+      {/* Skip link — visually hidden until focused, lets keyboard users jump past the navbar */}
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:z-[9999] focus:top-2 focus:left-2 focus:px-4 focus:py-2 focus:rounded-md focus:bg-[var(--navbar-bg)] focus:text-[var(--text)] focus:outline-none focus:ring-2 focus:ring-[var(--color-focus)] focus:text-sm focus:font-semibold"
+      >
+        Skip to main content
+      </a>
       <div className="mx-auto flex h-16 max-w-7xl items-center justify-between px-4 sm:px-6">
         {/* Left: Logo */}
         <div className="flex items-center gap-4">
@@ -440,46 +454,23 @@ const location = useLocation();
             )}
           </div>
 
-          {/* Easy-read font toggle */}
-          <button
-            onClick={toggleEasyReadFont}
-            aria-label={`Switch to ${!easyReadFont ? "easy-read dyslexia-friendly" : "default"} font`}
-            aria-pressed={easyReadFont}
-            title={easyReadFont ? "Disable easy-read font" : "Enable easy-read font"}
-            className={`flex items-center justify-center min-h-[44px] min-w-[44px] px-2 rounded-full border transition-colors outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] ${
-              easyReadFont
-                ? "border-[var(--accent)] text-[var(--accent)] bg-[var(--surface-elevated)]"
-                : "border-[var(--navbar-icon-border)] text-[var(--navbar-icon-color)] hover:border-[var(--accent)]/50 hover:text-[var(--accent)]"
-            }`}
-          >
-            <span className="font-bold text-xs tracking-wider uppercase" aria-hidden="true">
-              Aa
-            </span>
-          </button>
-
-          {/* Wallet area */}
-          {connecting ? (
-            <ConnectingSkeleton />
-          ) : connected && address ? (
-            <WalletStatus
-              address={address}
-              network={network ?? "TESTNET"}
-              expectedNetwork={expectedNetwork}
-              isNetworkMismatch={isNetworkMismatch}
-              onDisconnect={disconnect}
-            />
-          ) : (
-            <Link
-              to="/connect-wallet"
-              aria-label="Connect your Stellar wallet"
-              className="px-5 h-[44px] rounded-full bg-[var(--cta-bg)] text-white text-sm font-semibold shadow-[var(--cta-shadow)] hover:opacity-90 transition-opacity outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] flex items-center"
+          {/* Mobile hamburger — anon (marketing) view only.
+               In app view the sidebar toggle above the logo handles mobile nav. */}
+          {!isAppView && (
+            <button
+              type="button"
+              className="md:hidden flex items-center justify-center w-11 h-11 rounded-lg text-[var(--navbar-icon-color)] hover:text-[var(--text)] hover:bg-[var(--surface-elevated)] transition-all outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+              onClick={() => setMobileMenuOpen((prev) => !prev)}
+              aria-label={mobileMenuOpen ? "Close navigation menu" : "Open navigation menu"}
+              aria-expanded={mobileMenuOpen}
+              aria-controls="mobile-nav"
             >
               {mobileMenuOpen ? (
                 <X size={22} aria-hidden="true" />
               ) : (
                 <Menu size={22} aria-hidden="true" />
               )}
-            </Link>
+            </button>
           )}
         </div>
       </div>

--- a/src/components/navigation/__tests__/AppNavbar.keyboard.test.tsx
+++ b/src/components/navigation/__tests__/AppNavbar.keyboard.test.tsx
@@ -1,0 +1,487 @@
+/**
+ * AppNavbar keyboard navigation regression tests
+ *
+ * Covers every keyboard edge case identified during the audit:
+ *   A. Skip-link presence and target
+ *   B. Focus order — skip-link is first; logo is second
+ *   C. Anon hamburger opens/closes the mobile menu, aria-expanded stays in sync
+ *   D. Escape key closes an open mobile menu
+ *   E. App-view sidebar toggle attributes (aria-expanded, aria-controls)
+ *   F. Desktop nav links carry correct aria-current and are Tab-reachable
+ *   G. Easy-read font button exists exactly once per view; aria-pressed reflects state
+ *   H. Connecting skeleton is announced as status role and suppresses action buttons
+ *   I. CTA link "Connect Wallet" renders text (not hamburger icons) in anon view
+ */
+
+import { act, fireEvent, render, screen, within } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import AppNavbar from "../AppNavbar";
+import { ThemeProvider } from "../../../theme/ThemeProvider";
+
+// ─── Shared mocks ─────────────────────────────────────────────────────────────
+
+vi.mock("../../voice/VoiceMicButton", () => ({
+  VoiceMicButton: () => <div data-testid="mock-voice-mic" />,
+}));
+
+vi.mock("../../../hooks/useTickingNow", () => ({
+  useTickingNow: () => "2026-07-27T12:00:00.000Z",
+}));
+
+// Wallet mock — reset per describe block via walletOverrides
+const defaultWallet = {
+  connected: false,
+  address: undefined as string | undefined,
+  network: undefined as string | undefined,
+  expectedNetwork: "TESTNET",
+  expectedNetworkLabel: "Testnet",
+  isNetworkMismatch: false,
+  disconnect: vi.fn(),
+};
+
+let walletOverrides: Partial<typeof defaultWallet> = {};
+
+vi.mock("../../wallet-connect/Walletcontext", () => ({
+  useWallet: () => ({ ...defaultWallet, ...walletOverrides }),
+}));
+
+// Router mock — pathname can be overridden per test
+let mockPathname = "/";
+vi.mock("react-router-dom", () => ({
+  Link: ({
+    children,
+    to,
+    ...props
+  }: React.PropsWithChildren<{ to: string; [key: string]: unknown }>) => (
+    <a href={String(to)} {...props}>
+      {children}
+    </a>
+  ),
+  useLocation: () => ({ pathname: mockPathname }),
+}));
+
+// localStorage stub
+beforeEach(() => {
+  const store: Record<string, string> = {};
+  vi.stubGlobal("localStorage", {
+    getItem: (k: string) => store[k] ?? null,
+    setItem: (k: string, v: string) => { store[k] = v; },
+    removeItem: (k: string) => { delete store[k]; },
+    clear: () => { for (const k in store) delete store[k]; },
+  });
+  vi.useFakeTimers();
+  walletOverrides = {};
+  mockPathname = "/";
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+/** Renders AppNavbar wrapped in ThemeProvider and flushes the connecting timer. */
+function renderNavbar(props: React.ComponentProps<typeof AppNavbar> = {}) {
+  const result = render(
+    <ThemeProvider>
+      <AppNavbar {...props} />
+    </ThemeProvider>,
+  );
+  act(() => vi.runAllTimers());
+  return result;
+}
+
+// ─── A. Skip-link ──────────────────────────────────────────────────────────────
+
+describe("A: Skip-link", () => {
+  it("is present in the DOM as the first link in the header", () => {
+    renderNavbar();
+    const header = screen.getByRole("banner");
+    const links = within(header).getAllByRole("link");
+    expect(links[0]).toHaveTextContent(/skip to main content/i);
+  });
+
+  it("points to #main-content", () => {
+    renderNavbar();
+    const skip = screen.getByRole("link", { name: /skip to main content/i });
+    expect(skip).toHaveAttribute("href", "#main-content");
+  });
+
+  it("is visually hidden by default (sr-only class)", () => {
+    renderNavbar();
+    const skip = screen.getByRole("link", { name: /skip to main content/i });
+    // sr-only is Tailwind's screen-reader-only utility — confirm the class is present
+    expect(skip.className).toMatch(/sr-only/);
+  });
+});
+
+// ─── B. Focus order ────────────────────────────────────────────────────────────
+
+describe("B: Focus order — skip-link precedes all other focusable elements", () => {
+  it("skip-link appears before the logo in DOM order (anon view)", () => {
+    renderNavbar();
+    const header = screen.getByRole("banner");
+    const allLinks = within(header).getAllByRole("link");
+    const skipIdx = allLinks.findIndex((el) =>
+      /skip to main content/i.test(el.textContent ?? ""),
+    );
+    const logoIdx = allLinks.findIndex((el) =>
+      /fluxora home/i.test(el.getAttribute("aria-label") ?? ""),
+    );
+    expect(skipIdx).toBeLessThan(logoIdx);
+  });
+
+  it("logo link has a descriptive aria-label in anon view", () => {
+    renderNavbar();
+    expect(
+      screen.getByRole("link", { name: /fluxora home/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("logo link has a descriptive aria-label in app (connected) view", () => {
+    walletOverrides = { connected: true, address: "GABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF12", network: "TESTNET" };
+    mockPathname = "/app";
+    renderNavbar();
+    expect(
+      screen.getByRole("link", { name: /fluxora home/i }),
+    ).toBeInTheDocument();
+  });
+});
+
+// ─── C. Anon hamburger (marketing mobile menu) ────────────────────────────────
+
+describe("C: Anon hamburger opens and closes the mobile menu", () => {
+  it("renders a hamburger button in anon view on mobile", () => {
+    renderNavbar();
+    // The button is md:hidden so it's always in the DOM; visibility is CSS-only
+    expect(
+      screen.getByRole("button", { name: /open navigation menu/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("aria-expanded starts as false", () => {
+    renderNavbar();
+    const btn = screen.getByRole("button", { name: /open navigation menu/i });
+    expect(btn).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("aria-expanded becomes true after one click", () => {
+    renderNavbar();
+    const btn = screen.getByRole("button", { name: /open navigation menu/i });
+    fireEvent.click(btn);
+    expect(
+      screen.getByRole("button", { name: /close navigation menu/i }),
+    ).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("mobile menu renders nav links when open", () => {
+    renderNavbar();
+    fireEvent.click(screen.getByRole("button", { name: /open navigation menu/i }));
+    // Both the always-visible desktop <nav> and the mobile dropdown share the same
+    // aria-label; query by id to target only the dropdown.
+    const mobileNav = document.getElementById("mobile-nav")!;
+    expect(mobileNav).toBeInTheDocument();
+    expect(within(mobileNav).getByRole("link", { name: /features/i })).toBeInTheDocument();
+    expect(within(mobileNav).getByRole("link", { name: /docs/i })).toBeInTheDocument();
+    expect(within(mobileNav).getByRole("link", { name: /pricing/i })).toBeInTheDocument();
+  });
+
+  it("clicking a nav link closes the mobile menu", () => {
+    renderNavbar();
+    fireEvent.click(screen.getByRole("button", { name: /open navigation menu/i }));
+    const mobileNav = document.getElementById("mobile-nav")!;
+    fireEvent.click(within(mobileNav).getByRole("link", { name: /features/i }));
+    expect(document.getElementById("mobile-nav")).not.toBeInTheDocument();
+  });
+
+  it("aria-controls points to the mobile nav element id", () => {
+    renderNavbar();
+    const btn = screen.getByRole("button", { name: /open navigation menu/i });
+    expect(btn).toHaveAttribute("aria-controls", "mobile-nav");
+    fireEvent.click(btn);
+    expect(document.getElementById("mobile-nav")).toBeInTheDocument();
+  });
+
+  it("does NOT render a separate anon hamburger in app (connected) view", () => {
+    walletOverrides = { connected: true, address: "GABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF12", network: "TESTNET" };
+    mockPathname = "/app";
+    renderNavbar();
+    // In app view only the sidebar toggle exists — no anon hamburger
+    expect(
+      screen.queryByRole("button", { name: /open navigation menu/i }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+// ─── D. Escape key closes open mobile menu ────────────────────────────────────
+
+describe("D: Escape key closes an open mobile menu", () => {
+  it("Escape while menu is open sets mobileMenuOpen to false", () => {
+    renderNavbar();
+    const header = screen.getByRole("banner");
+    fireEvent.click(screen.getByRole("button", { name: /open navigation menu/i }));
+    expect(document.getElementById("mobile-nav")).toBeInTheDocument();
+
+    fireEvent.keyDown(header, { key: "Escape", code: "Escape" });
+    expect(document.getElementById("mobile-nav")).not.toBeInTheDocument();
+  });
+
+  it("Escape while menu is already closed is a no-op (no error)", () => {
+    renderNavbar();
+    const header = screen.getByRole("banner");
+    // menu is already closed — Escape must not throw
+    expect(() => {
+      fireEvent.keyDown(header, { key: "Escape", code: "Escape" });
+    }).not.toThrow();
+    expect(document.getElementById("mobile-nav")).not.toBeInTheDocument();
+  });
+
+  it("hamburger button reflects closed state after Escape", () => {
+    renderNavbar();
+    const header = screen.getByRole("banner");
+    fireEvent.click(screen.getByRole("button", { name: /open navigation menu/i }));
+    fireEvent.keyDown(header, { key: "Escape", code: "Escape" });
+    const btn = screen.getByRole("button", { name: /open navigation menu/i });
+    expect(btn).toHaveAttribute("aria-expanded", "false");
+  });
+});
+
+// ─── E. App-view sidebar toggle ───────────────────────────────────────────────
+
+describe("E: App-view sidebar toggle (md:hidden)", () => {
+  const connectedState = {
+    connected: true,
+    address: "GABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF12",
+    network: "TESTNET",
+  };
+
+  it("renders the sidebar toggle in app view", () => {
+    walletOverrides = connectedState;
+    mockPathname = "/app";
+    renderNavbar({ onSidebarToggle: vi.fn(), isSidebarOpen: false });
+    expect(
+      screen.getByRole("button", { name: /open navigation sidebar/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("aria-expanded reflects isSidebarOpen=false", () => {
+    walletOverrides = connectedState;
+    mockPathname = "/app";
+    renderNavbar({ onSidebarToggle: vi.fn(), isSidebarOpen: false });
+    expect(
+      screen.getByRole("button", { name: /open navigation sidebar/i }),
+    ).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("aria-expanded reflects isSidebarOpen=true", () => {
+    walletOverrides = connectedState;
+    mockPathname = "/app";
+    renderNavbar({ onSidebarToggle: vi.fn(), isSidebarOpen: true });
+    expect(
+      screen.getByRole("button", { name: /close navigation sidebar/i }),
+    ).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("aria-controls points to app-sidebar", () => {
+    walletOverrides = connectedState;
+    mockPathname = "/app";
+    renderNavbar({ onSidebarToggle: vi.fn(), isSidebarOpen: false });
+    expect(
+      screen.getByRole("button", { name: /open navigation sidebar/i }),
+    ).toHaveAttribute("aria-controls", "app-sidebar");
+  });
+
+  it("calls onSidebarToggle when the sidebar button is clicked", () => {
+    walletOverrides = connectedState;
+    mockPathname = "/app";
+    const onSidebarToggle = vi.fn();
+    renderNavbar({ onSidebarToggle, isSidebarOpen: false });
+    fireEvent.click(screen.getByRole("button", { name: /open navigation sidebar/i }));
+    expect(onSidebarToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT render the sidebar toggle in anon view", () => {
+    renderNavbar({ onSidebarToggle: vi.fn(), isSidebarOpen: false });
+    expect(
+      screen.queryByRole("button", { name: /navigation sidebar/i }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+// ─── F. Desktop nav links (aria-current + Tab reachability) ──────────────────
+
+describe("F: Desktop nav links", () => {
+  it("anon view renders marketing links (Features, Docs, Pricing) in the desktop nav", () => {
+    renderNavbar();
+    const desktopNav = screen.getByRole("navigation", {
+      name: /marketing navigation/i,
+    });
+    expect(within(desktopNav).getByRole("link", { name: /^features$/i })).toBeInTheDocument();
+    expect(within(desktopNav).getByRole("link", { name: /^docs$/i })).toBeInTheDocument();
+    expect(within(desktopNav).getByRole("link", { name: /^pricing$/i })).toBeInTheDocument();
+  });
+
+  it("app view renders app links (Dashboard, Streams, Recipient) in the desktop nav", () => {
+    walletOverrides = { connected: true, address: "GABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF12", network: "TESTNET" };
+    mockPathname = "/app";
+    renderNavbar();
+    const desktopNav = screen.getByRole("navigation", { name: /app navigation/i });
+    expect(within(desktopNav).getByRole("link", { name: /^dashboard$/i })).toBeInTheDocument();
+    expect(within(desktopNav).getByRole("link", { name: /^streams$/i })).toBeInTheDocument();
+    expect(within(desktopNav).getByRole("link", { name: /^recipient$/i })).toBeInTheDocument();
+  });
+
+  it("the active app route link carries aria-current=page (Streams route)", () => {
+    walletOverrides = { connected: true, address: "GABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF12", network: "TESTNET" };
+    mockPathname = "/app/streams";
+    renderNavbar();
+    const desktopNav = screen.getByRole("navigation", { name: /app navigation/i });
+    expect(
+      within(desktopNav).getByRole("link", { name: /^streams$/i }),
+    ).toHaveAttribute("aria-current", "page");
+    // Recipient should NOT be active on /app/streams
+    expect(
+      within(desktopNav).getByRole("link", { name: /^recipient$/i }),
+    ).not.toHaveAttribute("aria-current");
+  });
+
+  it("Dashboard link carries aria-current=page on exactly /app", () => {
+    walletOverrides = { connected: true, address: "GABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF12", network: "TESTNET" };
+    mockPathname = "/app";
+    renderNavbar();
+    const desktopNav = screen.getByRole("navigation", { name: /app navigation/i });
+    expect(
+      within(desktopNav).getByRole("link", { name: /^dashboard$/i }),
+    ).toHaveAttribute("aria-current", "page");
+  });
+
+  it("all desktop nav links are Tab-reachable (no tabIndex -1)", () => {
+    walletOverrides = { connected: true, address: "GABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF12", network: "TESTNET" };
+    mockPathname = "/app";
+    renderNavbar();
+    const desktopNav = screen.getByRole("navigation", { name: /app navigation/i });
+    within(desktopNav).getAllByRole("link").forEach((link) => {
+      expect(link).not.toHaveAttribute("tabindex", "-1");
+    });
+  });
+});
+
+// ─── G. Easy-read font toggle ─────────────────────────────────────────────────
+
+describe("G: Easy-read font toggle", () => {
+  it("exactly one font toggle button is in the document in anon view", () => {
+    renderNavbar();
+    // The desktop-only button is hidden with CSS but still in the DOM.
+    // The outer duplicate must have been removed, leaving only the one inside md:flex.
+    const toggles = screen.getAllByRole("button", {
+      name: /toggle easy-read font/i,
+    });
+    expect(toggles).toHaveLength(1);
+  });
+
+  it("exactly one font toggle button is in the document in app (connected) view", () => {
+    walletOverrides = { connected: true, address: "GABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF12", network: "TESTNET" };
+    mockPathname = "/app";
+    renderNavbar();
+    const toggles = screen.getAllByRole("button", {
+      name: /toggle easy-read font/i,
+    });
+    expect(toggles).toHaveLength(1);
+  });
+
+  it("aria-pressed starts as false", () => {
+    renderNavbar();
+    const btn = screen.getByRole("button", { name: /toggle easy-read font/i });
+    expect(btn).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("aria-pressed becomes true after one click", () => {
+    renderNavbar();
+    const btn = screen.getByRole("button", { name: /toggle easy-read font/i });
+    fireEvent.click(btn);
+    expect(btn).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("aria-pressed returns to false after two clicks", () => {
+    renderNavbar();
+    const btn = screen.getByRole("button", { name: /toggle easy-read font/i });
+    fireEvent.click(btn);
+    fireEvent.click(btn);
+    expect(btn).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("mobile menu also contains a font toggle in anon view when open", () => {
+    renderNavbar();
+    fireEvent.click(screen.getByRole("button", { name: /open navigation menu/i }));
+    const mobileNav = document.getElementById("mobile-nav")!;
+    expect(mobileNav).toBeInTheDocument();
+    expect(
+      within(mobileNav).getAllByRole("button", { name: /toggle easy-read font|easy-read/i }).length,
+    ).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ─── H. Connecting skeleton ───────────────────────────────────────────────────
+
+describe("H: Connecting skeleton (wallet session restore)", () => {
+  it("shows a 'Connecting wallet…' status region while connecting", () => {
+    // Do NOT flush timers — check the interim state
+    render(
+      <ThemeProvider>
+        <AppNavbar />
+      </ThemeProvider>,
+    );
+    // The skeleton should be present before timers fire
+    const status = screen.getAllByRole("status");
+    expect(status.some((el) => /connecting wallet/i.test(el.getAttribute("aria-label") ?? ""))).toBe(true);
+  });
+
+  it("hides the skeleton and shows the CTA after the timer resolves (anon)", () => {
+    renderNavbar(); // flushes timers
+    expect(
+      screen.queryByRole("status", { name: /connecting wallet/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /connect your stellar wallet/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("hides the skeleton and shows WalletStatus after the timer resolves (connected)", () => {
+    walletOverrides = {
+      connected: true,
+      address: "GABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF12",
+      network: "TESTNET",
+    };
+    mockPathname = "/app";
+    renderNavbar(); // flushes timers
+    expect(
+      screen.queryByRole("status", { name: /connecting wallet/i }),
+    ).not.toBeInTheDocument();
+    // WalletStatus renders a wallet trigger button
+    expect(
+      screen.getByRole("button", { name: /open wallet options/i }),
+    ).toBeInTheDocument();
+  });
+});
+
+// ─── I. CTA link content ──────────────────────────────────────────────────────
+
+describe("I: Connect-wallet CTA renders text, not icons", () => {
+  it("CTA link text is 'Connect Wallet', not empty or icon-only", () => {
+    renderNavbar();
+    const cta = screen.getByRole("link", { name: /connect your stellar wallet/i });
+    // The textContent must include the label text, confirming no icon-only render
+    expect(cta.textContent?.trim()).toBe("Connect Wallet");
+  });
+
+  it("CTA link navigates to /connect-wallet", () => {
+    renderNavbar();
+    const cta = screen.getByRole("link", { name: /connect your stellar wallet/i });
+    expect(cta).toHaveAttribute("href", "/connect-wallet");
+  });
+
+  it("CTA link is focusable (no tabIndex -1)", () => {
+    renderNavbar();
+    const cta = screen.getByRole("link", { name: /connect your stellar wallet/i });
+    expect(cta).not.toHaveAttribute("tabindex", "-1");
+  });
+});


### PR DESCRIPTION
- Add skip-link as first focusable element in header
- Add anon-view hamburger button wired to mobileMenuOpen state
- Add Escape key handler on header to close mobile menu
- Remove duplicate outer easy-read font toggle button
- Remove broken outer wallet area that rendered hamburger icons inside the Connect Wallet CTA link

Tests (AppNavbar.keyboard.test.tsx, 39 cases):
- Skip-link presence, href, and sr-only visibility
- Focus order: skip-link before logo in DOM
- Anon hamburger: aria-expanded, aria-controls, mobile nav links, link-click closes menu, absent in app view
- Escape closes menu; no-op when already closed
- Sidebar toggle: aria-expanded, aria-controls, callback, absent in anon view
- Desktop nav links per view, aria-current, Tab reachability
- Font toggle count (no duplicate), aria-pressed lifecycle, mobile menu toggle
- Connecting skeleton role=status; resolves to CTA or WalletStatus
- CTA renders text not icons, correct href, focusable

## Summary

<!-- What does this PR change and why? -->

## Changes

<!-- List the key changes made. -->

## Test plan

- [ ] `npm run build` passes (type-check + production build)
- [ ] `npm run test` passes (all unit tests green)
- [ ] `npm run test:coverage` passes (statements/branches/functions/lines ≥ 95%)
- [ ] New code is covered by tests; the coverage include list in `vitest.config.ts` is expanded if new production modules are added

## Coverage gate

CI enforces **95% coverage thresholds** (statements, branches, functions, lines) via
the `coverage` job in `.github/workflows/ci.yml`. The job runs `npm run test:coverage`
and fails the PR check when any threshold is missed. The coverage report is uploaded
as a build artifact for every run.

To add a new production file to the coverage baseline, append it to the `include`
array in `vitest.config.ts` and ensure tests cover it before opening the PR.
closes #1127
