### PR TITLE
design: spec flash-free cross-tab theme transition

### DIFF
--- a/src/design-tokens.css
+++ b/src/design-tokens.css
@@ -1219,3 +1219,30 @@
   }
 }
 
+/* ═══════════════════════════════════════════════════════════
+   14. CROSS-TAB THEME TRANSITION (.theme-transitioning)
+   ═══════════════════════════════════════════════════════════
+   See docs/THEME_CROSSFADE_TRANSITION_SPEC.md for the full design.
+
+   `ThemeProvider.applyTheme()` toggles `.theme-transitioning` on <html>
+   around every theme change (immediately before the `data-theme` update,
+   removed after the transition duration — deferred via `visibilitychange`
+   while the tab is hidden, so a background-tab flip cross-fades on refocus
+   instead of reading as an instant, jarring flash). The class was already
+   wired up on the JS side; this section supplies the CSS that was
+   previously missing, per the spec's documented property list:
+   background-color, border-color, color, fill, stroke transition; focus
+   rings (box-shadow/outline) are intentionally excluded so they never look
+   ambiguous mid-fade. `prefers-reduced-motion` is handled globally above,
+   which also zeroes this duration. */
+
+.theme-transitioning,
+.theme-transitioning * {
+  transition-property: background-color, border-color, color, fill, stroke;
+  transition-duration: var(--transition-base);
+  transition-timing-function: var(--ease-in-out);
+}
+
+.theme-transitioning *:focus-visible {
+  transition: none;
+}


### PR DESCRIPTION
Closes #1000

## Update
Rebased onto current `main`. Upstream's PR #922 already merged the `.theme-transitioning` class-toggling logic in `ThemeProvider.tsx` (with proper `visibilitychange`-aware deferral while the tab is hidden — more robust than my original approach) and documented the intended CSS in `docs/THEME_CROSSFADE_TRANSITION_SPEC.md`, **but the CSS rule for `.theme-transitioning` was never actually added** — the class had zero visual effect.

This PR now contains just that missing piece: a 27-line addition to `design-tokens.css` implementing the transition exactly as already documented (background-color/border-color/color/fill/stroke, `--transition-base` timing, focus-visible excluded so rings never fade ambiguously).

## Testing
Full `vitest` suite run against current `main` + this change: 2733 passed, 33 pre-existing failures unrelated to this diff (confirmed zero-diff on the failing files/areas before this change — date-dependent tests, not caused by this PR).
