### PR TITLE
fix: size ThemeSegmentedControl icons per --icon-size-sm

### DIFF
--- a/src/components/navigation/ThemeSegmentedControl.tsx
+++ b/src/components/navigation/ThemeSegmentedControl.tsx
@@ -64,7 +64,7 @@ export default function ThemeSegmentedControl() {
                 : "border-[var(--navbar-icon-border)] text-[var(--navbar-icon-color)] hover:border-[var(--accent)]/50 hover:text-[var(--accent)] bg-transparent"
             }`}
           >
-            <Icon className="icon-xs" aria-hidden="true" />
+            <Icon className="icon-sm" aria-hidden="true" />
             <span className="sr-only md:not-sr-only font-sans text-xs font-semibold">
               {opt.label}
             </span>

--- a/src/components/navigation/__tests__/ThemeSegmentedControl.test.tsx
+++ b/src/components/navigation/__tests__/ThemeSegmentedControl.test.tsx
@@ -105,4 +105,16 @@ describe("ThemeSegmentedControl", () => {
     expect(radios[2]).toHaveAttribute("aria-checked", "true");
     expect(localStorage.getItem("theme")).toBeNull();
   });
+
+  it("sizes icons per --icon-size-sm as specified (not --icon-size-xs)", () => {
+    const { container } = render(
+      <ThemeProvider>
+        <ThemeSegmentedControl />
+      </ThemeProvider>
+    );
+
+    const icons = container.querySelectorAll("svg.icon-sm");
+    expect(icons).toHaveLength(3);
+    expect(container.querySelectorAll("svg.icon-xs")).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
Closes #1001

## Problem
Issue #1001's requirements explicitly specify: "Define iconography for each of the three states (sun/moon/auto) sized per `--icon-size-sm`". The already-merged implementation (PR #914) uses the `icon-xs` (16px) utility class instead of `icon-sm` (20px) on the Sun/Moon/Monitor icons in `ThemeSegmentedControl.tsx`.

## What changed
- `ThemeSegmentedControl.tsx`: `className="icon-xs"` → `className="icon-sm"` on the icon.
- Added a regression test asserting the rendered icons carry `icon-sm` (not `icon-xs`).

## Testing
`vitest run` on the affected test file: 5 passed. `eslint`/`tsc -b` clean on the changed files.
