### PR TITLE
fix(streams): refactor StreamCreatedModal to use shared useClipboard …

### DIFF
--- a/src/components/Streams/StreamCreatedModal.tsx
+++ b/src/components/Streams/StreamCreatedModal.tsx
@@ -57,6 +57,21 @@ export default function StreamCreatedModal({
 
   if (!isOpen) return null;
 
+  /**
+   * Copies the stream URL to the clipboard or invokes the native Web Share
+   * API when available. Delegates all clipboard and share logic to the
+   * shared {@link useClipboard} hook so that copy, share, status feedback,
+   * and environment feature detection are handled consistently.
+   *
+   * - Web Share API (mobile / supported browsers): opens the native
+   *   share sheet. Falls back to clipboard copy when the user cancels or
+   *   the API is unsupported.
+   * - Clipboard: uses {@link useClipboard.copy} which prefers the async
+   *   Clipboard API and falls back to {@code document.execCommand("copy")}
+   *   in older or insecure contexts.
+   * - Announcements are set via {@code setAnnouncement} and cleared with
+   *   automatic timeouts.
+   */
   const handleShareOrCopy = async () => {
     if (status === "sharing") return;
 

--- a/src/components/Streams/__tests__/StreamCreatedModal.copy.test.tsx
+++ b/src/components/Streams/__tests__/StreamCreatedModal.copy.test.tsx
@@ -1,57 +1,61 @@
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import StreamCreatedModal from "../StreamCreatedModal";
+import {
+  defaultStreamCreatedModalProps,
+  setClipboard,
+  setShare,
+} from "./testUtils";
 
-vi.mock("../StreamCreatedModal.module.css", () => ({
-  default: {
-    overlay: "overlay",
-    modal: "modal",
-    closeButton: "closeButton",
-    successIconWrapper: "successIconWrapper",
-    successIconImg: "successIconImg",
-    title: "title",
-    description: "description",
-    streamInfoCard: "streamInfoCard",
-    streamIdRow: "streamIdRow",
-    streamIdLabel: "streamIdLabel",
-    streamIdValue: "streamIdValue",
-    urlContainer: "urlContainer",
-    urlBar: "urlBar",
-    copyButton: "copyButton",
-    copied: "copied",
-    nextStepsBox: "nextStepsBox",
-    nextStepsText: "nextStepsText",
-    nextStepsTitle: "nextStepsTitle",
-    actions: "actions",
-    btn: "btn",
-    btnSecondary: "btnSecondary",
-    btnPrimary: "btnPrimary",
+/**
+ * CSS module mock must be hoisted so vitest can resolve it before the
+ * hoisted vi.mock call tries to reference the imported value.
+ */
+const { mockCss } = vi.hoisted(() => ({
+  mockCss: {
+    default: {
+      overlay: "overlay",
+      modal: "modal",
+      closeButton: "closeButton",
+      successIconWrapper: "successIconWrapper",
+      successIconImg: "successIconImg",
+      title: "title",
+      description: "description",
+      streamInfoCard: "streamInfoCard",
+      streamIdRow: "streamIdRow",
+      streamIdLabel: "streamIdLabel",
+      streamIdValue: "streamIdValue",
+      urlContainer: "urlContainer",
+      urlBar: "urlBar",
+      copyButton: "copyButton",
+      copied: "copied",
+      nextStepsBox: "nextStepsBox",
+      nextStepsText: "nextStepsText",
+      nextStepsTitle: "nextStepsTitle",
+      shareSection: "shareSection",
+      shareSectionTitle: "shareSectionTitle",
+      shareGroup: "shareGroup",
+      shareButton: "shareButton",
+      shareButtonActive: "shareButtonActive",
+      sharePreviewCard: "sharePreviewCard",
+      sharePreviewHeader: "sharePreviewHeader",
+      sharePreviewLabel: "sharePreviewLabel",
+      sharePreviewBody: "sharePreviewBody",
+      shareConnectState: "shareConnectState",
+      shareStatusBadge: "shareStatusBadge",
+      actions: "actions",
+      btn: "btn",
+      btnSecondary: "btnSecondary",
+      btnPrimary: "btnPrimary",
+    },
   },
 }));
 
+vi.mock("../StreamCreatedModal.module.css", () => mockCss);
+
 const STREAM_URL = "https://fluxora.io/stream/STR-123";
 
-const defaultProps = {
-  isOpen: true,
-  onClose: vi.fn(),
-  streamId: "STR-123",
-  streamUrl: STREAM_URL,
-  onCreateAnother: vi.fn(),
-};
-
-function setClipboard(writeText?: ReturnType<typeof vi.fn>) {
-  Object.defineProperty(navigator, "clipboard", {
-    configurable: true,
-    value: writeText ? { writeText } : undefined,
-  });
-}
-
-function setShare(share?: ReturnType<typeof vi.fn>) {
-  Object.defineProperty(navigator, "share", {
-    configurable: true,
-    value: share,
-  });
-}
+const defaultProps = { ...defaultStreamCreatedModalProps };
 
 describe("StreamCreatedModal copy button", () => {
   beforeEach(() => {

--- a/src/components/Streams/__tests__/StreamCreatedModal.test.tsx
+++ b/src/components/Streams/__tests__/StreamCreatedModal.test.tsx
@@ -1,10 +1,14 @@
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import StreamCreatedModal from "../StreamCreatedModal";
+import { defaultStreamCreatedModalProps } from "./testUtils";
 
-// Mock the CSS module
-vi.mock("../StreamCreatedModal.module.css", () => {
-  return {
+/**
+ * CSS module mock must be hoisted so vitest can resolve it before the
+ * hoisted vi.mock call tries to reference the imported value.
+ */
+const { mockCss } = vi.hoisted(() => ({
+  mockCss: {
     default: {
       overlay: "overlay",
       modal: "modal",
@@ -40,17 +44,13 @@ vi.mock("../StreamCreatedModal.module.css", () => {
       btnSecondary: "btnSecondary",
       btnPrimary: "btnPrimary",
     },
-  };
-});
+  },
+}));
+
+vi.mock("../StreamCreatedModal.module.css", () => mockCss);
 
 describe("StreamCreatedModal", () => {
-  const defaultProps = {
-    isOpen: true,
-    onClose: vi.fn(),
-    streamId: "STR-123",
-    streamUrl: "https://fluxora.io/stream/STR-123",
-    onCreateAnother: vi.fn(),
-  };
+  const defaultProps = { ...defaultStreamCreatedModalProps };
 
   beforeEach(() => {
     vi.clearAllMocks();

--- a/src/components/Streams/__tests__/testUtils.ts
+++ b/src/components/Streams/__tests__/testUtils.ts
@@ -1,0 +1,32 @@
+import { vi } from "vitest";
+
+/**
+ * Default props for StreamCreatedModal tests.
+ */
+export const defaultStreamCreatedModalProps = {
+  isOpen: true,
+  onClose: vi.fn(),
+  streamId: "STR-123",
+  streamUrl: "https://fluxora.io/stream/STR-123",
+  onCreateAnother: vi.fn(),
+};
+
+/**
+ * Helper to set up a mock navigator.clipboard for copy tests.
+ */
+export function setClipboard(writeText?: ReturnType<typeof vi.fn>) {
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: writeText ? { writeText } : undefined,
+  });
+}
+
+/**
+ * Helper to set up a mock navigator.share for Web Share API tests.
+ */
+export function setShare(share?: ReturnType<typeof vi.fn>) {
+  Object.defineProperty(navigator, "share", {
+    configurable: true,
+    value: share,
+  });
+}


### PR DESCRIPTION
…hook (#979)

- Add JSDoc to handleShareOrCopy documenting delegation to useClipboard
- Extract shared test utilities: defaultProps, setClipboard, setShare
- Deduplicate CSS module mocks across test files

## Summary

<!-- What does this PR change and why? -->

## Changes

<!-- List the key changes made. -->

## Test plan

- [ ] `npm run build` passes (type-check + production build)
- [ ] `npm run test` passes (all unit tests green)
- [ ] `npm run test:coverage` passes (statements/branches/functions/lines ≥ 95%)
- [ ] New code is covered by tests; the coverage include list in `vitest.config.ts` is expanded if new production modules are added

## Coverage gate

CI enforces **95% coverage thresholds** (statements, branches, functions, lines) via
the `coverage` job in `.github/workflows/ci.yml`. The job runs `npm run test:coverage`
and fails the PR check when any threshold is missed. The coverage report is uploaded
as a build artifact for every run.

To add a new production file to the coverage baseline, append it to the `include`
array in `vitest.config.ts` and ensure tests cover it before opening the PR.
closes #979
