### PR TITLE
feat: separate EmptyState retry action

### DIFF
--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -240,7 +240,7 @@ export default function EmptyState({
     effectiveVariant === "search-no-results"
       ? onClearFilters ?? onPrimaryAction
       : effectiveVariant === "error"
-      ? onRetry ?? onPrimaryAction
+      ? onPrimaryAction ?? onRetry
       : onPrimaryAction;
 
   return (

--- a/src/components/__tests__/EmptyState.test.tsx
+++ b/src/components/__tests__/EmptyState.test.tsx
@@ -121,6 +121,24 @@ describe("EmptyState — error state", () => {
 // ── CTA button ────────────────────────────────────────────────────────────────
 
 describe("EmptyState — CTA button", () => {
+  it("keeps retry and primary actions distinct when both are supplied", () => {
+    const onRetry = vi.fn();
+    const onPrimaryAction = vi.fn();
+    render(
+      <EmptyState
+        variant="error"
+        error="Network error"
+        onRetry={onRetry}
+        onPrimaryAction={onPrimaryAction}
+      />,
+    );
+
+    screen.getByRole("button", { name: "Retry loading data" }).click();
+    screen.getByRole("button", { name: "Try again" }).click();
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(onPrimaryAction).toHaveBeenCalledTimes(1);
+  });
+
   it("renders CTA with correct aria-label when disconnected", () => {
     render(<EmptyState variant="treasury" walletConnected={false} />);
     expect(screen.getByRole("button", { name: "Connect wallet" })).toBeInTheDocument();


### PR DESCRIPTION
Closes #1296

Keep onRetry distinct from the primary CTA when both are supplied, while preserving the existing retry fallback behavior.

Validation: git diff --check passed.