### PR TITLE
fix(tests): resolve VoiceMicButton sidebar test failures for multiple…

### DIFF
--- a/src/components/voice/__tests__/VoiceMicButton.test.tsx
+++ b/src/components/voice/__tests__/VoiceMicButton.test.tsx
@@ -71,7 +71,7 @@ describe("VoiceMicButton — navbar variant", () => {
     it(`state="${state}" renders correct aria-label`, () => {
       mockUseVoiceContext(buildCtx({ state }));
       render(<VoiceMicButton variant="navbar" />);
-      const btn = screen.getByRole("button");
+      const btn = screen.getAllByRole("button")[0];
       expect(btn.getAttribute("aria-label")?.toLowerCase()).toContain(
         labelFragment.toLowerCase()
       );
@@ -167,7 +167,7 @@ describe("VoiceMicButton — sidebar variant", () => {
     it(`state="${state}" renders correct aria-label`, () => {
       mockUseVoiceContext(buildCtx({ state }));
       render(<VoiceMicButton variant="sidebar" />);
-      const btn = screen.getByRole("button");
+      const btn = screen.getAllByRole("button")[0];
       expect(btn.getAttribute("aria-label")?.toLowerCase()).toContain(
         labelFragment.toLowerCase()
       );


### PR DESCRIPTION
… buttons

Fixes #985 - The sidebar variant renders 2 buttons (mic + Help toggle), causing getByRole(button) to fail. Changed to getAllByRole(button)[0].

## Summary

<!-- What does this PR change and why? -->

## Changes

<!-- List the key changes made. -->

## Test plan

- [ ] `npm run build` passes (type-check + production build)
- [ ] `npm run test` passes (all unit tests green)
- [ ] `npm run test:coverage` passes (statements/branches/functions/lines ≥ 95%)
- [ ] New code is covered by tests; the coverage include list in `vitest.config.ts` is expanded if new production modules are added

## Coverage gate

CI enforces **95% coverage thresholds** (statements, branches, functions, lines) via
the `coverage` job in `.github/workflows/ci.yml`. The job runs `npm run test:coverage`
and fails the PR check when any threshold is missed. The coverage report is uploaded
as a build artifact for every run.

To add a new production file to the coverage baseline, append it to the `include`
array in `vitest.config.ts` and ensure tests cover it before opening the PR.
closes #985 