### PR TITLE
Add a trailing fade for scrollable streams

### DIFF
--- a/src/components/treasuryOverviewPage/StreamsTable.css
+++ b/src/components/treasuryOverviewPage/StreamsTable.css
@@ -95,3 +95,17 @@
     transition: none;
   }
 }
+.streams-table-scroll-shell {
+  position: relative;
+}
+
+.streams-table-trailing-fade {
+  position: absolute;
+  top: 1px;
+  right: 1px;
+  bottom: 1px;
+  width: 2.5rem;
+  pointer-events: none;
+  background: linear-gradient(to right, transparent, var(--color-surface-default));
+  border-radius: 0 0.5rem 0.5rem 0;
+}

--- a/src/components/treasuryOverviewPage/StreamsTable.tsx
+++ b/src/components/treasuryOverviewPage/StreamsTable.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import StreamRow from "./StreamRow";
 import { Stream } from "./Stream";
 import "./StreamsTable.css";
@@ -21,6 +21,29 @@ export default function StreamsTable({ streams, onCompare }: Props) {
   const [sortColumn, setSortColumn] = useState<SortColumn | null>(null);
   const [sortDirection, setSortDirection] = useState<SortDirection>("asc");
   const tbodyRef = useRef<HTMLTableSectionElement>(null);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const [showTrailingFade, setShowTrailingFade] = useState(false);
+
+  useEffect(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+
+    const updateFade = () => {
+      setShowTrailingFade(
+        container.scrollWidth > container.clientWidth + 1 &&
+          container.scrollLeft < container.scrollWidth - container.clientWidth - 1,
+      );
+    };
+
+    updateFade();
+    container.addEventListener("scroll", updateFade, { passive: true });
+    const observer = new ResizeObserver(updateFade);
+    observer.observe(container);
+    return () => {
+      container.removeEventListener("scroll", updateFade);
+      observer.disconnect();
+    };
+  }, [streams.length, sortColumn, sortDirection]);
 
   // Legacy single-select kept for visual highlight; driven by compareIds[0].
   const selectedId = compareIds[0] ?? null;
@@ -218,7 +241,15 @@ export default function StreamsTable({ streams, onCompare }: Props) {
         </div>
       )}
 
+      <div className="streams-table-scroll-shell">
       <div
+        ref={scrollContainerRef}
+        onScroll={() => setShowTrailingFade(
+          scrollContainerRef.current
+            ? scrollContainerRef.current.scrollLeft <
+              scrollContainerRef.current.scrollWidth - scrollContainerRef.current.clientWidth - 1
+            : false,
+        )}
         className="overflow-x-auto rounded-lg"
         style={{
           border: "1px solid var(--color-border-default)",
@@ -350,6 +381,8 @@ export default function StreamsTable({ streams, onCompare }: Props) {
             )}
           </tbody>
         </table>
+      </div>
+      {showTrailingFade && <div className="streams-table-trailing-fade" aria-hidden="true" />}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
Add a decorative trailing-edge fade to the StreamsTable only while horizontal content remains off-screen. The indicator updates on scroll, resize, and orientation-driven layout changes through a ResizeObserver, and is marked `aria-hidden` so keyboard/assistive-tech access remains unchanged.

## Validation
The focused Vitest command was not run locally because dependencies are not installed in the checkout (`vitest: command not found`).

Closes #1300