### PR TITLE
fix(status-pill): add interactive focus state

### DIFF
--- a/src/components/treasuryOverviewPage/StatusPill.test.tsx
+++ b/src/components/treasuryOverviewPage/StatusPill.test.tsx
@@ -7,8 +7,8 @@
  * names (e.g., "var(--color-success)") rather than resolved RGB values.
  */
 
-import { render, screen } from "@testing-library/react";
-import { describe, it, expect } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
 import StatusPill from "./StatusPill";
 
 describe("StatusPill", () => {
@@ -42,5 +42,17 @@ describe("StatusPill", () => {
     const style = window.getComputedStyle(pill);
     expect(style.color).toBe("var(--status-info)");
     expect(style.backgroundColor).toBe("var(--status-info-bg)");
+  });
+
+  it("supports keyboard activation when used as a filter chip", () => {
+    const onClick = vi.fn();
+    render(<StatusPill status="Active" onClick={onClick} />);
+    const chip = screen.getByRole("button", { name: "Active status" });
+
+    fireEvent.keyDown(chip, { key: "Enter" });
+    fireEvent.keyDown(chip, { key: " " });
+
+    expect(onClick).toHaveBeenCalledTimes(2);
+    expect(chip.className).toContain("focus-visible:outline-cyan-500");
   });
 });

--- a/src/components/treasuryOverviewPage/StatusPill.tsx
+++ b/src/components/treasuryOverviewPage/StatusPill.tsx
@@ -48,6 +48,8 @@ interface Props {
   status: StatusPillStatus;
   /** Icon size */
   iconSize?: "xs" | "sm" | "md" | "lg";
+  /** Makes the pill act as a keyboard-accessible filter chip. */
+  onClick?: () => void;
 }
 
 const statusStyles: Record<
@@ -105,8 +107,9 @@ const statusStyles: Record<
   },
 };
 
-export default function StatusPill({ status, iconSize = "xs" }: Props) {
+export default function StatusPill({ status, iconSize = "xs", onClick }: Props) {
   const { background, color, Icon, label, tokenName } = statusStyles[status];
+  const interactive = Boolean(onClick);
   const [animateClass, setAnimateClass] = useState("");
   const prevStatusRef = useRef(status);
 
@@ -125,11 +128,18 @@ export default function StatusPill({ status, iconSize = "xs" }: Props) {
   return (
     <>
       <span
-        role="status"
+        role={interactive ? "button" : "status"}
         aria-label={`${label} status`}
         tabIndex={0}
+        onClick={onClick}
+        onKeyDown={(event) => {
+          if (interactive && (event.key === "Enter" || event.key === " ")) {
+            event.preventDefault();
+            onClick?.();
+          }
+        }}
         style={{ backgroundColor: background, color }}
-        className={`inline-flex items-center rounded-md px-3 py-1 text-sm font-medium icon-${iconSize} status-pill-transition ${animateClass}`}
+        className={`inline-flex items-center rounded-md px-3 py-1 text-sm font-medium icon-${iconSize} status-pill-transition ${animateClass} ${interactive ? "cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-500" : ""}`}
         /*
          * data-status-token: used by design-review tooling and
          * contrastUtils.ts contrast checks to resolve the active token.


### PR DESCRIPTION
## Summary
- Support keyboard activation for StatusPill filter-chip usage.
- Use button semantics and a visible cyan focus ring when interactive.
- Preserve the existing non-interactive status role and visual behavior.

## Test plan
- [x] npm test -- --run src/components/treasuryOverviewPage/StatusPill.test.tsx (5 tests)

Closes #1303