### PR TITLE
Perf: preload Plus Jakarta Sans

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,17 @@
     />
     <meta name="theme-color" content="#06B6D4" />
     <link rel="canonical" href="https://fluxora.app/" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="preload"
+      as="style"
+      href="https://fonts.googleapis.com/css2?family=Lexend:wght@300..700&family=Plus+Jakarta+Sans:wght@400..700&display=swap"
+    />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Lexend:wght@300..700&family=Plus+Jakarta+Sans:wght@400..700&display=swap"
+    />
     <link rel="icon" type="image/svg+xml" href="/src/public/Icon.svg" id="favicon" />
     <link rel="alternate icon" type="image/png" href="/src/public/Icon.png" />
     <link rel="manifest" href="/manifest.json" />
@@ -60,7 +71,7 @@
     -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https:; font-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self';"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; connect-src 'self' https:; font-src 'self' https://fonts.gstatic.com; object-src 'none'; frame-ancestors 'none'; base-uri 'self';"
     />
 
     <!--

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,3 @@
-@import url("https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&family=Lexend:wght@300;400;500;600;700&display=swap");
 @import "tailwindcss";
 @import "./design-tokens.css";
 


### PR DESCRIPTION
## Summary
- Move Google font loading from CSS `@import` into early HTML resource hints.
- Preconnect to the font origins and preload the variable Plus Jakarta Sans/Lexend stylesheet with `display=swap`.
- Allow the font origins in the existing CSP.

## Verification
- `git diff --check` passes.
- `npm run build` reaches existing unrelated TypeScript errors in `ConnectWalletModal`, `WalletStatus`, and test files.

Closes #1308