### PR TITLE
Feat: Stabilize navbar keyboard navigation

### DIFF
--- a/src/components/navigation/AppNavbar.tsx
+++ b/src/components/navigation/AppNavbar.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useRef, useCallback } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { Menu, X, Type, Search, Command } from "lucide-react";
 import { useWallet } from "../wallet-connect/Walletcontext";
@@ -303,11 +303,30 @@ const location = useLocation();
   const showBreadcrumb = isAppView && breadcrumbs.length > 1;
   const links = connected ? APP_PRIMARY_LINKS : ANON_LINKS;
 
-  const closeMobile = () => setMobileMenuOpen(false);
+  // Anon hamburger — kept as a ref so focus can be deterministically returned
+  // to it whenever the mobile menu closes via keyboard (Escape) or link
+  // activation, instead of being silently dropped to <body>.
+  const hamburgerButtonRef = useRef<HTMLButtonElement | null>(null);
+
+  const closeMobile = useCallback((options?: { restoreFocus?: boolean }) => {
+    setMobileMenuOpen(false);
+    if (options?.restoreFocus) {
+      hamburgerButtonRef.current?.focus();
+    }
+  }, []);
+
+  // Safety net: any route change closes the mobile menu, regardless of
+  // whether it was triggered by clicking a link inside it (browser
+  // back/forward, programmatic navigation, etc. bypass that handler).
+  // This keeps menu state deterministic across rerenders instead of being
+  // contingent on which specific interaction caused the navigation.
+  useEffect(() => {
+    setMobileMenuOpen(false);
+  }, [location.pathname]);
 
   const handleHeaderKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
     if (e.key === "Escape" && mobileMenuOpen) {
-      closeMobile();
+      closeMobile({ restoreFocus: true });
     }
   };
 
@@ -447,6 +466,7 @@ const location = useLocation();
                In app view the sidebar toggle above the logo handles mobile nav. */}
           {!isAppView && (
             <button
+              ref={hamburgerButtonRef}
               type="button"
               className="md:hidden flex items-center justify-center w-11 h-11 rounded-lg text-[var(--navbar-icon-color)] hover:text-[var(--text)] hover:bg-[var(--surface-elevated)] transition-all outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
               onClick={() => setMobileMenuOpen((prev) => !prev)}
@@ -488,7 +508,7 @@ const location = useLocation();
               key={link.to}
               to={link.to}
               label={link.label}
-              onClick={closeMobile}
+              onClick={() => closeMobile({ restoreFocus: true })}
             />
           ))}
 
@@ -534,13 +554,13 @@ const location = useLocation();
                 isNetworkMismatch={isNetworkMismatch}
                 onDisconnect={() => {
                   disconnect();
-                  closeMobile();
+                  closeMobile({ restoreFocus: true });
                 }}
               />
             ) : (
               <Link
                 to="/connect-wallet"
-                onClick={closeMobile}
+                onClick={() => closeMobile({ restoreFocus: true })}
                 aria-label="Connect your Stellar wallet"
                 className="px-5 h-[44px] rounded-full bg-[var(--cta-bg)] text-white text-sm font-semibold shadow-[var(--cta-shadow)] hover:opacity-90 transition-opacity outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] flex items-center"
               >

--- a/src/components/navigation/WalletStatus.tsx
+++ b/src/components/navigation/WalletStatus.tsx
@@ -16,6 +16,14 @@ import { stellarExplorerUrl } from "../../lib/stellar";
 import { useClipboard } from "../../hooks/useClipboard";
 import { useOptionalToast } from "../toast/ToastProvider";
 import { formatAddress } from "../common/TruncatedAddress";
+import {
+  type ShareProvider,
+  SHARE_WORKSPACES_CHANGED_EVENT,
+  connectWorkspace,
+  disconnectWorkspace,
+  getShareProviderLabel,
+  readConnectedWorkspaces,
+} from "../../lib/shareWorkspaces";
 
 interface WalletStatusProps {
   address: string;

--- a/src/components/navigation/__tests__/AppNavbar.keyboard.test.tsx
+++ b/src/components/navigation/__tests__/AppNavbar.keyboard.test.tsx
@@ -487,3 +487,83 @@ describe("I: Connect-wallet CTA renders text, not icons", () => {
     expect(cta).not.toHaveAttribute("tabindex", "-1");
   });
 });
+
+// ─── J: Focus restoration on mobile-menu close ────────────────────────────────
+// A disclosure widget (the hamburger menu) must return focus to the control
+// that opened it whenever it closes via keyboard or link activation —
+// otherwise a keyboard user's focus silently falls back to <body> and their
+// place in the page is lost.
+
+describe("J: Focus restoration on mobile-menu close", () => {
+  it("Escape returns focus to the hamburger button", () => {
+    renderNavbar();
+    const header = screen.getByRole("banner");
+    const openBtn = screen.getByRole("button", { name: /open navigation menu/i });
+    fireEvent.click(openBtn);
+    expect(document.getElementById("mobile-nav")).toBeInTheDocument();
+
+    fireEvent.keyDown(header, { key: "Escape", code: "Escape" });
+
+    const closedBtn = screen.getByRole("button", { name: /open navigation menu/i });
+    expect(document.activeElement).toBe(closedBtn);
+  });
+
+  it("activating a link inside the mobile menu returns focus to the hamburger button", () => {
+    renderNavbar();
+    fireEvent.click(screen.getByRole("button", { name: /open navigation menu/i }));
+    const mobileNav = document.getElementById("mobile-nav")!;
+    fireEvent.click(within(mobileNav).getByRole("link", { name: /features/i }));
+
+    expect(document.getElementById("mobile-nav")).not.toBeInTheDocument();
+    const reopenedBtn = screen.getByRole("button", { name: /open navigation menu/i });
+    expect(document.activeElement).toBe(reopenedBtn);
+  });
+
+  it("activating the Connect Wallet CTA inside the mobile menu returns focus to the hamburger button", () => {
+    renderNavbar();
+    fireEvent.click(screen.getByRole("button", { name: /open navigation menu/i }));
+    const mobileNav = document.getElementById("mobile-nav")!;
+    fireEvent.click(within(mobileNav).getByRole("link", { name: /connect your stellar wallet/i }));
+
+    expect(document.getElementById("mobile-nav")).not.toBeInTheDocument();
+    const reopenedBtn = screen.getByRole("button", { name: /open navigation menu/i });
+    expect(document.activeElement).toBe(reopenedBtn);
+  });
+});
+
+// ─── K: Route-change auto-closes the mobile menu ──────────────────────────────
+// The menu must close deterministically on any navigation, not only when the
+// close handler happens to run first (e.g. browser back/forward or a
+// programmatic redirect that bypasses the in-menu link's onClick).
+
+describe("K: Route change closes an open mobile menu", () => {
+  it("mobile menu unmounts when the pathname changes while it is open", () => {
+    mockPathname = "/";
+    const { rerender } = renderNavbar();
+    fireEvent.click(screen.getByRole("button", { name: /open navigation menu/i }));
+    expect(document.getElementById("mobile-nav")).toBeInTheDocument();
+
+    mockPathname = "/#pricing";
+    act(() => {
+      rerender(
+        <ThemeProvider>
+          <AppNavbar />
+        </ThemeProvider>,
+      );
+    });
+
+    expect(document.getElementById("mobile-nav")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /open navigation menu/i }),
+    ).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("mounting on a fresh pathname does not throw and starts with the menu closed", () => {
+    mockPathname = "/#docs";
+    renderNavbar();
+    expect(document.getElementById("mobile-nav")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /open navigation menu/i }),
+    ).toHaveAttribute("aria-expanded", "false");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1128

Stabilizes keyboard focus behavior in `AppNavbar` and fixes a pre-existing crash that was blocking verification of connected-view navbar behavior.

- **Focus restoration on mobile-menu close** — Escape, clicking an in-menu link, or activating the Connect Wallet CTA all closed the mobile hamburger menu, but never returned focus anywhere. Since the focused element was removed from the DOM, focus silently fell back to `<body>`, breaking keyboard flow. Focus is now deterministically returned to the hamburger button on every close path.
- **Deterministic auto-close on route change** — the mobile menu previously only closed via the specific link's `onClick` handler. Browser back/forward or programmatic navigation could bypass that handler and leave a stale menu open. Added a `location.pathname` effect that always closes the menu on navigation, regardless of how it was triggered.
- **Fixed a pre-existing crash in `WalletStatus.tsx`** — `readConnectedWorkspaces`, `ShareProvider`, `connectWorkspace`, `disconnectWorkspace`, `getShareProviderLabel`, and `SHARE_WORKSPACES_CHANGED_EVENT` were referenced but never imported from `lib/shareWorkspaces.ts`. This crashed the entire navbar for any connected wallet. Confirmed via `git stash` that this bug already existed on `main`, unrelated to this change, but it blocked testing connected-view keyboard behavior so it's fixed here.

## Changes

- `src/components/navigation/AppNavbar.tsx`
  - Added `hamburgerButtonRef` and wired it to the anon mobile-menu toggle button.
  - `closeMobile` now accepts `{ restoreFocus?: boolean }` and focuses the hamburger button when requested.
  - Escape key handler, in-menu `NavLink` clicks, the mobile Connect Wallet CTA, and the wallet disconnect callback now request focus restoration.
  - New `useEffect` on `location.pathname` that unconditionally closes the mobile menu on route change.
- `src/components/navigation/WalletStatus.tsx`
  - Added the missing import from `lib/shareWorkspaces.ts`.
- `src/components/navigation/__tests__/AppNavbar.keyboard.test.tsx`
  - New `describe` blocks:
    - **J: Focus restoration on mobile-menu close** — Escape, in-menu link click, and CTA click all return focus to the hamburger button.
    - **K: Route change closes an open mobile menu** — pathname change while the menu is open unmounts it; mounting on a non-root pathname starts closed.

## Test plan

- [x] `npx vitest run src/components/navigation/__tests__/AppNavbar.keyboard.test.tsx` — 44/44 passed (39 existing + 5 new)
- [x] `npx vitest run` across `AppNavbar.*`, `WalletStatus.*` test files — 62/62 passed
- [x] Full repo test suite run for regressions — no failures in any navigation/navbar/NavLink test; the 57 pre-existing failures elsewhere (`StreamCreatedModal`, `ActivityHeatmap`, `WalletButton`) are unrelated and present independent of this branch
- [x] Confirmed the `WalletStatus` crash pre-dates this branch via `git stash` + test run against unmodified `HEAD`

