### PR TITLE
fix(csv-upload): refine edge case handling for preview validation

### DIFF
--- a/src/components/csv-upload/PreviewValidateStep.css
+++ b/src/components/csv-upload/PreviewValidateStep.css
@@ -464,3 +464,54 @@
     min-width: unset;
   }
 }
+
+/* ─── Edge states ───────────────────────────────────────────────────────── */
+.csv-preview-step--loading,
+.csv-preview-step--error {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 3rem 1rem;
+  text-align: center;
+  background: var(--surface-raised);
+  border: 1px dashed var(--border);
+  border-radius: 8px;
+  gap: 1rem;
+}
+
+.csv-preview-loading-spinner {
+  width: 2rem;
+  height: 2rem;
+  border: 3px solid var(--border);
+  border-top-color: var(--primary);
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.csv-preview-error-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--color-danger, #ef4444);
+}
+
+.csv-preview-error-actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.csv-preview-empty-state {
+  text-align: center;
+  padding: 2rem;
+  color: var(--muted);
+  background: var(--surface-raised);
+}
+

--- a/src/components/csv-upload/PreviewValidateStep.tsx
+++ b/src/components/csv-upload/PreviewValidateStep.tsx
@@ -10,7 +10,11 @@ export interface PreviewValidateStepProps {
   onRowsChange: (rows: CsvRow[]) => void;
   onReview: () => void;
   onReplaceFile: () => void;
+  isLoading?: boolean;
+  error?: string | null;
+  onRetry?: () => void;
 }
+
 
 // ─── Status badge ─────────────────────────────────────────────────────────────
 
@@ -289,6 +293,9 @@ const PreviewValidateStep: React.FC<PreviewValidateStepProps> = ({
   onRowsChange,
   onReview,
   onReplaceFile,
+  isLoading,
+  error,
+  onRetry,
 }) => {
   const [editingRowId, setEditingRowId] = useState<string | null>(null);
   const [liveMessage, setLiveMessage] = useState('');
@@ -392,6 +399,36 @@ const PreviewValidateStep: React.FC<PreviewValidateStepProps> = ({
     setIsConfirmModalOpen(false);
   }, []);
 
+  if (isLoading) {
+    return (
+      <div className="csv-preview-step csv-preview-step--loading" aria-busy="true" aria-live="polite">
+        <div className="csv-preview-loading-spinner" />
+        <p>Loading preview...</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="csv-preview-step csv-preview-step--error" role="alert">
+        <div className="csv-preview-error-content">
+          <ErrorIcon />
+          <p>{error}</p>
+        </div>
+        <div className="csv-preview-error-actions">
+          {onRetry && (
+            <button type="button" className="btn btn-secondary" onClick={onRetry}>
+              Retry
+            </button>
+          )}
+          <button type="button" className="btn btn-back" onClick={onReplaceFile}>
+            Replace CSV
+          </button>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="csv-preview-step">
       {/* ── Summary bar ── */}
@@ -453,7 +490,16 @@ const PreviewValidateStep: React.FC<PreviewValidateStepProps> = ({
             </tr>
           </thead>
           <tbody>
-            {rows.map((row) => {
+            {rows.length === 0 ? (
+              <tr>
+                <td colSpan={6} className="csv-preview-empty-state">
+                  <div className="csv-preview-empty-content">
+                    <p>No valid rows found in this file.</p>
+                  </div>
+                </td>
+              </tr>
+            ) : (
+              rows.map((row) => {
               const isEditing = editingRowId === row.id;
               const firstFieldError = Object.entries(row.fieldErrors)[0];
 

--- a/src/components/csv-upload/__tests__/PreviewValidateStep.test.tsx
+++ b/src/components/csv-upload/__tests__/PreviewValidateStep.test.tsx
@@ -27,7 +27,7 @@ function makeRow(overrides: Partial<CsvRow> = {}): CsvRow {
   };
 }
 
-function renderStep(rows: CsvRow[]) {
+function renderStep(rows: CsvRow[], extraProps: Partial<import('../PreviewValidateStep').PreviewValidateStepProps> = {}) {
   const onRowsChange = vi.fn();
   const onReview = vi.fn();
   const onReplaceFile = vi.fn();
@@ -37,6 +37,7 @@ function renderStep(rows: CsvRow[]) {
       onRowsChange={onRowsChange}
       onReview={onReview}
       onReplaceFile={onReplaceFile}
+      {...extraProps}
     />,
   );
   return { onRowsChange, onReview, onReplaceFile, result };
@@ -180,6 +181,35 @@ describe('PreviewValidateStep', () => {
     it('appends "d" suffix to duration value', () => {
       renderStep([makeRow({ durationDays: '60' })]);
       expect(screen.getByText('60d')).toBeInTheDocument();
+    });
+  });
+
+  describe('edge states', () => {
+    it('renders loading state when isLoading is true', () => {
+      renderStep([], { isLoading: true });
+      expect(screen.getByText('Loading preview...')).toBeInTheDocument();
+      expect(screen.getByRole('status', { busy: true })).toBeInTheDocument();
+    });
+
+    it('renders error state with retry and replace actions', async () => {
+      const user = userEvent.setup();
+      const onRetry = vi.fn();
+      const { onReplaceFile } = renderStep([], { error: 'Failed to parse CSV', onRetry });
+      
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+      expect(screen.getByText('Failed to parse CSV')).toBeInTheDocument();
+      
+      await user.click(screen.getByRole('button', { name: 'Retry' }));
+      expect(onRetry).toHaveBeenCalledTimes(1);
+
+      await user.click(screen.getByRole('button', { name: 'Replace CSV' }));
+      expect(onReplaceFile).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders empty table body when rows array is empty', () => {
+      renderStep([]);
+      expect(screen.getByText('No valid rows found in this file.')).toBeInTheDocument();
+      expect(screen.queryByRole('row', { name: /Row 1/ })).not.toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
Closes #1134 

## Summary

This PR tightens up the CSV upload preview validation step (`PreviewValidateStep`) by explicitly handling edge cases that were previously implicit. While the core user flow and happy path remain visible and backward-compatible, this change ensures that states for loading, errors, and empty datasets are explicitly rendered and regression-safe.

## Changes

- **Loading State**: Added an explicit `isLoading` state which displays a dedicated loading spinner and message when processing the CSV.
- **Error State**: Added an explicit `error` state and an optional `onRetry` callback that renders an inline error alert with retry and file replacement actions if the upload or validation fails.
- **Empty State**: Refined the empty state to provide a clear "No valid rows found in this file" message inside the table layout when the parsed rows array is empty.
- **Responsive Styling**: Updated CSS in `PreviewValidateStep.css` to accommodate these new edge states cleanly and responsively.
- **Tests**: Expanded unit tests in `PreviewValidateStep.test.tsx` to explicitly cover the loading, error, and empty states.

## Test plan

- [ ] `npm run build` passes (type-check + production build)
- [ ] `npm run test` passes (all unit tests green)
- [ ] `npm run test:coverage` passes (statements/branches/functions/lines ≥ 95%)
- [ ] New code is covered by tests; the coverage include list in `vitest.config.ts` is expanded if new production modules are added

## Coverage gate

CI enforces **95% coverage thresholds** (statements, branches, functions, lines) via
the `coverage` job in `.github/workflows/ci.yml`. The job runs `npm run test:coverage`
and fails the PR check when any threshold is missed. The coverage report is uploaded
as a build artifact for every run.

To add a new production file to the coverage baseline, append it to the `include`
array in `vitest.config.ts` and ensure tests cover it before opening the PR.
