### PR TITLE
Stop loading skeletons after retry cutoff

### DIFF
--- a/src/components/LOADING_STATES.md
+++ b/src/components/LOADING_STATES.md
@@ -1,0 +1,8 @@
+# Loading retry cutoff
+
+The loading surfaces share `MAX_LOADING_RETRIES` (three attempts) and
+`LoadingRetryState` from `Skeleton.tsx`. Data hooks expose `retryCount`; after
+the cutoff, the page renders an assertive error state with a manual **Try
+again** action. A manual retry starts a new request and keeps the same shared
+counter, so a persistently unavailable service cannot leave a skeleton on
+screen indefinitely.

--- a/src/components/RecipientLoading.tsx
+++ b/src/components/RecipientLoading.tsx
@@ -1,8 +1,22 @@
-import { Skeleton, SkeletonCard } from "./Skeleton";
+import {
+  LoadingRetryState,
+  MAX_LOADING_RETRIES,
+  Skeleton,
+  SkeletonCard,
+} from "./Skeleton";
 import "./skeleton.css";
 
+interface RecipientLoadingProps {
+  retryCount?: number;
+  onRetry?: () => void;
+}
+
 /** Skeleton for the Recipient portal balance card + stats row. */
-export default function RecipientLoading() {
+export default function RecipientLoading({ retryCount = 0, onRetry }: RecipientLoadingProps) {
+  if (retryCount >= MAX_LOADING_RETRIES) {
+    return <LoadingRetryState label="your streams" onRetry={onRetry} />;
+  }
+
   return (
     <div role="status" aria-label="Loading recipient portal" aria-busy="true">
       <span className="sr-only">Loading your streams…</span>

--- a/src/components/Skeleton.tsx
+++ b/src/components/Skeleton.tsx
@@ -1,6 +1,24 @@
 import React from "react";
 import "./skeleton.css";
 
+export const MAX_LOADING_RETRIES = 3;
+
+export function LoadingRetryState({
+  label,
+  onRetry,
+}: {
+  label: string;
+  onRetry?: () => void;
+}) {
+  return (
+    <div role="alert" aria-live="assertive" className="loading-retry-state">
+      <strong>We couldn&apos;t load {label}.</strong>
+      <span>Automatic retries have stopped.</span>
+      {onRetry && <button type="button" onClick={onRetry}>Try again</button>}
+    </div>
+  );
+}
+
 interface SkeletonProps extends React.HTMLAttributes<HTMLDivElement> {
   width?: string | number;
   height?: string | number;

--- a/src/components/StreamsLoading.tsx
+++ b/src/components/StreamsLoading.tsx
@@ -1,8 +1,22 @@
-import { Skeleton, SkeletonCard } from "./Skeleton";
+import {
+  LoadingRetryState,
+  MAX_LOADING_RETRIES,
+  Skeleton,
+  SkeletonCard,
+} from "./Skeleton";
 import "./skeleton.css";
 
+interface StreamsLoadingProps {
+  retryCount?: number;
+  onRetry?: () => void;
+}
+
 /** Skeleton for the Streams page table surface. */
-export default function StreamsLoading() {
+export default function StreamsLoading({ retryCount = 0, onRetry }: StreamsLoadingProps) {
+  if (retryCount >= MAX_LOADING_RETRIES) {
+    return <LoadingRetryState label="streams" onRetry={onRetry} />;
+  }
+
   return (
     <div role="status" aria-label="Loading streams" aria-busy="true">
       <span className="sr-only">Loading streams…</span>

--- a/src/components/TreasuryOverviewLoading.tsx
+++ b/src/components/TreasuryOverviewLoading.tsx
@@ -1,8 +1,25 @@
-import { Skeleton, SkeletonCard } from "./Skeleton";
+import {
+  LoadingRetryState,
+  MAX_LOADING_RETRIES,
+  Skeleton,
+  SkeletonCard,
+} from "./Skeleton";
 import "./skeleton.css";
 
+interface TreasuryOverviewLoadingProps {
+  retryCount?: number;
+  onRetry?: () => void;
+}
+
 /** Skeleton for the full Dashboard / Treasury overview surface. */
-export default function TreasuryOverviewLoading() {
+export default function TreasuryOverviewLoading({
+  retryCount = 0,
+  onRetry,
+}: TreasuryOverviewLoadingProps) {
+  if (retryCount >= MAX_LOADING_RETRIES) {
+    return <LoadingRetryState label="the treasury overview" onRetry={onRetry} />;
+  }
+
   return (
     <div role="status" aria-label="Loading treasury overview" aria-busy="true">
       <span className="sr-only">Loading treasury overview…</span>

--- a/src/components/__tests__/LoadingSkeletons.test.tsx
+++ b/src/components/__tests__/LoadingSkeletons.test.tsx
@@ -1,10 +1,18 @@
 import { render, screen } from "@testing-library/react";
-import { describe, it, expect } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
 import StreamsLoading from "../StreamsLoading";
 import TreasuryOverviewLoading from "../TreasuryOverviewLoading";
 import RecipientLoading from "../RecipientLoading";
 
 describe("StreamsLoading", () => {
+  it("escalates after the shared retry cutoff and offers manual retry", async () => {
+    const onRetry = vi.fn();
+    render(<StreamsLoading retryCount={3} onRetry={onRetry} />);
+    expect(screen.getByRole("alert")).toHaveTextContent("Automatic retries have stopped");
+    await userEvent.click(screen.getByRole("button", { name: "Try again" }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
   it("has role=status with correct aria-label and aria-busy", () => {
     render(<StreamsLoading />);
     const region = screen.getByRole("status");

--- a/src/components/skeleton.css
+++ b/src/components/skeleton.css
@@ -182,3 +182,23 @@
     background-position: 50% 0;
   }
 }
+.loading-retry-state {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.5rem;
+  padding: 1.25rem;
+  color: var(--text);
+  background: var(--color-surface-default);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-lg);
+}
+
+.loading-retry-state button {
+  padding: 0.5rem 0.875rem;
+  color: var(--color-on-accent, #fff);
+  background: var(--color-accent-primary);
+  border: 0;
+  border-radius: 0.5rem;
+  cursor: pointer;
+}

--- a/src/components/treasuryOverviewPage/useTreasury.ts
+++ b/src/components/treasuryOverviewPage/useTreasury.ts
@@ -21,6 +21,7 @@ export interface TreasuryData {
   loading: boolean;
   error: string | null;
   refetch: () => void;
+  retryCount: number;
 }
 
 const GENERIC_ERROR = "Unable to load treasury data.";
@@ -48,6 +49,7 @@ export function useTreasury(filters?: StreamsFilters): TreasuryData {
   const [streams, setStreams] = useState<StreamRecord[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [retryCount, setRetryCount] = useState(0);
   const [reloadToken, setReloadToken] = useState(0);
   const filtersKey = serializeFilters(filters);
   const inFlightRef = useRef<number>(0);
@@ -60,6 +62,7 @@ export function useTreasury(filters?: StreamsFilters): TreasuryData {
     let cancelled = false;
     setLoading(true);
     setError(null);
+    setRetryCount((count) => count + 1);
 
     Promise.all([getTreasuryMetrics(), getStreams(filtersRef.current)])
       .then(([nextMetrics, nextStreams]) => {
@@ -99,6 +102,7 @@ export function useTreasury(filters?: StreamsFilters): TreasuryData {
         setMetrics(updatedMetrics);
         setStreams(nextStreams);
         setError(null);
+        setRetryCount(0);
         setLoading(false);
       })
       .catch((cause) => {
@@ -118,7 +122,7 @@ export function useTreasury(filters?: StreamsFilters): TreasuryData {
     setReloadToken((token) => token + 1);
   }, []);
 
-  return { metrics, streams, loading, error, refetch };
+  return { metrics, streams, loading, error, refetch, retryCount };
 }
 
 /**
@@ -137,6 +141,7 @@ export function useRecipientStreams(address: string | null | undefined): {
   const [streams, setStreams] = useState<StreamRecord[]>([]);
   const [loading, setLoading] = useState<boolean>(Boolean(address));
   const [error, setError] = useState<string | null>(null);
+  const [retryCount, setRetryCount] = useState(0);
   const [reloadToken, setReloadToken] = useState(0);
   const inFlightRef = useRef<number>(0);
 
@@ -152,12 +157,14 @@ export function useRecipientStreams(address: string | null | undefined): {
     let cancelled = false;
     setLoading(true);
     setError(null);
+    setRetryCount((count) => count + 1);
 
     getRecipientStreams(address)
       .then((next) => {
         if (cancelled || runId !== inFlightRef.current) return;
         setStreams(next);
         setError(null);
+        setRetryCount(0);
         setLoading(false);
       })
       .catch((cause) => {
@@ -176,7 +183,7 @@ export function useRecipientStreams(address: string | null | undefined): {
     setReloadToken((token) => token + 1);
   }, []);
 
-  return { streams, loading, error, refetch };
+  return { streams, loading, error, refetch, retryCount };
 }
 
 function serializeFilters(filters?: StreamsFilters): string {

--- a/src/pages/Recipient.tsx
+++ b/src/pages/Recipient.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useRef, useCallback, useMemo } from "react";
 import RecipientEmptyState from "../components/RecipientEmptyState";
 import { RecipientStreams, type Stream } from "../components/recipient/RecipientStreams";
 import RecipientLoading from "../components/RecipientLoading";
+import { MAX_LOADING_RETRIES } from "../components/Skeleton";
 import ZeroAccrualBanner from "../components/ZeroAccrualBanner";
 import { useWallet } from "../components/wallet-connect/Walletcontext";
 import { useToast } from "../components/toast/ToastProvider";
@@ -650,7 +651,14 @@ export default function Recipient() {
     }
   };
 
-  if (pageLoading) return <RecipientLoading />;
+  if (pageLoading || (recipientStreams.error && recipientStreams.retryCount >= MAX_LOADING_RETRIES)) {
+    return (
+      <RecipientLoading
+        retryCount={recipientStreams.retryCount}
+        onRetry={handlePageRefetch}
+      />
+    );
+  }
 
   // Show empty-state path when:
   //   - wallet is disconnected, OR

--- a/src/pages/Streams.tsx
+++ b/src/pages/Streams.tsx
@@ -19,6 +19,7 @@ import EmptyState from "../components/EmptyState";
 import StreamCreatedModal from "../components/Streams/StreamCreatedModal";
 import { useToast } from "../components/toast/ToastProvider";
 import StreamsLoading from "../components/StreamsLoading";
+import { MAX_LOADING_RETRIES } from "../components/Skeleton";
 import Input from "../components/Input";
 import ZeroAccrualBanner from "../components/ZeroAccrualBanner";
 import SessionRecoveryBanner, {
@@ -801,7 +802,7 @@ export default function Streams() {
   const { t } = useI18n();
   const hasMountedFilterAnnouncer = useRef(false);
 
-  const { streams, loading, error, refetch } = useTreasury();
+  const { streams, loading, error, refetch, retryCount } = useTreasury();
   const filterLabels: Record<StatusFilter, string> = {
     All: t("streams.filter.all"),
     Active: t("streams.filter.active"),
@@ -1148,7 +1149,9 @@ export default function Streams() {
     [announce],
   );
 
-  if (loading) return <StreamsLoading />;
+  if (loading || (error && retryCount >= MAX_LOADING_RETRIES)) {
+    return <StreamsLoading retryCount={retryCount} onRetry={refetch} />;
+  }
 
   if (error) {
     return (


### PR DESCRIPTION
## Summary
Introduce one shared three-attempt cutoff and accessible `LoadingRetryState`. Treasury and recipient data hooks expose their retry count, and the Streams/Recipient pages switch from indefinite skeletons to an assertive error state with a manual `Try again` action after repeated failures. Existing loading roles and labels remain on the skeleton path.

## Validation
The focused Vitest command was not run locally because dependencies are not installed in the checkout (`vitest: command not found`).

Closes #1297