### PR TITLE
fix(a11y): give the widget Move button a unique accessible name

### DIFF
--- a/docs/TREASURY_WIDGET_DRAG_ARRANGE_SPEC.md
+++ b/docs/TREASURY_WIDGET_DRAG_ARRANGE_SPEC.md
@@ -91,6 +91,10 @@ The standard accent cyan `--color-accent-primary` (`#00b8d4`) fails contrast che
 - **Move Trigger Button:**
   - Standard focusable `<button class="keyboard-move-btn">`. Visually hidden by default, becomes visible when keyboard focused.
   - Activating (Space / Enter) reveals the Move menu.
+  - `aria-label="Move {label} widget"` gives each button a unique accessible
+    name — with many widgets on the page, a bare "Move" name is
+    indistinguishable to screen reader users navigating by element list.
+  - `aria-haspopup="menu"` / `aria-expanded` expose the menu-trigger state.
 - **Move Directional Menu:**
   - Renders menu options (Move Left / Right / Up / Down) with appropriate disabled states (e.g. Move Left is disabled for the first widget).
   - Pressing Escape closes the menu and returns focus to the trigger button.

--- a/src/components/treasuryOverviewPage/MetricCard.test.tsx
+++ b/src/components/treasuryOverviewPage/MetricCard.test.tsx
@@ -30,11 +30,43 @@ describe("MetricCard", () => {
   it("applies correct styles from design tokens", () => {
     const { container } = render(<MetricCard {...mockMetric} />);
     const card = container.firstChild as HTMLElement;
-    
+
     // Check inline styles use CSS variables (jsdom doesn't resolve them)
     const inlineStyle = card.getAttribute("style") || "";
     expect(inlineStyle).toContain("var(--color-surface-default)");
     expect(inlineStyle).toContain("var(--color-border-default)");
+  });
+
+  describe("keyboard Move button accessibility", () => {
+    const moveMenuOptions = {
+      onMoveLeft: () => {},
+      onMoveRight: () => {},
+      onMoveUp: () => {},
+      onMoveDown: () => {},
+      canMoveLeft: true,
+      canMoveRight: true,
+      canMoveUp: true,
+      canMoveDown: true,
+    };
+
+    it("gives the Move button a widget-specific accessible name", () => {
+      render(<MetricCard {...mockMetric} moveMenuOptions={moveMenuOptions} />);
+      // A bare "Move" name is ambiguous across many widgets on the same
+      // page — screen reader users tabbing/list-navigating between cards
+      // would hear an identical, indistinguishable "Move, button" for
+      // every single widget without a per-widget label.
+      expect(
+        screen.getByRole("button", { name: "Move Total Balance widget" }),
+      ).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: "Move" })).not.toBeInTheDocument();
+    });
+
+    it("exposes menu-trigger semantics (aria-haspopup, aria-expanded)", () => {
+      render(<MetricCard {...mockMetric} moveMenuOptions={moveMenuOptions} />);
+      const trigger = screen.getByRole("button", { name: "Move Total Balance widget" });
+      expect(trigger).toHaveAttribute("aria-haspopup", "menu");
+      expect(trigger).toHaveAttribute("aria-expanded", "false");
+    });
   });
 
   describe("locale resilience", () => {

--- a/src/components/treasuryOverviewPage/MetricCard.tsx
+++ b/src/components/treasuryOverviewPage/MetricCard.tsx
@@ -201,6 +201,9 @@ export default function MetricCard({
           <div style={{ position: "relative" }}>
             <button
               className="keyboard-move-btn"
+              aria-label={`Move ${label} widget`}
+              aria-haspopup="menu"
+              aria-expanded={isMoveMenuOpen}
               onClick={(e) => {
                 e.stopPropagation();
                 setIsMoveMenuOpen(!isMoveMenuOpen);

--- a/src/components/treasuryOverviewPage/__tests__/Metrics.test.tsx
+++ b/src/components/treasuryOverviewPage/__tests__/Metrics.test.tsx
@@ -162,7 +162,7 @@ describe("Metrics", () => {
       render(<Metrics metrics={treasuryDemoMetrics} />);
 
       // Open the move-menu on the first widget ("Active Streams")
-      const [firstMoveBtn] = screen.getAllByRole("button", { name: "Move" });
+      const [firstMoveBtn] = screen.getAllByRole("button", { name: "Move Active Streams widget" });
       await user.click(firstMoveBtn);
 
       // The "Move Down" menu item should now be enabled (idx 0 + 1 < 3)
@@ -184,7 +184,7 @@ describe("Metrics", () => {
       const user = userEvent.setup();
       render(<Metrics metrics={treasuryDemoMetrics} />);
 
-      const [firstMoveBtn] = screen.getAllByRole("button", { name: "Move" });
+      const [firstMoveBtn] = screen.getAllByRole("button", { name: "Move Active Streams widget" });
       await user.click(firstMoveBtn);
 
       const moveDownItem = screen.getByRole("menuitem", { name: "Move Down" });
@@ -210,7 +210,7 @@ describe("Metrics", () => {
       ];
       render(<Metrics metrics={fourMetrics} />);
 
-      const [firstMoveBtn] = screen.getAllByRole("button", { name: "Move" });
+      const [firstMoveBtn] = screen.getAllByRole("button", { name: "Move Active Streams widget" });
       await user.click(firstMoveBtn);
 
       const moveDownItem = screen.getByRole("menuitem", { name: "Move Down" });


### PR DESCRIPTION
Closes #1005

## Problem
Issue #1005 requires the drag-to-arrange widget system to be accessible, with a keyboard-only reorder alternative for screen reader users. The already-merged implementation's "Move" trigger button (`.keyboard-move-btn` in `MetricCard.tsx`) has no `aria-label` — its only accessible name is its literal text, "Move", identical across every widget card on the page.

For a treasury dashboard with several metric widgets, a screen reader user navigating by element/button list hears "Move, button" repeated indistinguishably for every single widget, with no way to tell which widget's reorder menu they're about to open. The adjacent kebab ("⋮") menu button already does this correctly (`aria-label="Menu for {label}"`), so this brings the primary keyboard reorder control in line with that existing pattern.

Also missing: `aria-haspopup="menu"` / `aria-expanded`, despite the button opening a `role="menu"` popup — added alongside the label fix since they're the same control.

## What changed
- `MetricCard.tsx`: `aria-label={`Move ${label} widget`}`, `aria-haspopup="menu"`, `aria-expanded={isMoveMenuOpen}` on the Move trigger button.
- Updated 3 existing `Metrics.test.tsx` tests that queried the old bare `"Move"` name to use the corrected widget-specific name.
- Added regression tests in `MetricCard.test.tsx` asserting the unique accessible name and the menu-trigger ARIA attributes.
- `docs/TREASURY_WIDGET_DRAG_ARRANGE_SPEC.md`: documented the fix.

## Note
I also checked the spec's claim that "focus is restored to the moved card's Move button after layout updates" — verified this live (rendered + moved a widget + checked `document.activeElement`), and it does work correctly via `data-widget-id` in `Metrics.tsx`. No issue there.

## Testing
`vitest run` on `MetricCard.test.tsx` + `Metrics.test.tsx`: 23 passed. Full `treasuryOverviewPage` suite: 260 passed (2 pre-existing, unrelated `ActivityHeatmap` date-window failures — confirmed zero-diff on that file). `eslint` clean on changed files.
