### PR TITLE
fix: wire transaction data to StreamCreatedModal receipt for creation flow

### DIFF
--- a/src/components/CreateStreamModal.tsx
+++ b/src/components/CreateStreamModal.tsx
@@ -154,6 +154,16 @@ function validateDuration(value: string, t: any): string | undefined {
 
 /** Snapshot of everything `createStream` needs, captured at submit time so a
  * queued (offline) submission replays with the exact values the user reviewed. */
+/** Data passed to the parent when a stream is successfully created. Used by the
+ * success modal to display a branded downloadable transaction receipt. */
+export interface StreamCreatedData {
+  txHash?: string | null;
+  amount: string;
+  rate: string;
+  sender: string;
+  recipient: string;
+}
+
 interface StreamSubmissionPayload {
   sender: string;
   recipient: string;
@@ -166,8 +176,9 @@ interface StreamSubmissionPayload {
 interface CreateStreamModalProps {
   isOpen: boolean;
   onClose: () => void;
-  /** Called when user completes the flow and clicks "Create stream" on step 3. Use to show success modal. */
-  onStreamCreated?: () => void | Promise<void>;
+  /** Called when user completes the flow and clicks "Create stream" on step 3. Use to show success modal.
+   * Receives transaction data (txHash, amount, rate, sender, recipient) for the downloadable receipt. */
+  onStreamCreated?: (data?: StreamCreatedData) => void | Promise<void>;
   /** Called when stream creation fails after the user confirms the review step. */
   onStreamError?: (err: unknown) => void;
   /**
@@ -461,16 +472,26 @@ export default function CreateStreamModal({
     }
 
     setHasCompletedConfirmation(true);
+
+    const amountNum = parseFloat(depositAmount.replace(/,/g, "")) || 0;
+    const createdData: StreamCreatedData = {
+      txHash: submittedTxHash,
+      amount: `${amountNum.toLocaleString()} USDC`,
+      rate: `${accrualRate} USDC/day`,
+      sender: wallet.address ?? "",
+      recipient,
+    };
+
     if (flushedFromQueueRef.current) {
       flushedFromQueueRef.current = false;
       addToast(t("createStream.queue.flushSuccessToast"), "success", undefined, {
         label: t("createStream.queue.viewStreamAction"),
-        onClick: () => onStreamCreated?.(),
+        onClick: () => onStreamCreated?.(createdData),
       });
     } else {
       addToast(t("createStream.success.message"), "success");
     }
-    onStreamCreated?.();
+    onStreamCreated?.(createdData);
     onClose();
   }, [
     addToast,
@@ -479,6 +500,11 @@ export default function CreateStreamModal({
     onStreamCreated,
     transactionStatus.status,
     t,
+    submittedTxHash,
+    depositAmount,
+    accrualRate,
+    wallet.address,
+    recipient,
   ]);
 
   // Auto-flush a queued submission as soon as connectivity returns. Runs even

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from "react";
 import RecentStreams, { Stream } from "../components/RecentStreams";
 import CreateStreamModal from "../components/CreateStreamModal";
+import type { StreamCreatedData } from "../components/CreateStreamModal";
 import TreasuryEmptyState from "../components/TreasuryEmptyState";
 import TreasuryOnboarding from "../components/TreasuryOnboarding";
 import ConnectWalletModal from "../components/ConnectWalletModal";
@@ -90,7 +91,7 @@ export default function Dashboard() {
     setIsModalOpen(true);
   };
 
-  const handleStreamCreated = () => {
+  const handleStreamCreated = (_data?: StreamCreatedData) => {
     setIsModalOpen(false);
     setToast({
       message:

--- a/src/pages/Streams.tsx
+++ b/src/pages/Streams.tsx
@@ -12,6 +12,7 @@ import {
 import { useNavigate, useParams } from "react-router-dom";
 import { useI18n } from "../i18n";
 import CreateStreamModal from "../components/CreateStreamModal";
+import type { StreamCreatedData } from "../components/CreateStreamModal";
 import EmptyState from "../components/EmptyState";
 import StreamCreatedModal from "../components/Streams/StreamCreatedModal";
 import { useToast } from "../components/toast/ToastProvider";
@@ -815,6 +816,11 @@ export default function Streams() {
   const [createdStream, setCreatedStream] = useState({
     id: "STR-NEW",
     url: "https://fluxora.io/stream/STR-NEW",
+    txHash: undefined as string | null | undefined,
+    amount: undefined as string | undefined,
+    rate: undefined as string | undefined,
+    sender: undefined as string | undefined,
+    recipient: undefined as string | undefined,
   });
 
   // Pagination state
@@ -1061,11 +1067,16 @@ export default function Streams() {
     setIsCreateModalOpen(true);
   }, [resolveSessionOnInteraction]);
 
-  const handleStreamCreated = useCallback(() => {
+  const handleStreamCreated = useCallback((data?: StreamCreatedData) => {
     const generatedId = `STR-${String(streams.length + 1).padStart(3, "0")}`;
     setCreatedStream({
       id: generatedId,
       url: `https://fluxora.io/stream/${generatedId}`,
+      txHash: data?.txHash,
+      amount: data?.amount,
+      rate: data?.rate,
+      sender: data?.sender,
+      recipient: data?.recipient,
     });
     setIsCreateModalOpen(false);
     setIsSuccessModalOpen(true);
@@ -1180,6 +1191,11 @@ export default function Streams() {
           onClose={() => setIsSuccessModalOpen(false)}
           streamId={createdStream.id}
           streamUrl={createdStream.url}
+          txHash={createdStream.txHash ?? undefined}
+          amount={createdStream.amount}
+          rate={createdStream.rate}
+          sender={createdStream.sender}
+          recipient={createdStream.recipient}
           onCreateAnother={() => {
             setIsSuccessModalOpen(false);
             setIsCreateModalOpen(true);


### PR DESCRIPTION
Closes #1016

## Summary

This PR completes the downloadable transaction receipt feature by wiring actual transaction data (txHash, amount, rate, sender, recipient) from CreateStreamModal through to StreamCreatedModal.

## Problem

CreateStreamModal.onStreamCreated was a void callback with no transaction data. The StreamCreatedModal receipt preview always showed placeholder defaults instead of the actual stream values.

## Changes

- src/components/CreateStreamModal.tsx - Exported StreamCreatedData interface. Updated onStreamCreated to pass tx data when transaction confirms.
- src/pages/Streams.tsx - Updated createdStream state and handleStreamCreated to receive and forward data.
- src/pages/Dashboard.tsx - Updated handleStreamCreated signature for compatibility.

## Already Complete

- receiptGenerator.ts - Full branded canvas receipt
- TransactionReceiptPreview.tsx - Accessible HTML preview with download button
- Recipient.tsx - Withdrawal receipt dialog
- TRANSACTION_RECEIPT_SPEC.md - Complete design spec

## Verification

- tsc --noEmit passes
- 18 tests pass (receipt, preview, transaction, failure, offline queue)
