### PR TITLE
feat: shake Input on invalid transition

### DIFF
--- a/src/components/Input.module.css
+++ b/src/components/Input.module.css
@@ -101,6 +101,17 @@
   border-color: var(--color-danger);
 }
 
+@keyframes input-error-shake {
+  0%, 100% { transform: translateX(0); }
+  25% { transform: translateX(-4px); }
+  50% { transform: translateX(4px); }
+  75% { transform: translateX(-3px); }
+}
+
+.errorShake {
+  animation: input-error-shake 250ms ease-in-out;
+}
+
 /* IME composition is pending text, not an invalid value. */
 .input.composing,
 .input[data-composing="true"] {
@@ -198,5 +209,9 @@
   .textarea,
   .select {
     transition: none;
+  }
+
+  .errorShake {
+    animation: none;
   }
 }

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -20,6 +20,8 @@
 
 import {
   useId,
+  useEffect,
+  useRef,
   type InputHTMLAttributes,
   type SelectHTMLAttributes,
   type TextareaHTMLAttributes,
@@ -94,6 +96,8 @@ export default function Input({
 }: InputProps) {
   const generatedId = useId();
   const [isComposing, setIsComposing] = useState(false);
+  const wasInvalid = useRef(false);
+  const [shakeError, setShakeError] = useState(false);
 
   // Generate ID if not provided
   const inputId = id ?? generatedId;
@@ -101,6 +105,11 @@ export default function Input({
   // Determine if input has error
   const hasError = Boolean(error) && !(compositionAware && isComposing);
   const composingClass = compositionAware && isComposing ? styles.composing : "";
+
+  useEffect(() => {
+    setShakeError(hasError && !wasInvalid.current);
+    wasInvalid.current = hasError;
+  }, [hasError]);
 
   const handleCompositionStart: CompositionEventHandler<HTMLInputElement> = (event) => {
     onCompositionStart?.(event);
@@ -147,7 +156,7 @@ export default function Input({
           id={inputId}
           className={`${styles.input} ${styles.textarea} ${
             hasError ? styles.error : ""
-          } ${composingClass} ${className}`.trim()}
+          } ${shakeError ? styles.errorShake : ""} ${composingClass} ${className}`.trim()}
           aria-invalid={hasError ? "true" : "false"}
           aria-errormessage={hasError ? `${inputId}-error` : undefined}
           aria-describedby={describedBy}
@@ -165,7 +174,7 @@ export default function Input({
           id={inputId}
           className={`${styles.input} ${styles.select} ${
             hasError ? styles.error : ""
-          } ${composingClass} ${className}`.trim()}
+          } ${shakeError ? styles.errorShake : ""} ${composingClass} ${className}`.trim()}
           aria-invalid={hasError ? "true" : "false"}
           aria-errormessage={hasError ? `${inputId}-error` : undefined}
           aria-describedby={describedBy}
@@ -188,7 +197,7 @@ export default function Input({
           type={type}
           className={`${styles.input} ${
             hasError ? styles.error : ""
-          } ${composingClass} ${className}`.trim()}
+          } ${shakeError ? styles.errorShake : ""} ${composingClass} ${className}`.trim()}
           aria-invalid={hasError ? "true" : "false"}
           aria-errormessage={hasError ? `${inputId}-error` : undefined}
           aria-describedby={describedBy}

--- a/src/components/__tests__/Input.test.tsx
+++ b/src/components/__tests__/Input.test.tsx
@@ -187,3 +187,19 @@ describe('Input Validation ARIA attributes', () => {
     expect(input.getAttribute("aria-describedby")).toBe(hintDescribedBy);
   });
 });
+
+describe('Input invalid transition animation', () => {
+  it('adds the shake class on each valid-to-invalid transition', () => {
+    const { rerender, container } = render(<Input id="shake-input" label="Name" />);
+    const input = container.querySelector('input')!;
+
+    rerender(<Input id="shake-input" label="Name" error="Required" />);
+    expect(input.className).toContain('errorShake');
+    rerender(<Input id="shake-input" label="Name" error="Still required" />);
+    expect(input.className).toContain('errorShake');
+
+    rerender(<Input id="shake-input" label="Name" />);
+    rerender(<Input id="shake-input" label="Name" error="Required again" />);
+    expect(input.className).toContain('errorShake');
+  });
+});


### PR DESCRIPTION
Closes #1292

Add a single 250ms invalid-transition shake using transform, with prefers-reduced-motion support and regression coverage.

Validation: git diff --check passed.