### PR TITLE
fix(recipient-streams): label pinned state

### DIFF
--- a/src/components/__tests__/RecipientStreams.test.tsx
+++ b/src/components/__tests__/RecipientStreams.test.tsx
@@ -49,6 +49,20 @@ describe("RecipientStreams Testing Engine", () => {
     expect(callCount).toBe(1);
   });
 
+  it("labels pinned state with text alongside the star icon", async () => {
+    const fetchMock = vi.fn().mockResolvedValue([
+      { id: "1", sender: "Alice", amount: "10", status: "active", isPinned: true },
+    ]);
+
+    render(<RecipientStreams fetchStreamsFn={fetchMock} pollIntervalMs={0} />);
+
+    expect(await screen.findByText("Pinned")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Unpin stream" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+  });
+
   describe("theme-aware styling via design tokens", () => {
     beforeEach(() => {
       document.documentElement.removeAttribute("data-theme");

--- a/src/components/recipient/RecipientStreams.tsx
+++ b/src/components/recipient/RecipientStreams.tsx
@@ -471,9 +471,13 @@ export const RecipientStreams: React.FC<RecipientStreamsProps> = ({
                   onClick={() => togglePin(stream.id)}
                   className="hover:text-yellow-500 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-md"
                   style={{ color: "var(--color-text-tertiary)" }}
-                  aria-label="Pin stream"
+                  aria-label={stream.isPinned ? "Unpin stream" : "Pin stream"}
+                  aria-pressed={stream.isPinned}
                 >
-                  {stream.isPinned ? "★" : "☆"}
+                  <span aria-hidden="true">{stream.isPinned ? "★" : "☆"}</span>
+                  <span className="ml-1 text-xs font-medium">
+                    {stream.isPinned ? "Pinned" : "Unpinned"}
+                  </span>
                 </button>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- Add visible Pinned/Unpinned text alongside the star icon.
- Update the accessible label and expose `aria-pressed` for the toggle.
- Add a focused regression test for the pinned state.

## Test plan
- [x] npm test -- --run src/components/__tests__/RecipientStreams.test.tsx (6 tests)

Closes #1305