### PR TITLE
docs: add dev-only ComponentGallery route for design QA

### DIFF
--- a/docs/COMPONENT_GUIDELINES.md
+++ b/docs/COMPONENT_GUIDELINES.md
@@ -1,0 +1,373 @@
+# Component Guidelines
+
+This document is the canonical reference for the four core UI components used throughout
+Fluxora's dashboard and recipient portal. Use it to understand each component's API,
+accessibility contract, and design-token integration before contributing.
+
+For a **live visual reference** of every variant and state, open the ComponentGallery dev
+route at `/app/component-gallery` (available in development builds only — guarded by
+`IS_DEV` exactly like `/app/empty-state-demo`).
+
+---
+
+## Table of Contents
+
+1. [Button](#button)
+2. [Input](#input)
+3. [StatusPill](#statuspill)
+4. [MetricCard](#metriccard)
+5. [Design tokens quick reference](#design-tokens-quick-reference)
+6. [Accessibility standards](#accessibility-standards)
+7. [ComponentGallery dev route](#componentgallery-dev-route)
+8. [Adding a new component to the gallery](#adding-a-new-component-to-the-gallery)
+
+---
+
+## Button
+
+**Source:** `src/components/Button.tsx`  
+**Styles:** `src/components/Button.module.css`
+
+### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `variant` | `'primary' \| 'secondary' \| 'danger' \| 'success' \| 'ghost'` | `'primary'` | Visual style |
+| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` | Touch target and font size |
+| `disabled` | `boolean` | `false` | Non-interactive and visually muted |
+| `loading` | `boolean` | `false` | Shows spinner, sets `aria-busy="true"`, blocks clicks |
+| `icon` | `ReactNode` | — | Icon element rendered before text |
+| `iconOnly` | `boolean` | `false` | Icon with no text; **requires `aria-label`** |
+| `iconSize` | `'xs' \| 'sm' \| 'md' \| 'lg'` | `'sm'` | Size class applied to icon wrapper |
+| `fullWidth` | `boolean` | `false` | Stretches button to fill container width |
+| `type` | `'button' \| 'submit' \| 'reset'` | `'button'` | HTML button type |
+| `loadingContent` | `ReactNode` | — | Custom loading text/node (replaces spinner text) |
+
+All standard `ButtonHTMLAttributes` are passed through to the underlying `<button>`.
+
+### Variants
+
+| Variant | Use case |
+|---------|----------|
+| `primary` | Main call-to-action (create stream, withdraw, confirm) |
+| `secondary` | Alternative or lower-priority actions |
+| `danger` | Destructive actions (cancel stream, delete) |
+| `success` | Positive confirmations |
+| `ghost` | Subtle/tertiary actions, toolbar controls |
+
+### Usage examples
+
+```tsx
+// Primary CTA
+<Button onClick={handleCreate}>Create Stream</Button>
+
+// Secondary with size
+<Button variant="secondary" size="sm">Cancel</Button>
+
+// Loading state (blocks interaction)
+<Button loading>Creating…</Button>
+
+// Disabled
+<Button disabled>Unavailable</Button>
+
+// Icon-only — aria-label is mandatory
+<Button iconOnly icon={<PlusCircle size={16} />} aria-label="Add stream" />
+
+// Danger with full width
+<Button variant="danger" fullWidth>Cancel all streams</Button>
+```
+
+### Accessibility notes
+
+- Focus ring is driven by `:focus-visible` so keyboard users always see it.
+- `aria-busy="true"` is set automatically when `loading` is `true`.
+- `aria-disabled="true"` is set when `disabled` or `loading`.
+- `iconOnly` buttons **must** have an `aria-label` — the linter will warn if omitted.
+- Minimum touch target: 44 × 44 px at `size="lg"`, 40 × 40 px at `size="md"`.
+
+---
+
+## Input
+
+**Source:** `src/components/Input.tsx`  
+**Styles:** `src/components/Input.module.css`
+
+### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `label` | `string` | — | Visible label; wired via `htmlFor`/`id` |
+| `type` | `string` | `'text'` | HTML input type, plus `'textarea'` and `'select'` |
+| `error` | `string` | — | Error message shown in red; sets `aria-invalid="true"` |
+| `helperText` | `string` | — | Guidance text shown below input (suppressed when error present) |
+| `required` | `boolean` | `false` | Adds `*` indicator and `required` attribute |
+| `disabled` | `boolean` | `false` | Makes field non-interactive |
+| `options` | `Array<{ value: string; label: string }>` | — | Required for `type="select"` |
+| `id` | `string` | auto-generated | Overrides generated id for label association |
+| `compositionAware` | `boolean` | auto | Defers error styling during CJK input composition |
+| `className` | `string` | `''` | Extra CSS class on the inner input/textarea/select element |
+
+Standard `InputHTMLAttributes` (excluding `type`) are forwarded to the input element.
+
+### Input types
+
+| `type` value | Renders | Notes |
+|--------------|---------|-------|
+| `'text'` | `<input type="text">` | Default |
+| `'email'` | `<input type="email">` | Browser email validation |
+| `'password'` | `<input type="password">` | Masked characters |
+| `'number'` | `<input type="number">` | Numeric keyboard on mobile |
+| `'search'` | `<input type="search">` | Search semantics |
+| `'textarea'` | `<textarea>` | Multi-line text; also compositionAware by default |
+| `'select'` | `<select>` | Requires `options` prop |
+
+### Usage examples
+
+```tsx
+// Basic text input
+<Input label="Recipient address" type="text" placeholder="G…" required />
+
+// Email with error
+<Input
+  label="Email"
+  type="email"
+  error="Enter a valid email address."
+  defaultValue="not-valid"
+/>
+
+// Textarea with helper text
+<Input
+  label="Notes"
+  type="textarea"
+  helperText="Optional. Max 500 characters."
+/>
+
+// Select
+<Input
+  label="Asset"
+  type="select"
+  options={[
+    { value: "usdc", label: "USDC" },
+    { value: "xlm", label: "XLM" },
+  ]}
+/>
+
+// Disabled pre-filled
+<Input label="Stream ID" type="text" disabled defaultValue="abc123" />
+```
+
+### Accessibility notes
+
+- Label is always associated via `htmlFor`/`id` (auto-generated via `useId` if not provided).
+- `aria-invalid="true"` is applied when `error` is set.
+- `aria-errormessage` points to the `<ValidationMessage>` element id.
+- `aria-describedby` points to the helper text element when present and there is no error.
+- Dangling `aria-describedby` references are avoided: helper id is only included when the helper
+  element is actually in the DOM.
+
+---
+
+## StatusPill
+
+**Source:** `src/components/treasuryOverviewPage/StatusPill.tsx`
+
+### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `status` | see below | — | Stream or health status to display |
+| `iconSize` | `'xs' \| 'sm' \| 'md' \| 'lg'` | `'xs'` | Controls icon class applied |
+
+#### Status values
+
+| Status | Icon | Token family |
+|--------|------|-------------|
+| `Active` | Play | success |
+| `Paused` | Pause | warning |
+| `Completed` | CheckCircle | info |
+| `Healthy` | Heart | success |
+| `At-Risk` | AlertTriangle | warning |
+| `Critical` | XCircle | error |
+
+### Usage examples
+
+```tsx
+// Stream list status
+<StatusPill status="Active" />
+
+// Health indicator with larger icon
+<StatusPill status="At-Risk" iconSize="sm" />
+```
+
+### Accessibility notes
+
+- Renders `role="status"` with `aria-label="{label} status"` (e.g. `"Active status"`).
+- `tabIndex={0}` — keyboard-focusable for screen-reader inspection.
+- Status is conveyed by **icon shape + text + colour** — never colour alone (WCAG 1.4.1).
+- An `aria-live="polite"` region announces status transitions without disrupting scroll.
+- All six statuses pass WCAG AA contrast under both light and dark themes using
+  `--status-*` and `--status-*-bg` tokens.
+
+### Colour-blind safety
+
+StatusPill passes all three simulation modes (protanopia, deuteranopia, tritanopia) because
+each status maps to a unique Lucide icon shape that is differentiable without colour.
+
+---
+
+## MetricCard
+
+**Source:** `src/components/treasuryOverviewPage/MetricCard.tsx`
+
+### Core props (Metric interface)
+
+| Prop | Type | Required | Description |
+|------|------|----------|-------------|
+| `icon` | `ReactNode` | ✓ | Icon or emoji in the card header |
+| `label` | `string` | ✓ | Metric name — also the `aria-label` of the `role="group"` |
+| `value` | `string` | ✓ | Formatted metric value (pass `""` when using `tokens`) |
+| `desc` | `string` | ✓ | Secondary description shown at card bottom |
+| `trend` | `number[]` | — | ≥ 2 values render a rate-of-change sparkline |
+| `tokens` | `Array<{ asset: string; amount: number }>` | — | Multi-token display; overrides `value` |
+
+### Additional props
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `draggable` | `boolean` | Enables drag-and-drop; shows grip icon |
+| `onResize` | `(size) => void` | Enables kebab resize option |
+| `onHide` | `() => void` | Enables kebab hide option |
+| `currentSize` | `'1x1' \| '2x1'` | Current grid size |
+| `moveMenuOptions` | object | Adds keyboard move submenu |
+| `reorderButtons` | `ReactNode` | Slot for mobile reorder up/down buttons |
+
+### Usage examples
+
+```tsx
+// Basic card
+<MetricCard
+  icon={<DollarSign size={24} />}
+  label="Total Streamed"
+  value="12,400 USDC"
+  desc="Across all active streams"
+/>
+
+// With trend sparkline
+<MetricCard
+  icon={<TrendingUp size={24} />}
+  label="Weekly Flow"
+  value="3,200 USDC"
+  desc="Up 18% from last week"
+  trend={[1200, 1400, 1600, 2100, 3200]}
+/>
+
+// Multi-token (value overridden)
+<MetricCard
+  icon={<Zap size={24} />}
+  label="Vault Balance"
+  value=""
+  desc="Combined balance"
+  tokens={[
+    { asset: "USDC", amount: 8500 },
+    { asset: "XLM", amount: 42000 },
+  ]}
+/>
+```
+
+### Accessibility notes
+
+- The card wrapper uses `role="group"` with `aria-label={label}`.
+- Design tokens `data-token-surface` and `data-token-border` anchor automated contrast checks.
+- Surface and border use greyscale-neutral tokens — unaffected by colour-blind filters.
+- Sparkline `<svg>` has `role="img"` and an `aria-label` describing trend direction.
+- Drag handle uses `onMouseDown`/`Up`/`Leave` guards so the element is only draggable while
+  the handle is actively held, preventing accidental drag.
+
+---
+
+## Design tokens quick reference
+
+The components above rely exclusively on the design-token CSS custom properties defined in
+`src/design-tokens.css`. Commonly used tokens:
+
+| Token | Usage |
+|-------|-------|
+| `--color-text-primary` | Body text, headings |
+| `--color-text-secondary` | Muted labels, helper text |
+| `--color-text-vivid` | Metric values, highlighted numbers |
+| `--color-surface-default` | Card and surface backgrounds |
+| `--color-border-default` | Card borders, dividers |
+| `--color-bg-primary` | Page background |
+| `--color-accent-primary` | Focus rings, active indicators |
+| `--status-success` / `--status-success-bg` | Active, Healthy pills |
+| `--status-warning` / `--status-warning-bg` | Paused, At-Risk pills |
+| `--status-error` / `--status-error-bg` | Critical pills |
+| `--status-info` / `--status-info-bg` | Completed pills |
+
+Tokens resolve to different hex values in light, dark, and cyberpunk themes via the
+`data-theme` attribute set on `<html>` by `ThemeProvider`.
+
+---
+
+## Accessibility standards
+
+All components target **WCAG 2.1 Level AA**:
+
+| Criterion | Implementation |
+|-----------|---------------|
+| 1.3.1 Info & Relationships | Semantic HTML: `<button>`, `<label>`, `role="group"`, `role="status"` |
+| 1.4.1 Use of Colour | Status conveyed by icon + text + colour; never colour alone |
+| 1.4.3 Contrast (Minimum) | All text/icon tokens verified ≥ 4.5:1 (normal) / 3:1 (large) |
+| 2.1.1 Keyboard | All interactive elements reachable and operable via keyboard |
+| 2.4.6 Headings & Labels | Visible labels for all inputs; descriptive headings |
+| 4.1.2 Name, Role, Value | ARIA attributes on busy/disabled/invalid states |
+| 4.1.3 Status Messages | `aria-live` regions announce dynamic changes |
+
+---
+
+## ComponentGallery dev route
+
+The gallery page at `/app/component-gallery` (development builds only) renders the full
+variant/state matrix for every component documented here. It is guarded identically to the
+existing `EmptyStateDemo`:
+
+```tsx
+// src/App.tsx
+const ComponentGallery = IS_DEV
+  ? lazy(() => import("./pages/dev/ComponentGallery"))
+  : () => null;
+
+// Inside the /app nested route (RequireWallet + Layout):
+{IS_DEV && (
+  <Route
+    path="component-gallery"
+    element={lazyAppRoute(<ComponentGallery />)}
+  />
+)}
+```
+
+`IS_DEV` is `import.meta.env.DEV`, which Vite sets to `false` in production builds.
+The import is lazy so the gallery chunk is excluded entirely from the production bundle.
+
+### Using the gallery
+
+1. Run `npm run dev` (or `pnpm run dev`).
+2. Connect a wallet (the route is inside `RequireWallet`).
+3. Navigate to `http://localhost:5173/app/component-gallery`.
+4. Use the **Gallery theme** fieldset to switch between light, dark, and cyberpunk themes.
+5. Inspect variant/state matrices for each component.
+
+---
+
+## Adding a new component to the gallery
+
+1. Import the component at the top of `src/pages/dev/ComponentGallery.tsx`.
+2. Add a new `<GallerySection id="gallery-your-component" title="YourComponent">` block.
+3. Add `<SubSection>` groups for each prop dimension you want to demonstrate.
+4. Wrap each example in `<Cell label="YourComponent — variant, state">`.
+5. Add a `<SourceNote path="…" />` line with the canonical source path.
+6. Write tests in `src/pages/dev/__tests__/ComponentGallery.test.tsx` — at minimum:
+   - Section heading is present.
+   - All variants render.
+   - No new axe violations introduced.
+7. Update this document with the new component's API table and usage examples.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,10 @@ const EmptyStateDemo = IS_DEV
   ? lazy(() => import("./pages/EmptyStateDemo"))
   : () => null;
 
+const ComponentGallery = IS_DEV
+  ? lazy(() => import("./pages/dev/ComponentGallery"))
+  : () => null;
+
 
 function LegacyStreamRedirect() {
   const { streamId } = useParams();
@@ -139,6 +143,12 @@ export default function App() {
                         <Route
                           path="empty-state-demo"
                           element={lazyAppRoute(<EmptyStateDemo />)}
+                        />
+                      )}
+                      {IS_DEV && (
+                        <Route
+                          path="component-gallery"
+                          element={lazyAppRoute(<ComponentGallery />)}
                         />
                       )}
                     </Route>

--- a/src/pages/dev/ComponentGallery.tsx
+++ b/src/pages/dev/ComponentGallery.tsx
@@ -1,0 +1,695 @@
+/**
+ * ComponentGallery
+ * ────────────────
+ * Design QA page for Button, Input, StatusPill, and MetricCard.
+ * Accessible at /app/component-gallery (dev only — IS_DEV guard in App.tsx).
+ *
+ * Covers:
+ *  - Button  — all variants × sizes × states (loading, disabled, icon-only,
+ *              full-width)
+ *  - Input   — all types × states (error, disabled, required, helper text)
+ *  - StatusPill — all 6 statuses × all 4 icon sizes
+ *  - MetricCard — standard, multi-token, with trend sparkline, edge cases
+ *  - Live theme toggle (light / dark / cyberpunk) without leaving the page
+ *
+ * Accessibility (WCAG 2.1 AA):
+ *  - <main id="main-content"> targeted by the global skip-link
+ *  - Every section uses <section aria-labelledby="…">
+ *  - Every example uses <figure aria-label="…"> + <figcaption>
+ *  - Theme toggle is a <fieldset>/<legend> radio group (arrow-key navigable)
+ *  - Colour is never the only differentiator — labels always present
+ *  - No layout overflow at 320 px (min-width clamp grids)
+ */
+
+import { type ReactNode } from "react";
+import { useTheme } from "../../theme/ThemeProvider";
+import type { Theme } from "../../theme/ThemeProvider";
+import Button from "../../components/Button";
+import Input from "../../components/Input";
+import StatusPill from "../../components/treasuryOverviewPage/StatusPill";
+import MetricCard from "../../components/treasuryOverviewPage/MetricCard";
+import { Zap, TrendingUp, Users, DollarSign, Star } from "lucide-react";
+
+// ─── Constant matrices ────────────────────────────────────────────────────────
+
+const BUTTON_VARIANTS = [
+  "primary",
+  "secondary",
+  "danger",
+  "success",
+  "ghost",
+] as const;
+
+const BUTTON_SIZES = ["sm", "md", "lg"] as const;
+
+const STATUS_PILL_STATUSES = [
+  "Active",
+  "Paused",
+  "Completed",
+  "Healthy",
+  "At-Risk",
+  "Critical",
+] as const;
+
+const ICON_SIZES = ["xs", "sm", "md", "lg"] as const;
+
+const THEMES: Theme[] = ["light", "dark", "cyberpunk"];
+
+// ─── Page component ───────────────────────────────────────────────────────────
+
+export default function ComponentGallery() {
+  const { theme, setTheme } = useTheme();
+
+  return (
+    <main
+      id="main-content"
+      style={{
+        padding: "clamp(16px, 4vw, 40px)",
+        maxWidth: 1200,
+        margin: "0 auto",
+      }}
+    >
+      {/* ── Page header ───────────────────────────────────────── */}
+      <header>
+        <h1
+          style={{
+            fontSize: "clamp(20px, 3vw, 28px)",
+            fontWeight: 700,
+            marginBottom: 8,
+            color: "var(--color-text-primary, var(--text))",
+          }}
+        >
+          Component Gallery — Design QA
+        </h1>
+        <p
+          style={{
+            color: "var(--color-text-secondary, var(--muted))",
+            marginBottom: 24,
+            fontSize: 14,
+          }}
+        >
+          Full variant/state matrix for Button, Input, StatusPill, and MetricCard.
+          Use the theme toggle to inspect light, dark, and cyberpunk appearances.
+        </p>
+      </header>
+
+      {/* ── Theme toggle ──────────────────────────────────────── */}
+      <ThemeToggle current={theme} onChange={setTheme} />
+
+      {/* ── Button ────────────────────────────────────────────── */}
+      <GallerySection id="gallery-buttons" title="Button">
+        <SourceNote path="src/components/Button.tsx" />
+
+        <SubSection title="Variants × Sizes">
+          <VariantSizeGrid />
+        </SubSection>
+
+        <SubSection title="Loading state">
+          <Grid>
+            {BUTTON_VARIANTS.map((variant) => (
+              <Cell key={variant} label={`Button — ${variant}, loading`}>
+                <Button variant={variant} loading>
+                  Saving…
+                </Button>
+              </Cell>
+            ))}
+          </Grid>
+        </SubSection>
+
+        <SubSection title="Disabled state">
+          <Grid>
+            {BUTTON_VARIANTS.map((variant) => (
+              <Cell key={variant} label={`Button — ${variant}, disabled`}>
+                <Button variant={variant} disabled>
+                  Disabled
+                </Button>
+              </Cell>
+            ))}
+          </Grid>
+        </SubSection>
+
+        <SubSection title="Icon-only (requires aria-label)">
+          <Grid>
+            {BUTTON_VARIANTS.map((variant) => (
+              <Cell key={variant} label={`Button — ${variant}, icon-only`}>
+                <Button
+                  variant={variant}
+                  iconOnly
+                  icon={<Zap size={16} aria-hidden="true" />}
+                  aria-label={`${variant} action`}
+                />
+              </Cell>
+            ))}
+          </Grid>
+        </SubSection>
+
+        <SubSection title="Full-width">
+          <Cell label="Button — primary, full-width">
+            <Button variant="primary" fullWidth>
+              Full-Width Primary
+            </Button>
+          </Cell>
+        </SubSection>
+      </GallerySection>
+
+      {/* ── Input ─────────────────────────────────────────────── */}
+      <GallerySection id="gallery-inputs" title="Input">
+        <SourceNote path="src/components/Input.tsx" />
+
+        <SubSection title="Text input types">
+          <Grid>
+            <Cell label="Input — text, default">
+              <Input label="Full name" type="text" placeholder="Ada Lovelace" />
+            </Cell>
+            <Cell label="Input — email, default">
+              <Input label="Email address" type="email" placeholder="ada@example.com" />
+            </Cell>
+            <Cell label="Input — password, default">
+              <Input label="Password" type="password" placeholder="••••••••" />
+            </Cell>
+            <Cell label="Input — number, default">
+              <Input label="Amount (USDC)" type="number" placeholder="0.00" />
+            </Cell>
+          </Grid>
+        </SubSection>
+
+        <SubSection title="Textarea and Select">
+          <Grid>
+            <Cell label="Input — textarea, default">
+              <Input label="Notes" type="textarea" placeholder="Stream notes…" />
+            </Cell>
+            <Cell label="Input — select, default">
+              <Input
+                label="Network"
+                type="select"
+                placeholder="Select network"
+                options={[
+                  { value: "testnet", label: "Testnet" },
+                  { value: "mainnet", label: "Mainnet" },
+                ]}
+              />
+            </Cell>
+          </Grid>
+        </SubSection>
+
+        <SubSection title="Validation states">
+          <Grid>
+            <Cell label="Input — text, error">
+              <Input
+                label="Stellar address"
+                type="text"
+                error="Must start with G and be 56 characters long."
+                defaultValue="not-valid"
+              />
+            </Cell>
+            <Cell label="Input — email, error">
+              <Input
+                label="Email address"
+                type="email"
+                error="Enter a valid email address."
+                defaultValue="not-an-email"
+              />
+            </Cell>
+            <Cell label="Input — text, helper text">
+              <Input
+                label="Stream ID"
+                type="text"
+                helperText="Copy the 12-character ID from the transaction receipt."
+                placeholder="abc123…"
+              />
+            </Cell>
+            <Cell label="Input — select, error">
+              <Input
+                label="Asset"
+                type="select"
+                error="Please select an asset."
+                options={[
+                  { value: "usdc", label: "USDC" },
+                  { value: "xlm", label: "XLM" },
+                ]}
+              />
+            </Cell>
+          </Grid>
+        </SubSection>
+
+        <SubSection title="Disabled and required states">
+          <Grid>
+            <Cell label="Input — text, disabled">
+              <Input
+                label="Read-only address"
+                type="text"
+                disabled
+                defaultValue="GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+              />
+            </Cell>
+            <Cell label="Input — text, required">
+              <Input label="Recipient address" type="text" required placeholder="G…" />
+            </Cell>
+            <Cell label="Input — password, required + disabled">
+              <Input
+                label="API key"
+                type="password"
+                required
+                disabled
+                defaultValue="sk_live_xxx"
+              />
+            </Cell>
+          </Grid>
+        </SubSection>
+      </GallerySection>
+
+      {/* ── StatusPill ────────────────────────────────────────── */}
+      <GallerySection id="gallery-status-pill" title="StatusPill">
+        <SourceNote path="src/components/treasuryOverviewPage/StatusPill.tsx" />
+
+        <SubSection title="All statuses, default icon size (xs)">
+          <Grid>
+            {STATUS_PILL_STATUSES.map((status) => (
+              <Cell key={status} label={`StatusPill — ${status}`}>
+                <StatusPill status={status} iconSize="xs" />
+              </Cell>
+            ))}
+          </Grid>
+        </SubSection>
+
+        <SubSection title="Icon sizes (Active status)">
+          <Grid>
+            {ICON_SIZES.map((size) => (
+              <Cell key={size} label={`StatusPill — Active, iconSize ${size}`}>
+                <StatusPill status="Active" iconSize={size} />
+              </Cell>
+            ))}
+          </Grid>
+        </SubSection>
+
+        {/* Full matrix — all statuses × all icon sizes, as an accessible table */}
+        <SubSection title="Full matrix — all statuses × all icon sizes">
+          <div style={{ overflowX: "auto" }}>
+            <table
+              aria-label="StatusPill variant matrix"
+              style={{
+                borderCollapse: "collapse",
+                minWidth: 480,
+                width: "100%",
+              }}
+            >
+              <thead>
+                <tr>
+                  <th
+                    scope="col"
+                    style={thStyle}
+                  >
+                    Status
+                  </th>
+                  {ICON_SIZES.map((size) => (
+                    <th key={size} scope="col" style={thStyle}>
+                      icon-{size}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {STATUS_PILL_STATUSES.map((status) => (
+                  <tr key={status}>
+                    <th scope="row" style={{ ...thStyle, textAlign: "left", fontWeight: 500 }}>
+                      {status}
+                    </th>
+                    {ICON_SIZES.map((size) => (
+                      <td
+                        key={size}
+                        style={{ padding: "8px 12px" }}
+                        aria-label={`${status}, icon size ${size}`}
+                      >
+                        <StatusPill status={status} iconSize={size} />
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </SubSection>
+      </GallerySection>
+
+      {/* ── MetricCard ────────────────────────────────────────── */}
+      <GallerySection id="gallery-metric-card" title="MetricCard">
+        <SourceNote path="src/components/treasuryOverviewPage/MetricCard.tsx" />
+
+        <SubSection title="Basic variants">
+          <Grid minWidth={280}>
+            <Cell label="MetricCard — standard">
+              <MetricCard
+                icon={<DollarSign size={24} aria-hidden="true" />}
+                label="Total Streamed"
+                value="12,400 USDC"
+                desc="Across all active streams"
+              />
+            </Cell>
+            <Cell label="MetricCard — with trend sparkline">
+              <MetricCard
+                icon={<TrendingUp size={24} aria-hidden="true" />}
+                label="Weekly Flow"
+                value="3,200 USDC"
+                desc="Up 18% from last week"
+                trend={[1200, 1400, 1100, 1600, 1800, 2100, 3200]}
+              />
+            </Cell>
+            <Cell label="MetricCard — multi-token">
+              <MetricCard
+                icon={<Zap size={24} aria-hidden="true" />}
+                label="Vault Balance"
+                value=""
+                desc="Combined multi-asset balance"
+                tokens={[
+                  { asset: "USDC", amount: 8500 },
+                  { asset: "XLM", amount: 42000 },
+                ]}
+              />
+            </Cell>
+            <Cell label="MetricCard — active streams count">
+              <MetricCard
+                icon={<Users size={24} aria-hidden="true" />}
+                label="Active Streams"
+                value="24"
+                desc="14 healthy · 8 at-risk · 2 critical"
+              />
+            </Cell>
+          </Grid>
+        </SubSection>
+
+        <SubSection title="Edge cases">
+          <Grid minWidth={280}>
+            <Cell label="MetricCard — long label">
+              <MetricCard
+                icon={<Star size={24} aria-hidden="true" />}
+                label="Total Treasury Capital Deployed This Quarter"
+                value="99,999.99 USDC"
+                desc="Long label wraps correctly inside the card."
+              />
+            </Cell>
+            <Cell label="MetricCard — zero value">
+              <MetricCard
+                icon={<DollarSign size={24} aria-hidden="true" />}
+                label="Pending Withdrawals"
+                value="0 USDC"
+                desc="No withdrawals pending."
+              />
+            </Cell>
+          </Grid>
+        </SubSection>
+      </GallerySection>
+
+      {/* ── Responsive note ───────────────────────────────────── */}
+      <section
+        aria-label="Responsive QA note"
+        style={{
+          marginTop: 40,
+          padding: "16px 20px",
+          background: "var(--color-surface-default, var(--surface))",
+          border: "1px solid var(--color-border-default, var(--border))",
+          borderRadius: 10,
+          fontSize: 13,
+          color: "var(--color-text-secondary, var(--muted))",
+        }}
+      >
+        <strong style={{ color: "var(--color-text-primary, var(--text))" }}>
+          Responsive QA
+        </strong>
+        <p style={{ margin: "6px 0 0" }}>
+          Resize the viewport to 320 px, 375 px, 768 px, and 1024 px to verify
+          all cards remain readable and grids reflow. Each grid uses{" "}
+          <code>minmax(min(100%, Xpx), 1fr)</code> so cells never overflow on
+          narrow viewports.
+        </p>
+      </section>
+    </main>
+  );
+}
+
+// ─── Theme toggle (fieldset/legend radio group) ───────────────────────────────
+
+function ThemeToggle({
+  current,
+  onChange,
+}: {
+  current: Theme;
+  onChange: (t: Theme) => void;
+}) {
+  const THEME_LABELS: Record<Theme, { emoji: string; label: string }> = {
+    light: { emoji: "☀️", label: "Light" },
+    dark: { emoji: "🌙", label: "Dark" },
+    cyberpunk: { emoji: "⚡", label: "Cyberpunk" },
+  };
+
+  return (
+    <fieldset
+      style={{
+        border: "1px solid var(--color-border-default, var(--border))",
+        borderRadius: 10,
+        padding: "12px 20px",
+        marginBottom: 32,
+        background: "var(--color-surface-default, var(--surface))",
+        display: "flex",
+        flexWrap: "wrap",
+        alignItems: "center",
+        gap: 8,
+      }}
+    >
+      <legend
+        style={{
+          fontSize: 13,
+          fontWeight: 600,
+          color: "var(--color-text-primary, var(--text))",
+          paddingInline: 4,
+        }}
+      >
+        Gallery theme
+      </legend>
+
+      {THEMES.map((t) => {
+        const { emoji, label } = THEME_LABELS[t];
+        const isSelected = current === t;
+        return (
+          <label
+            key={t}
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 6,
+              padding: "6px 14px",
+              borderRadius: 6,
+              border: `2px solid ${
+                isSelected
+                  ? "var(--color-accent-primary, #6366f1)"
+                  : "var(--color-border-default, var(--border))"
+              }`,
+              background: isSelected
+                ? "var(--color-accent-bg, rgba(99,102,241,0.1))"
+                : "transparent",
+              cursor: "pointer",
+              fontSize: 13,
+              fontWeight: isSelected ? 600 : 400,
+              color: isSelected
+                ? "var(--color-accent-primary, #6366f1)"
+                : "var(--color-text-primary, var(--text))",
+              transition: "border-color 0.15s, background 0.15s, color 0.15s",
+            }}
+          >
+            <input
+              type="radio"
+              name="gallery-theme"
+              value={t}
+              checked={isSelected}
+              onChange={() => onChange(t)}
+              style={{
+                /* Hidden visually but keeps keyboard/AT semantics */
+                position: "absolute",
+                opacity: 0,
+                width: 0,
+                height: 0,
+              }}
+            />
+            <span aria-hidden="true" style={{ fontSize: 16, lineHeight: 1 }}>
+              {emoji}
+            </span>
+            {label}
+          </label>
+        );
+      })}
+    </fieldset>
+  );
+}
+
+// ─── Section layout helpers ───────────────────────────────────────────────────
+
+function GallerySection({
+  id,
+  title,
+  children,
+}: {
+  id: string;
+  title: string;
+  children: ReactNode;
+}) {
+  const headingId = `${id}-heading`;
+  return (
+    <section aria-labelledby={headingId} style={{ marginBottom: 56 }}>
+      <h2
+        id={headingId}
+        style={{
+          fontSize: "clamp(17px, 2.5vw, 22px)",
+          fontWeight: 700,
+          marginBottom: 16,
+          paddingBottom: 10,
+          borderBottom: "2px solid var(--color-border-default, var(--border))",
+          color: "var(--color-text-primary, var(--text))",
+        }}
+      >
+        {title}
+      </h2>
+      {children}
+    </section>
+  );
+}
+
+function SubSection({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <div style={{ marginBottom: 28 }}>
+      <h3
+        style={{
+          fontSize: 12,
+          fontWeight: 600,
+          marginBottom: 12,
+          color: "var(--color-text-secondary, var(--muted))",
+          textTransform: "uppercase",
+          letterSpacing: "0.08em",
+        }}
+      >
+        {title}
+      </h3>
+      {children}
+    </div>
+  );
+}
+
+function Grid({ children, minWidth = 200 }: { children: ReactNode; minWidth?: number }) {
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: `repeat(auto-fill, minmax(min(100%, ${minWidth}px), 1fr))`,
+        gap: 20,
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+/**
+ * Cell — wraps an example with a visible label.
+ * Uses <figure> so screen readers associate the label with the content.
+ */
+function Cell({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <figure style={{ margin: 0 }} aria-label={label}>
+      <figcaption
+        style={{
+          fontSize: 11,
+          fontWeight: 600,
+          color: "var(--color-text-secondary, var(--muted))",
+          marginBottom: 6,
+          textTransform: "uppercase",
+          letterSpacing: "0.06em",
+          userSelect: "none",
+        }}
+      >
+        {label}
+      </figcaption>
+      {children}
+    </figure>
+  );
+}
+
+function SourceNote({ path }: { path: string }) {
+  return (
+    <p
+      style={{
+        fontSize: 12,
+        color: "var(--color-text-secondary, var(--muted))",
+        marginBottom: 16,
+        marginTop: -8,
+      }}
+    >
+      Source: <code>{path}</code>
+    </p>
+  );
+}
+
+// ─── Shared table header cell style ──────────────────────────────────────────
+
+const thStyle: React.CSSProperties = {
+  padding: "6px 12px",
+  fontSize: 11,
+  fontWeight: 600,
+  color: "var(--color-text-secondary, var(--muted))",
+  textTransform: "uppercase" as const,
+  letterSpacing: "0.06em",
+  textAlign: "center",
+  borderBottom: "1px solid var(--color-border-default, var(--border))",
+};
+
+// ─── Button variant × size grid ───────────────────────────────────────────────
+
+function VariantSizeGrid() {
+  return (
+    <div style={{ overflowX: "auto" }}>
+      <table
+        aria-label="Button variant and size matrix"
+        style={{ borderCollapse: "collapse", minWidth: 360, width: "100%" }}
+      >
+        <thead>
+          <tr>
+            <th scope="col" style={{ ...thStyle, textAlign: "left" }}>
+              Variant
+            </th>
+            {BUTTON_SIZES.map((size) => (
+              <th key={size} scope="col" style={thStyle}>
+                size={size}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {BUTTON_VARIANTS.map((variant) => (
+            <tr key={variant}>
+              <th
+                scope="row"
+                style={{
+                  ...thStyle,
+                  textAlign: "left",
+                  fontWeight: 500,
+                  textTransform: "none",
+                  letterSpacing: "normal",
+                }}
+              >
+                {variant}
+              </th>
+              {BUTTON_SIZES.map((size) => (
+                <td
+                  key={size}
+                  style={{ padding: "8px 12px", textAlign: "center" }}
+                  aria-label={`Button — ${variant}, size ${size}`}
+                >
+                  <Button variant={variant} size={size}>
+                    {variant.charAt(0).toUpperCase() + variant.slice(1)}
+                  </Button>
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/pages/dev/__tests__/ComponentGallery.test.tsx
+++ b/src/pages/dev/__tests__/ComponentGallery.test.tsx
@@ -1,0 +1,380 @@
+/**
+ * ComponentGallery tests
+ * ──────────────────────
+ * Covers:
+ *  - Page renders without crash
+ *  - Correct landmark / heading structure
+ *  - All four component sections are present
+ *  - All Button variants and sizes are rendered
+ *  - All Input types (including textarea and select) are rendered
+ *  - All StatusPill statuses are rendered
+ *  - MetricCard instances (standard, sparkline, multi-token, edge cases)
+ *  - Theme toggle changes the active theme label
+ *  - Accessibility: no axe violations
+ */
+
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { axe } from "vitest-axe";
+import { ThemeProvider } from "../../../theme/ThemeProvider";
+import ComponentGallery from "../ComponentGallery";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function renderGallery() {
+  return render(
+    <MemoryRouter>
+      <ThemeProvider>
+        <ComponentGallery />
+      </ThemeProvider>
+    </MemoryRouter>,
+  );
+}
+
+// ─── Setup / teardown ─────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  localStorage.clear();
+  document.documentElement.removeAttribute("data-theme");
+});
+
+afterEach(() => {
+  document.documentElement.removeAttribute("data-theme");
+});
+
+// ─── Page structure ───────────────────────────────────────────────────────────
+
+describe("ComponentGallery — page structure", () => {
+  it("renders without crashing", () => {
+    expect(() => renderGallery()).not.toThrow();
+  });
+
+  it("has exactly one <main> landmark with id=main-content", () => {
+    renderGallery();
+    const mains = screen.getAllByRole("main");
+    expect(mains).toHaveLength(1);
+    expect(mains[0]).toHaveAttribute("id", "main-content");
+  });
+
+  it("has exactly one h1 with the gallery title", () => {
+    renderGallery();
+    const h1s = screen.getAllByRole("heading", { level: 1 });
+    expect(h1s).toHaveLength(1);
+    expect(h1s[0]).toHaveTextContent(/component gallery/i);
+  });
+
+  it("has all four component section headings (h2)", () => {
+    renderGallery();
+    const sectionHeadings = screen
+      .getAllByRole("heading", { level: 2 })
+      .map((h) => h.textContent?.toLowerCase() ?? "");
+
+    expect(sectionHeadings).toContain("button");
+    expect(sectionHeadings).toContain("input");
+    expect(sectionHeadings).toContain("statuspill");
+    expect(sectionHeadings).toContain("metriccard");
+  });
+
+  it("heading hierarchy does not skip levels", () => {
+    renderGallery();
+    const headings = Array.from(
+      document.querySelectorAll("h1, h2, h3, h4, h5, h6"),
+    ).map((h) => parseInt(h.tagName.slice(1), 10));
+
+    expect(headings[0]).toBe(1);
+
+    for (let i = 1; i < headings.length; i++) {
+      if (headings[i] > headings[i - 1]) {
+        expect(headings[i] - headings[i - 1]).toBeLessThanOrEqual(1);
+      }
+    }
+  });
+});
+
+// ─── Theme toggle ─────────────────────────────────────────────────────────────
+
+describe("ComponentGallery — theme toggle", () => {
+  it("renders the theme toggle fieldset with legend", () => {
+    renderGallery();
+    // The legend text
+    expect(screen.getByText(/gallery theme/i)).toBeInTheDocument();
+  });
+
+  it("renders radio buttons for light, dark, and cyberpunk themes", () => {
+    renderGallery();
+    expect(screen.getByRole("radio", { name: /light/i })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: /dark/i })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: /cyberpunk/i })).toBeInTheDocument();
+  });
+
+  it("defaults to the current app theme (light in test environment)", () => {
+    renderGallery();
+    // The light radio should be checked by default (test env has no localStorage)
+    const lightRadio = screen.getByRole("radio", { name: /light/i });
+    expect(lightRadio).toBeChecked();
+  });
+
+  it("selecting dark theme checks the dark radio", () => {
+    renderGallery();
+    const darkRadio = screen.getByRole("radio", { name: /dark/i });
+    fireEvent.click(darkRadio);
+    expect(darkRadio).toBeChecked();
+  });
+
+  it("selecting cyberpunk theme checks the cyberpunk radio", () => {
+    renderGallery();
+    const cyberpunkRadio = screen.getByRole("radio", { name: /cyberpunk/i });
+    fireEvent.click(cyberpunkRadio);
+    expect(cyberpunkRadio).toBeChecked();
+  });
+});
+
+// ─── Button section ───────────────────────────────────────────────────────────
+
+describe("ComponentGallery — Button section", () => {
+  it("renders buttons for all 5 variants", () => {
+    renderGallery();
+    // The variant×size table has row headers for each variant
+    const variantRowHeaders = screen
+      .getAllByRole("rowheader")
+      .map((h) => h.textContent?.toLowerCase() ?? "");
+    // Filter to those in the button matrix table
+    expect(variantRowHeaders).toContain("primary");
+    expect(variantRowHeaders).toContain("secondary");
+    expect(variantRowHeaders).toContain("danger");
+    expect(variantRowHeaders).toContain("success");
+    expect(variantRowHeaders).toContain("ghost");
+  });
+
+  it("renders buttons for all 3 sizes (column headers in variant table)", () => {
+    renderGallery();
+    const buttonTable = screen.getByRole("table", {
+      name: /button variant and size matrix/i,
+    });
+    const colHeaders = within(buttonTable)
+      .getAllByRole("columnheader")
+      .map((h) => h.textContent ?? "");
+    expect(colHeaders.some((t) => /sm/i.test(t))).toBe(true);
+    expect(colHeaders.some((t) => /md/i.test(t))).toBe(true);
+    expect(colHeaders.some((t) => /lg/i.test(t))).toBe(true);
+  });
+
+  it("renders disabled buttons for all 5 variants", () => {
+    renderGallery();
+    // Each disabled button has the text "Disabled" and is actually disabled
+    const disabledButtons = screen
+      .getAllByRole("button", { name: /disabled/i })
+      .filter((btn) => btn.hasAttribute("disabled") || btn.getAttribute("aria-disabled") === "true");
+    // 5 variants × 1 disabled state each
+    expect(disabledButtons.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it("renders icon-only buttons with aria-label attributes", () => {
+    renderGallery();
+    const iconOnlyButtons = screen
+      .getAllByRole("button")
+      .filter((btn) => {
+        const label = btn.getAttribute("aria-label") ?? "";
+        return label.includes("action");
+      });
+    // 5 variants × icon-only
+    expect(iconOnlyButtons.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it("renders the full-width button", () => {
+    renderGallery();
+    const fullWidthCell = screen.getByRole("figure", {
+      name: /button — primary, full-width/i,
+    });
+    expect(fullWidthCell).toBeInTheDocument();
+    expect(within(fullWidthCell).getByRole("button")).toBeInTheDocument();
+  });
+});
+
+// ─── Input section ────────────────────────────────────────────────────────────
+
+describe("ComponentGallery — Input section", () => {
+  it("renders a text input with label", () => {
+    renderGallery();
+    expect(screen.getByLabelText(/full name/i)).toBeInTheDocument();
+  });
+
+  it("renders email inputs with label (default and error state)", () => {
+    renderGallery();
+    // Two email inputs: the default one and the validation-error one both have "Email address" label.
+    const emailInputs = screen.getAllByLabelText(/email address/i);
+    expect(emailInputs.length).toBeGreaterThanOrEqual(2);
+    expect(emailInputs[0]).toHaveAttribute("type", "email");
+  });
+
+  it("renders a password input", () => {
+    renderGallery();
+    const passwordInputs = screen.getAllByLabelText(/password/i);
+    expect(passwordInputs.length).toBeGreaterThanOrEqual(1);
+    expect(passwordInputs[0]).toHaveAttribute("type", "password");
+  });
+
+  it("renders a textarea", () => {
+    renderGallery();
+    // Textarea's label is "Notes"
+    expect(screen.getByLabelText(/notes/i)).toBeInTheDocument();
+  });
+
+  it("renders a select with options", () => {
+    renderGallery();
+    // Network select
+    expect(screen.getByLabelText(/^network$/i)).toBeInTheDocument();
+  });
+
+  it("renders inputs in error state with aria-invalid", () => {
+    renderGallery();
+    const invalidInputs = document
+      .querySelectorAll('[aria-invalid="true"]');
+    expect(invalidInputs.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders a disabled input", () => {
+    renderGallery();
+    const readOnlyInput = screen.getByLabelText(/read-only address/i);
+    expect(readOnlyInput).toBeDisabled();
+  });
+
+  it("renders a required input", () => {
+    renderGallery();
+    const recipientInput = screen.getByLabelText(/recipient address/i);
+    expect(recipientInput).toBeRequired();
+  });
+
+  it("renders a helper text below the Stream ID input", () => {
+    renderGallery();
+    expect(
+      screen.getByText(/copy the 12-character id/i),
+    ).toBeInTheDocument();
+  });
+});
+
+// ─── StatusPill section ───────────────────────────────────────────────────────
+
+describe("ComponentGallery — StatusPill section", () => {
+  const allStatuses = [
+    "Active",
+    "Paused",
+    "Completed",
+    "Healthy",
+    "At-Risk",
+    "Critical",
+  ];
+
+  it("renders a StatusPill for every status", () => {
+    renderGallery();
+    for (const status of allStatuses) {
+      // StatusPill renders role="status" with aria-label="{status} status"
+      const pills = screen.getAllByRole("status", {
+        name: new RegExp(`${status} status`, "i"),
+      });
+      expect(pills.length).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it("renders the variant matrix table with correct headers", () => {
+    renderGallery();
+    const matrixTable = screen.getByRole("table", {
+      name: /statuspill variant matrix/i,
+    });
+    expect(matrixTable).toBeInTheDocument();
+
+    const colHeaders = within(matrixTable)
+      .getAllByRole("columnheader")
+      .map((h) => h.textContent ?? "");
+
+    expect(colHeaders.some((t) => /icon-xs/i.test(t))).toBe(true);
+    expect(colHeaders.some((t) => /icon-sm/i.test(t))).toBe(true);
+    expect(colHeaders.some((t) => /icon-md/i.test(t))).toBe(true);
+    expect(colHeaders.some((t) => /icon-lg/i.test(t))).toBe(true);
+  });
+
+  it("matrix table has a row for every status", () => {
+    renderGallery();
+    const matrixTable = screen.getByRole("table", {
+      name: /statuspill variant matrix/i,
+    });
+    const rowHeaders = within(matrixTable)
+      .getAllByRole("rowheader")
+      .map((h) => h.textContent ?? "");
+
+    for (const status of allStatuses) {
+      expect(rowHeaders).toContain(status);
+    }
+  });
+});
+
+// ─── MetricCard section ───────────────────────────────────────────────────────
+
+describe("ComponentGallery — MetricCard section", () => {
+  it("renders the standard MetricCard with its label", () => {
+    renderGallery();
+    // MetricCard uses role="group" with aria-label={label}
+    expect(
+      screen.getByRole("group", { name: /total streamed/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the sparkline MetricCard", () => {
+    renderGallery();
+    expect(
+      screen.getByRole("group", { name: /weekly flow/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the multi-token MetricCard", () => {
+    renderGallery();
+    expect(
+      screen.getByRole("group", { name: /vault balance/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the active streams count MetricCard", () => {
+    renderGallery();
+    expect(
+      screen.getByRole("group", { name: /active streams/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the long-label edge-case MetricCard", () => {
+    renderGallery();
+    expect(
+      screen.getByRole("group", {
+        name: /total treasury capital deployed/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the zero-value edge-case MetricCard", () => {
+    renderGallery();
+    expect(
+      screen.getByRole("group", { name: /pending withdrawals/i }),
+    ).toBeInTheDocument();
+  });
+});
+
+// ─── Cell / figure captions ───────────────────────────────────────────────────
+
+describe("ComponentGallery — Cell figure labels", () => {
+  it("renders figure elements with aria-label for every gallery cell", () => {
+    renderGallery();
+    // Each Cell renders a <figure aria-label="…">
+    const figures = document.querySelectorAll("figure[aria-label]");
+    expect(figures.length).toBeGreaterThanOrEqual(10);
+  });
+});
+
+// ─── Accessibility ────────────────────────────────────────────────────────────
+
+describe("ComponentGallery — accessibility (axe)", () => {
+  it("has no axe violations on initial render", async () => {
+    const { container } = renderGallery();
+    const results = await axe(container);
+    expect(results.violations).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1316

Adds a dev-only `/app/component-gallery` route that renders the full prop/variant/state matrix for **Button**, **Input**, **StatusPill**, and **MetricCard** side by side — matching the established `EmptyStateDemo` pattern — for design QA and onboarding new contributors.

---

## Changes

| File | Change |
|------|--------|
| `src/pages/dev/ComponentGallery.tsx` | New gallery page |
| `src/App.tsx` | Route registration (IS_DEV guard) |
| `src/pages/dev/__tests__/ComponentGallery.test.tsx` | 35-test suite |
| `docs/COMPONENT_GUIDELINES.md` | Component API reference + gallery guide |

---

## Route guard

Identical to `EmptyStateDemo`:

```ts
const ComponentGallery = IS_DEV
  ? lazy(() => import("./pages/dev/ComponentGallery"))
  : () => null;

{IS_DEV && <Route path="component-gallery" element={lazyAppRoute(<ComponentGallery />)} />}
```

`IS_DEV` is `import.meta.env.DEV` — Vite sets it to `false` in production builds, so the chunk is excluded from the bundle entirely.

---

## What the gallery covers

### Button
- 5 variants × 3 sizes table
- Loading state (all 5 variants)
- Disabled state (all 5 variants)
- Icon-only with `aria-label` (all 5 variants)
- Full-width

### Input
- Types: text, email, password, number, textarea, select
- Validation: error + `aria-invalid`, helper text
- States: disabled, required, required+disabled

### StatusPill
- All 6 statuses at default icon size
- All 4 icon sizes for Active
- Full 6×4 matrix table (`<table>` with `<th scope>`)

### MetricCard
- Standard, sparkline trend, multi-token
- Edge cases: long label, zero value

---

## Accessibility (WCAG 2.1 AA)

- `<main id="main-content">` targeted by global skip-link
- `<section aria-labelledby>` per component group
- `<figure aria-label>` + `<figcaption>` for every example cell (label e.g. `"Button — primary, disabled"`)
- `<fieldset>/<legend>` radio group for theme toggle (arrow-key navigable)
- `<table>` with `<th scope="col/row">` for variant matrices
- Colour is never the only differentiator — labels always present
- **axe reports 0 violations** on initial render (tested)

---

## Theme toggle

`<fieldset>` radio group with Light / Dark / Cyberpunk options. Calls `setTheme()` from `useTheme()` — switches the full app theme live without leaving the page.

---

## Responsive

All grids use `minmax(min(100%, Xpx), 1fr)` — no overflow at 320 px. Tables have `overflow-x: auto`. Headings and page padding use `clamp()`.

---

## Tests

35 tests in `src/pages/dev/__tests__/ComponentGallery.test.tsx`:
- Page structure (main landmark, h1, h2 for all four sections, heading hierarchy)
- Theme toggle (3 radios, state changes)
- All Button variants/sizes/states
- All Input types/states
- All StatusPill statuses and matrix table headers/rows
- All MetricCard instances
- Figure label count
- **axe: 0 violations**

---

## Documentation

`docs/COMPONENT_GUIDELINES.md` — prop tables, usage examples, accessibility notes, design token quick reference, gallery usage instructions, and a step-by-step guide for adding new components to the gallery.