### PR TITLE
feat: debounce InputField validation

### DIFF
--- a/src/components/InputField.tsx
+++ b/src/components/InputField.tsx
@@ -8,6 +8,9 @@ export interface InputFieldProps {
   error?: string;
   helperText?: string;
   success?: boolean;
+  /** Optional value validator used for inline validation while typing. */
+  validate?: (value: string) => string | undefined;
+  validationDebounceMs?: number;
   /** Defers error styling and live announcements until compositionend. */
   compositionAware?: boolean;
   children: React.ReactNode;
@@ -20,12 +23,17 @@ export const InputField: React.FC<InputFieldProps> = ({
   error,
   helperText,
   success,
+  validate,
+  validationDebounceMs = 300,
   compositionAware = true,
   children,
 }) => {
   const [isComposing, setIsComposing] = React.useState(false);
+  const [validatedError, setValidatedError] = React.useState(error);
+  const validationTimer = React.useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const activeError = validate ? validatedError : error;
   // Determine which message (if any) is active
-  const hasError = Boolean(error) && !(compositionAware && isComposing);
+  const hasError = Boolean(activeError) && !(compositionAware && isComposing);
   const hasHint = Boolean(helperText) && !hasError;
   const hasSuccess = success === true && !hasError;
 
@@ -46,8 +54,27 @@ export const InputField: React.FC<InputFieldProps> = ({
   // Clone the child element to inject ARIA props onto the underlying <input>
   const child = React.Children.only(children) as React.ReactElement;
   const childProps = child.props as {
+    onChange?: (event: React.ChangeEvent<HTMLElement>) => void;
+    onBlur?: (event: React.FocusEvent<HTMLElement>) => void;
     onCompositionStart?: (event: React.CompositionEvent<HTMLElement>) => void;
     onCompositionEnd?: (event: React.CompositionEvent<HTMLElement>) => void;
+  };
+  React.useEffect(() => {
+    if (!validate) setValidatedError(error);
+    return () => {
+      if (validationTimer.current) clearTimeout(validationTimer.current);
+    };
+  }, [error, validate]);
+
+  const handleValidation = (value: string, immediate = false) => {
+    if (!validate) return;
+    if (validationTimer.current) clearTimeout(validationTimer.current);
+    const nextError = validate(value);
+    if (!nextError || immediate) {
+      setValidatedError(nextError);
+      return;
+    }
+    validationTimer.current = setTimeout(() => setValidatedError(nextError), validationDebounceMs);
   };
   const clonedChild = React.cloneElement(child, {
     id,
@@ -55,6 +82,14 @@ export const InputField: React.FC<InputFieldProps> = ({
     ...(required ? { 'aria-required': 'true' } : {}),
     ...(messageId ? { 'aria-describedby': messageId } : {}),
     'data-composing': compositionAware && isComposing ? 'true' : undefined,
+    onChange: (event: React.ChangeEvent<HTMLElement>) => {
+      childProps.onChange?.(event);
+      handleValidation((event.currentTarget as HTMLInputElement).value);
+    },
+    onBlur: (event: React.FocusEvent<HTMLElement>) => {
+      childProps.onBlur?.(event);
+      handleValidation((event.currentTarget as HTMLInputElement).value, true);
+    },
     onCompositionStart: (event: React.CompositionEvent<HTMLElement>) => {
       childProps.onCompositionStart?.(event);
       if (compositionAware) setIsComposing(true);
@@ -79,7 +114,7 @@ export const InputField: React.FC<InputFieldProps> = ({
       </div>
 
       {hasError && (
-        <ValidationMessage id={`${id}-error`} message={error!} type="error" />
+        <ValidationMessage id={`${id}-error`} message={activeError!} type="error" />
       )}
       {hasHint && (
         <ValidationMessage id={`${id}-hint`} message={helperText!} type="hint" />

--- a/src/components/__tests__/InputField.test.tsx
+++ b/src/components/__tests__/InputField.test.tsx
@@ -9,8 +9,8 @@
 // Feature: create-stream-modal-validation, Property 13: label htmlFor matches input id
 // Feature: create-stream-modal-validation, Property 14: required=true sets aria-required="true"
 
-import { describe, it, expect } from 'vitest';
-import { render } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
 import * as fc from 'fast-check';
 import { InputField } from '../InputField';
 
@@ -244,5 +244,27 @@ describe('Property 14: required=true sets aria-required="true"', () => {
       }),
       { numRuns: 100 }
     );
+  });
+});
+
+describe('InputField debounced validation', () => {
+  it('delays invalid feedback while typing and clears it immediately', () => {
+    vi.useFakeTimers();
+    const validate = (value: string) => value.length < 3 ? 'Enter at least 3 characters' : undefined;
+    render(
+      <InputField id="username" label="Username" validate={validate}>
+        <input type="text" />
+      </InputField>,
+    );
+    const input = screen.getByLabelText('Username');
+
+    fireEvent.change(input, { target: { value: 'a' } });
+    expect(screen.queryByText('Enter at least 3 characters')).not.toBeInTheDocument();
+    vi.advanceTimersByTime(300);
+    expect(screen.getByText('Enter at least 3 characters')).toBeInTheDocument();
+
+    fireEvent.change(input, { target: { value: 'abc' } });
+    expect(screen.queryByText('Enter at least 3 characters')).not.toBeInTheDocument();
+    vi.useRealTimers();
   });
 });


### PR DESCRIPTION
Closes #1293

Add an optional debounced inline validator to InputField. Invalid feedback waits 300ms while typing, valid clearing is immediate, blur validates synchronously, and timers are cleaned up.

Validation: git diff --check passed.