### PR TITLE
feat(treasury): announce metrics refresh

### DIFF
--- a/src/components/treasuryOverviewPage/Header.test.tsx
+++ b/src/components/treasuryOverviewPage/Header.test.tsx
@@ -1,0 +1,23 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import Header from "./Header";
+
+const navigate = vi.fn();
+vi.mock("react-router-dom", () => ({
+  useNavigate: () => navigate,
+}));
+
+describe("Treasury Header refresh control", () => {
+  it("announces completion after a manual metrics refresh", () => {
+    const onRefresh = vi.fn();
+    render(<Header onRefresh={onRefresh} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Refresh metrics" }));
+
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("Treasury metrics refresh completed.")).toHaveAttribute(
+      "aria-live",
+      "polite",
+    );
+  });
+});

--- a/src/components/treasuryOverviewPage/Header.tsx
+++ b/src/components/treasuryOverviewPage/Header.tsx
@@ -1,11 +1,19 @@
+import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 export interface HeaderProps {
   onExportClick?: () => void;
+  onRefresh?: () => void;
 }
 
-export default function Header({ onExportClick }: HeaderProps) {
+export default function Header({ onExportClick, onRefresh }: HeaderProps) {
   const navigate = useNavigate();
+  const [announcement, setAnnouncement] = useState("");
+
+  const handleRefresh = () => {
+    onRefresh?.();
+    setAnnouncement("Treasury metrics refresh completed.");
+  };
 
   return (
     <div className="flex items-center justify-between">
@@ -19,6 +27,16 @@ export default function Header({ onExportClick }: HeaderProps) {
       </div>
 
       <div className="flex gap-4">
+        {onRefresh && (
+          <button
+            type="button"
+            onClick={handleRefresh}
+            className="px-4 py-2 text-[var(--color-text-primary)] bg-white rounded-lg border"
+            style={{ borderColor: "var(--color-border-default)" }}
+          >
+            Refresh metrics
+          </button>
+        )}
         {onExportClick && (
           <button
             onClick={onExportClick}
@@ -42,6 +60,9 @@ export default function Header({ onExportClick }: HeaderProps) {
           Create stream
         </button>
       </div>
+      <span className="sr-only" aria-live="polite">
+        {announcement}
+      </span>
     </div>
   );
 }

--- a/src/pages/TreasuryPage.tsx
+++ b/src/pages/TreasuryPage.tsx
@@ -90,7 +90,10 @@ export default function TreasuryPage() {
             intended for design review and QA sessions only. */}
         {IS_DEV && <ColorBlindToggle />}
 
-        <Header onExportClick={() => setShowReportBuilder(true)} />
+        <Header
+          onExportClick={() => setShowReportBuilder(true)}
+          onRefresh={refetch}
+        />
         {showReportBuilder && (
           <ReportBuilderPanel
             streams={streams || []}


### PR DESCRIPTION
## Summary
- Add a manual Refresh metrics control to the treasury overview header.
- Announce refresh completion through an `aria-live="polite"` region.
- Wire the control to the page’s existing treasury refetch callback.

## Test plan
- [x] npm test -- --run src/components/treasuryOverviewPage/Header.test.tsx

Closes #1304