### PR TITLE
fix(pagination): add touch active feedback

### DIFF
--- a/src/components/Pagination.css
+++ b/src/components/Pagination.css
@@ -85,6 +85,14 @@
   box-shadow: 0 0 15px rgba(59, 130, 246, 0.2);
 }
 
+.page-num-btn:active:not(:disabled) {
+  background: var(--primary, #3b82f6);
+  border-color: var(--primary, #3b82f6);
+  color: var(--text-on-primary, #ffffff);
+  transform: translateY(1px);
+  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.25);
+}
+
 .page-nav-btn {
   background: var(--surface-alt, rgba(15, 23, 42, 0.4));
   border-color: var(--border-subtle);

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -79,7 +79,22 @@ export const Pagination: React.FC<PaginationProps> = ({
           Page {normalizedPage} of {totalPages}
         </span>
 
+        <div className="page-number-list" aria-label="Pages">
+          {Array.from({ length: totalPages }, (_, index) => index + 1).map((page) => (
+            <button
+              key={page}
+              type="button"
+              className={`page-num-btn${page === normalizedPage ? ' is-active' : ''}`}
+              aria-current={page === normalizedPage ? 'page' : undefined}
+              onClick={() => onPageChange(page)}
+            >
+              {page}
+            </button>
+          ))}
+        </div>
+
         <button
+          type="button"
           onClick={() => onPageChange(normalizedPage + 1)}
           disabled={normalizedPage >= totalPages}
           className="page-nav-btn"


### PR DESCRIPTION
## Summary
- Render accessible page-number buttons with an `aria-current` marker.
- Add a distinct pressed `:active` state for touch feedback, separate from hover.

## Test plan
- [x] npm test -- --run src/components/__tests__/Pagination.test.tsx (7 tests)
- [ ] npx tsc --noEmit (pre-existing test/type errors in ConnectWalletModal and CreateStreamModal suites)

Closes #1302