### PR TITLE
Standardize loading-state test IDs

### DIFF
--- a/src/components/LOADING_STATES.md
+++ b/src/components/LOADING_STATES.md
@@ -1,0 +1,15 @@
+# Loading-state selectors
+
+Loading surfaces keep their accessible `role="status"` and accessible label.
+Tests that need a stable DOM hook should select the root `data-testid` from the
+shared `LOADING_TEST_IDS` map in `Skeleton.tsx`:
+
+| Surface | Selector |
+| --- | --- |
+| Shared block | `loading-skeleton-block` |
+| Streams page | `loading-skeleton-streams` |
+| Treasury overview | `loading-skeleton-treasury` |
+| Recipient portal | `loading-skeleton-recipient` |
+
+The selectors describe loading context, not individual visual rectangles. Do
+not add test IDs to replace semantic queries for status announcements.

--- a/src/components/RecipientLoading.tsx
+++ b/src/components/RecipientLoading.tsx
@@ -1,10 +1,10 @@
-import { Skeleton, SkeletonCard } from "./Skeleton";
+import { LOADING_TEST_IDS, Skeleton, SkeletonCard } from "./Skeleton";
 import "./skeleton.css";
 
 /** Skeleton for the Recipient portal balance card + stats row. */
 export default function RecipientLoading() {
   return (
-    <div role="status" aria-label="Loading recipient portal" aria-busy="true">
+    <div data-testid={LOADING_TEST_IDS.recipient} role="status" aria-label="Loading recipient portal" aria-busy="true">
       <span className="sr-only">Loading your streams…</span>
 
       {/* Page header */}

--- a/src/components/Skeleton.tsx
+++ b/src/components/Skeleton.tsx
@@ -1,6 +1,14 @@
 import React from "react";
 import "./skeleton.css";
 
+/** Stable selectors for loading-state roots; keep accessible roles as well. */
+export const LOADING_TEST_IDS = {
+  block: "loading-skeleton-block",
+  streams: "loading-skeleton-streams",
+  treasury: "loading-skeleton-treasury",
+  recipient: "loading-skeleton-recipient",
+} as const;
+
 interface SkeletonProps extends React.HTMLAttributes<HTMLDivElement> {
   width?: string | number;
   height?: string | number;

--- a/src/components/StreamsLoading.tsx
+++ b/src/components/StreamsLoading.tsx
@@ -1,10 +1,10 @@
-import { Skeleton, SkeletonCard } from "./Skeleton";
+import { LOADING_TEST_IDS, Skeleton, SkeletonCard } from "./Skeleton";
 import "./skeleton.css";
 
 /** Skeleton for the Streams page table surface. */
 export default function StreamsLoading() {
   return (
-    <div role="status" aria-label="Loading streams" aria-busy="true">
+    <div data-testid={LOADING_TEST_IDS.streams} role="status" aria-label="Loading streams" aria-busy="true">
       <span className="sr-only">Loading streams…</span>
 
       {/* Page header */}

--- a/src/components/TreasuryOverviewLoading.tsx
+++ b/src/components/TreasuryOverviewLoading.tsx
@@ -1,10 +1,10 @@
-import { Skeleton, SkeletonCard } from "./Skeleton";
+import { LOADING_TEST_IDS, Skeleton, SkeletonCard } from "./Skeleton";
 import "./skeleton.css";
 
 /** Skeleton for the full Dashboard / Treasury overview surface. */
 export default function TreasuryOverviewLoading() {
   return (
-    <div role="status" aria-label="Loading treasury overview" aria-busy="true">
+    <div data-testid={LOADING_TEST_IDS.treasury} role="status" aria-label="Loading treasury overview" aria-busy="true">
       <span className="sr-only">Loading treasury overview…</span>
 
       {/* Page header */}

--- a/src/components/__tests__/LoadingSkeletons.test.tsx
+++ b/src/components/__tests__/LoadingSkeletons.test.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect } from "vitest";
 import StreamsLoading from "../StreamsLoading";
 import TreasuryOverviewLoading from "../TreasuryOverviewLoading";
 import RecipientLoading from "../RecipientLoading";
+import { LOADING_TEST_IDS } from "../Skeleton";
 
 describe("StreamsLoading", () => {
   it("has role=status with correct aria-label and aria-busy", () => {
@@ -10,6 +11,11 @@ describe("StreamsLoading", () => {
     const region = screen.getByRole("status");
     expect(region).toHaveAttribute("aria-label", "Loading streams");
     expect(region).toHaveAttribute("aria-busy", "true");
+  });
+
+  it("uses the shared streams loading selector", () => {
+    render(<StreamsLoading />);
+    expect(screen.getByTestId(LOADING_TEST_IDS.streams)).toHaveAttribute("role", "status");
   });
 
   it("renders sr-only announcement text", () => {
@@ -53,6 +59,11 @@ describe("TreasuryOverviewLoading", () => {
     const region = screen.getByRole("status");
     expect(region).toHaveAttribute("aria-label", "Loading treasury overview");
     expect(region).toHaveAttribute("aria-busy", "true");
+  });
+
+  it("uses the shared treasury loading selector", () => {
+    render(<TreasuryOverviewLoading />);
+    expect(screen.getByTestId(LOADING_TEST_IDS.treasury)).toHaveAttribute("role", "status");
   });
 
   it("renders sr-only announcement text", () => {
@@ -113,6 +124,11 @@ describe("RecipientLoading", () => {
     const region = screen.getByRole("status");
     expect(region).toHaveAttribute("aria-label", "Loading recipient portal");
     expect(region).toHaveAttribute("aria-busy", "true");
+  });
+
+  it("uses the shared recipient loading selector", () => {
+    render(<RecipientLoading />);
+    expect(screen.getByTestId(LOADING_TEST_IDS.recipient)).toHaveAttribute("role", "status");
   });
 
   it("renders sr-only announcement text", () => {


### PR DESCRIPTION
## Summary
Define one shared `LOADING_TEST_IDS` map and apply it to the Streams, Treasury overview, and Recipient loading roots. The names are documented, existing `role="status"` semantics remain intact, and focused tests assert the new selectors.

## Validation
The focused Vitest command was not run locally because dependencies are not installed in the checkout (`vitest: command not found`).

Closes #1298