### PR TITLE
Fix stream modal footer above the iOS keyboard

### DIFF
--- a/src/components/CreateStreamModal.css
+++ b/src/components/CreateStreamModal.css
@@ -39,6 +39,22 @@
   justify-content: center;
 }
 
+/* Mobile Safari resizes the visual viewport when its keyboard opens. Using
+   dynamic viewport units keeps the modal and its footer inside that resized
+   area instead of measuring against the hidden layout viewport. */
+@supports (height: 100dvh) {
+  .create-stream-overlay {
+    height: 100dvh;
+    min-height: 100dvh;
+    padding-top: max(1rem, env(safe-area-inset-top));
+    padding-bottom: max(1rem, env(safe-area-inset-bottom));
+  }
+
+  .create-stream-modal {
+    max-height: min(calc(100dvh - 2rem), 600px);
+  }
+}
+
 .create-stream-modal {
   box-shadow: 0 24px 48px rgba(0, 0, 0, 0.4);
   max-height: min(90vh, 600px);
@@ -72,6 +88,12 @@
   margin: -2px -4px;
   scrollbar-width: none;
   -ms-overflow-style: none;
+}
+
+@media (max-width: 640px) {
+  .create-stream-modal .modal-footer {
+    padding-bottom: max(0.25rem, env(safe-area-inset-bottom));
+  }
 }
 
 .create-stream-modal .modal-body-scroll::-webkit-scrollbar {
@@ -2295,4 +2317,3 @@
     transition: none;
   }
 }
-


### PR DESCRIPTION
## Summary
Use Safari-aware dynamic viewport units for the Create Stream modal overlay and modal max-height, plus safe-area padding for the mobile footer. When the amount field opens the on-screen keyboard, the modal now measures against the resized visual viewport so footer actions remain reachable without changing focus trapping or scroll locking.

## Validation
The focused Vitest command was not run locally because dependencies are not installed in the checkout (`vitest: command not found`).

Closes #1301