### PR TITLE
Docs: add component guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,9 @@ function ThemeToggle() {
 
 New contributors should start with [CONTRIBUTING.md](CONTRIBUTING.md) for a full walkthrough of local setup, branch naming, commit conventions, and the test/coverage workflow.
 
+Component-specific styling and accessibility conventions are documented in
+[docs/COMPONENT_GUIDELINES.md](docs/COMPONENT_GUIDELINES.md).
+
 
 Pull requests and pushes to `main` run the GitHub Actions CI workflow
 (`.github/workflows/ci.yml`) on Node 18 and Node 20. The workflow installs with

--- a/docs/COMPONENT_GUIDELINES.md
+++ b/docs/COMPONENT_GUIDELINES.md
@@ -104,6 +104,19 @@ than hardcoded colour literals or pixel values. Common tokens:
 
 ---
 
+## CSS Modules and component boundaries
+
+- Keep component-only styles in a colocated CSS Module or stylesheet; do not
+  add selectors to a global file unless they are shared by multiple components.
+- Use the design tokens above from CSS Modules and avoid hardcoded colors,
+  spacing, typography, or motion values.
+- Keep data fetching in API hooks/services and keep presentational components
+  focused on rendering and user interaction.
+- Reuse shared primitives such as `VirtualList`, `EmptyState`, and the wallet
+  provider before adding a parallel implementation.
+
+---
+
 ## Wallet state
 
 Read wallet address and network exclusively through `useWallet()` from


### PR DESCRIPTION
## Summary
- Add contributor guidance for component styling, boundaries, accessibility, and focused tests.
- Link the guidance from the repository README.

## Verification
- Markdown diff passes `git diff --check`.

Closes #1311