### PR TITLE
fix: unblock npm run build — pre-existing errors on main

### DIFF
--- a/src/components/__tests__/ConnectWalletModal.test.tsx
+++ b/src/components/__tests__/ConnectWalletModal.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, act } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React, { act } from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
@@ -391,7 +391,6 @@ describe("ConnectWalletModal", () => {
       const title = screen.getByText('Choose your wallet');
       expect(title).toHaveAttribute('id', 'connect-wallet-modal-title');
     });
-  });
   });
 });
 

--- a/src/components/__tests__/ValuePropositionSection.test.tsx
+++ b/src/components/__tests__/ValuePropositionSection.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from "@testing-library/react";
 import ValuePropositionSection from "../ValuePropositionSection";
 import { vi } from 'vitest';
@@ -37,7 +36,7 @@ describe("ValuePropositionSection", () => {
       "Native Stellar infrastructure. Soroban smart contracts",
     ];
     descriptions.forEach((desc) => {
-      const matches = screen.getAllByText((content, element) => element?.textContent?.includes(desc));
+      const matches = screen.getAllByText((_content, element) => Boolean(element?.textContent?.includes(desc)));
       expect(matches.length).toBeGreaterThan(0);
     });
   });

--- a/src/components/csv-upload/PreviewValidateStep.tsx
+++ b/src/components/csv-upload/PreviewValidateStep.tsx
@@ -608,7 +608,7 @@ const PreviewValidateStep: React.FC<PreviewValidateStepProps> = ({
                   )}
                 </React.Fragment>
               );
-            })}
+            }))}
           </tbody>
         </table>
       </div>

--- a/src/components/navigation/AppNavbar.tsx
+++ b/src/components/navigation/AppNavbar.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useCallback } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { Menu, X, Type, Search, Command } from "lucide-react";
 import { useWallet } from "../wallet-connect/Walletcontext";
@@ -289,28 +289,12 @@ export default function AppNavbar({
   } = useWallet();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [connecting, setConnecting] = useState(false);
-  const [isPaletteOpen, setIsPaletteOpen] = useState(false);
 
   // Simulate a brief "connecting" state on first mount when wallet restores session
   useEffect(() => {
     setConnecting(true);
     const t = setTimeout(() => setConnecting(false), 600);
     return () => clearTimeout(t);
-  }, []);
-
-  const openPalette = useCallback(() => setIsPaletteOpen(true), []);
-  const closePalette = useCallback(() => setIsPaletteOpen(false), []);
-
-  // Global Cmd/Ctrl+K shortcut
-  useEffect(() => {
-    const handleGlobalKeyDown = (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && e.key === "k") {
-        e.preventDefault();
-        setIsPaletteOpen((open) => !open);
-      }
-    };
-    document.addEventListener("keydown", handleGlobalKeyDown);
-    return () => document.removeEventListener("keydown", handleGlobalKeyDown);
   }, []);
 
 const location = useLocation();
@@ -568,7 +552,7 @@ const location = useLocation();
       )}
 
       {/* Command Palette — rendered inside header but uses fixed positioning */}
-      <KeyboardShortcutsModal isOpen={isPaletteOpen} onClose={closePalette} />
+      <KeyboardShortcutsModal />
     </header>
   );
 }

--- a/src/components/presence/__tests__/PresenceCursorOverlay.test.tsx
+++ b/src/components/presence/__tests__/PresenceCursorOverlay.test.tsx
@@ -70,7 +70,7 @@ describe("PresenceCursorOverlay", () => {
     const { container } = render(
       <PresenceCursorOverlay viewers={[belowViewer, aboveViewer]} />,
     );
-    const wrappers = container.querySelectorAll(".presence-cursor-dot-wrapper");
+    const wrappers = container.querySelectorAll<HTMLElement>(".presence-cursor-dot-wrapper");
     expect(wrappers[0].style.top).toBe("0%");
     expect(wrappers[1].style.top).toBe("100%");
   });

--- a/src/hooks/__tests__/usePresenceViewers.test.ts
+++ b/src/hooks/__tests__/usePresenceViewers.test.ts
@@ -165,7 +165,7 @@ describe("usePresenceViewers — edge cases", () => {
     const { result, rerender } = renderHook(
       ({ id }: { id: string | undefined }) =>
         usePresenceViewers(id, mockViewers),
-      { initialProps: { id: "STR-123" } }
+      { initialProps: { id: "STR-123" as string | undefined } }
     );
 
     expect(result.current.viewers).toHaveLength(1);

--- a/src/pages/EmbedStreamWidget.tsx
+++ b/src/pages/EmbedStreamWidget.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useParams, useSearchParams } from "react-router-dom";
 import { Skeleton } from "../components/Skeleton";
 import { useTickingNow } from "../hooks/useTickingNow";

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -117,15 +117,15 @@ export default function Home() {
     // do not expose `window`).
     if (typeof window === "undefined") return;
 
-    let timeoutId: ReturnType<typeof window.setTimeout> | undefined;
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
 
     // Debounced handler — collapses rapid resize / orientationchange events
     // into a single state update so re-renders are kept to a minimum.
     const handleResize = () => {
       if (timeoutId !== undefined) {
-        window.clearTimeout(timeoutId);
+        clearTimeout(timeoutId);
       }
-      timeoutId = window.setTimeout(() => {
+      timeoutId = setTimeout(() => {
         timeoutId = undefined;
         setIsMobileLayout(isMobileViewport());
       }, VIEWPORT_RESIZE_DEBOUNCE_MS);
@@ -142,7 +142,7 @@ export default function Home() {
       // Cancel any in-flight debounce so unmounting components can never
       // trigger a state update on an already-unmounted tree.
       if (timeoutId !== undefined) {
-        window.clearTimeout(timeoutId);
+        clearTimeout(timeoutId);
       }
     };
   }, []);

--- a/src/pages/__tests__/Home.test.tsx
+++ b/src/pages/__tests__/Home.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from "@testing-library/react";
+import { render, screen, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { axe } from "vitest-axe";
@@ -7,7 +7,18 @@ import Home, {
   LAZY_SECTION_ROOT_MARGIN,
   LAZY_SECTION_SKELETON_HEIGHT,
 } from "../Home";
+import { VIEWPORT_RESIZE_DEBOUNCE_MS } from "../../lib/breakpoints";
 import { ThemeProvider } from "../../theme/ThemeProvider";
+
+let viewportWidth = 1024;
+
+function setViewportWidth(width: number) {
+  viewportWidth = width;
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    get: () => viewportWidth,
+  });
+}
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/src/theme/__tests__/ThemeEditorPanel.contrast.test.tsx
+++ b/src/theme/__tests__/ThemeEditorPanel.contrast.test.tsx
@@ -37,7 +37,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, within, act } from "@testing-library/react";
+import { render, screen, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import ThemeEditorPanel, {
   ContrastBadge,


### PR DESCRIPTION
Closes #356

## Problem
`npm run build` (`tsc -b && vite build`) is currently broken on `main`, which fails the "Build & test" CI check for every open PR, regardless of what it changes — including two of mine (#1250, #1251).

## What changed
Cleared every error `tsc -b` reported, in the order encountered:

- **`PreviewValidateStep.tsx`**: a recent merge (#1243) wrapped `rows.map(...)` in a ternary's else-branch `(...)` but never added the matching closing paren. The parser gave up much later in an unrelated expression, misreporting the true source.
- **`ConnectWalletModal.test.tsx`**: duplicate `act` import (from both `@testing-library/react` and `react`) + a stray extra closing brace closing a `describe` block twice.
- **`ValuePropositionSection.test.tsx`**: unused `React` import (project uses the automatic JSX runtime), unused matcher param, matcher return type widened to `boolean`.
- **`AppNavbar.tsx`**: removed genuinely dead `isPaletteOpen` state/handlers — `KeyboardShortcutsModal` wraps `CommandPaletteModal`, which already owns its own open state and its own Cmd/Ctrl+K listener internally, so `AppNavbar`'s parallel copy was inert duplicate logic passing props the component doesn't even accept.
- **`PresenceCursorOverlay.test.tsx`**: `querySelectorAll<HTMLElement>` instead of untyped `Element` for `.style` access.
- **`usePresenceViewers.test.ts`**: widened `renderHook`'s inferred `initialProps` type to match the hook's declared `string | undefined` param.
- **`Home.test.tsx`**: restored the missing `setViewportWidth` test helper, top-level `act` import, and `VIEWPORT_RESIZE_DEBOUNCE_MS` import — all referenced throughout the file but never defined/imported.
- **`EmbedStreamWidget.tsx` / `ThemeEditorPanel.contrast.test.tsx`**: unused imports.
- **`Home.tsx`**: `ReturnType<typeof window.setTimeout>` resolved to Node's `Timeout` under this project's global type merging; switched to the bare `setTimeout`/`clearTimeout` already used consistently elsewhere (`ConnectWalletModal.tsx`, `Sidebar.tsx`, etc.). Verified this wasn't the cause of any test regression (see scope note).

## Scope note
This targets **`npm run build`** only. Once these files could finally compile, 3 unrelated `npm run test` failures surfaced:
- A `role="status"` gap on the loading state in `PreviewValidateStep.tsx`, from the same #1243 merge.
- Two pre-existing `Home.test.tsx` debounce-timer test failures — confirmed independent of the `setTimeout` change above (reproduced identically with the original `window.setTimeout` code).

Left those alone intentionally — separate concern from unblocking the build.

## Testing
`npm run build` succeeds end-to-end (`tsc -b` clean, `vite build` produces output). Ran the test suites for every file touched: 356 passed, 8 failed (all 8 pre-existing/unrelated per above, not introduced by this PR).
