### PR TITLE
Virtualize large recipient stream lists

### DIFF
--- a/src/components/__tests__/RecipientStreams.filters.test.tsx
+++ b/src/components/__tests__/RecipientStreams.filters.test.tsx
@@ -284,6 +284,24 @@ describe("RecipientStreams — populated state", () => {
   });
 });
 
+describe("RecipientStreams — large lists", () => {
+  it("virtualizes incoming streams once the list exceeds 50 items", async () => {
+    const streams = Array.from({ length: 60 }, (_, index) => ({
+      ...activeStream,
+      id: `stream-${index}`,
+      senderName: `Sender ${index}`,
+    }));
+
+    render(<RecipientStreams streams={streams} pollIntervalMs={0} />);
+
+    const list = await screen.findByRole("list", { name: "Incoming streams" });
+    expect(list).toHaveAttribute("data-virtualized", "true");
+    expect(list.querySelectorAll('[role="listitem"]').length).toBeLessThan(
+      streams.length,
+    );
+  });
+});
+
 // ─── 6. Keyboard accessibility on pin button ──────────────────────────────────
 
 describe("RecipientStreams — keyboard accessibility", () => {

--- a/src/components/recipient/RecipientStreams.tsx
+++ b/src/components/recipient/RecipientStreams.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useCallback, useRef } from "react";
 import EmptyState from "../EmptyState";
 import { Skeleton, SkeletonCard } from "../Skeleton";
+import VirtualList from "../VirtualList";
 import "../skeleton.css";
 
 // Types matching stream properties across testing matrix & app contracts
@@ -425,10 +426,15 @@ export const RecipientStreams: React.FC<RecipientStreamsProps> = ({
         </div>
       ) : (
         /* State 4: Populated State */
-        <div className="space-y-3">
-          {sortedStreams.map((stream) => (
+        <VirtualList
+          items={sortedStreams}
+          getKey={(stream) => stream.id}
+          ariaLabel="Incoming streams"
+          className="space-y-3"
+          estimateSize={96}
+          threshold={50}
+          renderItem={(stream) => (
             <div
-              key={stream.id}
               className="p-4 rounded-xl flex justify-between items-center"
               style={{ border: "1px solid var(--color-border-default)" }}
             >
@@ -471,8 +477,8 @@ export const RecipientStreams: React.FC<RecipientStreamsProps> = ({
                 </button>
               </div>
             </div>
-          ))}
-        </div>
+          )}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
Use the existing VirtualList component for incoming recipient streams once the list exceeds 50 entries. Add a regression test covering virtualization and mounted row limits.

Closes #1309