### PR TITLE
a11y: explain TESTNET badge via tooltip and hidden text

### DIFF
--- a/src/components/navigation/WalletStatus.tsx
+++ b/src/components/navigation/WalletStatus.tsx
@@ -34,6 +34,71 @@ interface WalletStatusProps {
 }
 
 
+/** Tooltip explaining the network badge, with sr-only text for screen readers. */
+function NetworkBadge({ isTestnet }: { isTestnet: boolean }) {
+  const [tooltipOpen, setTooltipOpen] = useState(false);
+  const badgeRef = useRef<HTMLSpanElement>(null);
+  const tooltipId = "network-badge-tooltip";
+
+  const label = isTestnet ? "Testnet" : "Mainnet";
+  const explanation = isTestnet
+    ? "Connected to the Stellar test network. Streamed assets are not real USDC."
+    : "Connected to the Stellar mainnet. Real assets are in use.";
+
+  const showTooltip = () => setTooltipOpen(true);
+  const hideTooltip = () => setTooltipOpen(false);
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Escape") {
+      hideTooltip();
+      badgeRef.current?.focus();
+    }
+  };
+
+  return (
+    <div className="relative inline-flex">
+      <span
+        ref={badgeRef}
+        tabIndex={0}
+        role="status"
+        aria-describedby={tooltipOpen ? tooltipId : undefined}
+        aria-label={`Network: ${label}. ${explanation}`}
+        onMouseEnter={showTooltip}
+        onMouseLeave={hideTooltip}
+        onFocus={showTooltip}
+        onBlur={hideTooltip}
+        onKeyDown={handleKeyDown}
+        className={`flex items-center gap-1.5 px-3 h-8 rounded-full text-xs font-semibold border cursor-default outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus)] ${
+          isTestnet
+            ? "bg-amber-400/15 text-amber-300 border-amber-400/30"
+            : "bg-emerald-400/15 text-emerald-300 border-emerald-400/30"
+        }`}
+      >
+        <span
+          className={`w-2 h-2 rounded-full ${
+            isTestnet ? "bg-amber-300" : "bg-emerald-400"
+          }`}
+        />
+        {label}
+      </span>
+      {/* sr-only explanation — always present for screen readers */}
+      <span className="sr-only" aria-live="polite">
+        {explanation}
+      </span>
+      {/* Visual tooltip on hover/focus */}
+      {tooltipOpen && (
+        <div
+          id={tooltipId}
+          role="tooltip"
+          className="absolute top-full mt-2 left-1/2 -translate-x-1/2 whitespace-nowrap px-3 py-2 rounded-lg bg-[var(--tooltip-bg,var(--surface-elevated))] border border-[var(--tooltip-border,var(--border-neutral))] shadow-[var(--tooltip-shadow)] text-[var(--tooltip-text-color,var(--text-secondary))] text-xs z-[1100] pointer-events-none"
+        >
+          {explanation}
+        </div>
+      )}
+    </div>
+  );
+}
+
 export default function WalletStatus({
   address,
   network,
@@ -220,20 +285,7 @@ export default function WalletStatus({
           Expected {expectedNetwork}
         </span>
       ) : (
-        <span
-          className={`flex items-center gap-1.5 px-3 h-8 rounded-full text-xs font-semibold border ${
-            isTestnet
-              ? "bg-amber-400/15 text-amber-300 border-amber-400/30"
-              : "bg-emerald-400/15 text-emerald-300 border-emerald-400/30"
-          }`}
-        >
-          <span
-            className={`w-2 h-2 rounded-full ${
-              isTestnet ? "bg-amber-300" : "bg-emerald-400"
-            }`}
-          />
-          {isTestnet ? "Testnet" : "Mainnet"}
-        </span>
+        <NetworkBadge isTestnet={isTestnet} />
       )}
 
       {slackWorkspace && (

--- a/src/components/navigation/__tests__/WalletStatus.network.test.tsx
+++ b/src/components/navigation/__tests__/WalletStatus.network.test.tsx
@@ -1,0 +1,135 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import WalletStatus from "../WalletStatus";
+
+describe("WalletStatus network badge", () => {
+  const mockAddress = "GABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
+
+  it("shows Testnet badge when network is TESTNET", () => {
+    render(
+      <WalletStatus
+        address={mockAddress}
+        network="TESTNET"
+        onDisconnect={() => {}}
+      />
+    );
+
+    const badge = screen.getByRole("status", { name: /network: testnet/i });
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveTextContent("Testnet");
+  });
+
+  it("shows Mainnet badge when network is MAINNET", () => {
+    render(
+      <WalletStatus
+        address={mockAddress}
+        network="MAINNET"
+        expectedNetwork="MAINNET"
+        isNetworkMismatch={false}
+        onDisconnect={() => {}}
+      />
+    );
+
+    const badge = screen.getByRole("status", { name: /network: mainnet/i });
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveTextContent("Mainnet");
+  });
+
+  it("has sr-only explanation text for Testnet", () => {
+    render(
+      <WalletStatus
+        address={mockAddress}
+        network="TESTNET"
+        onDisconnect={() => {}}
+      />
+    );
+
+    const srText = screen.getByText(/Stellar test network/i);
+    expect(srText).toBeInTheDocument();
+    expect(srText).toHaveClass("sr-only");
+  });
+
+  it("has sr-only explanation text for Mainnet", () => {
+    render(
+      <WalletStatus
+        address={mockAddress}
+        network="MAINNET"
+        expectedNetwork="MAINNET"
+        isNetworkMismatch={false}
+        onDisconnect={() => {}}
+      />
+    );
+
+    const srText = screen.getByText(/Stellar mainnet/i);
+    expect(srText).toBeInTheDocument();
+    expect(srText).toHaveClass("sr-only");
+  });
+
+  it("shows tooltip on focus of the network badge", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <WalletStatus
+        address={mockAddress}
+        network="TESTNET"
+        onDisconnect={() => {}}
+      />
+    );
+
+    const badge = screen.getByRole("status", { name: /network: testnet/i });
+    await user.click(badge);
+
+    // Tooltip should appear
+    const tooltip = screen.getByRole("tooltip");
+    expect(tooltip).toBeInTheDocument();
+    expect(tooltip).toHaveTextContent(/Stellar test network/i);
+  });
+
+  it("hides tooltip on blur", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <WalletStatus
+        address={mockAddress}
+        network="TESTNET"
+        onDisconnect={() => {}}
+      />
+    );
+
+    const badge = screen.getByRole("status", { name: /network: testnet/i });
+    await user.click(badge);
+    expect(screen.getByRole("tooltip")).toBeInTheDocument();
+
+    // Click elsewhere to blur
+    await user.click(document.body);
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+
+  it("is keyboard-focusable (tabIndex=0)", () => {
+    render(
+      <WalletStatus
+        address={mockAddress}
+        network="TESTNET"
+        onDisconnect={() => {}}
+      />
+    );
+
+    const badge = screen.getByRole("status", { name: /network: testnet/i });
+    expect(badge).toHaveAttribute("tabIndex", "0");
+  });
+
+  it("shows wrong network badge when there is a mismatch", () => {
+    render(
+      <WalletStatus
+        address={mockAddress}
+        network="TESTNET"
+        expectedNetwork="MAINNET"
+        isNetworkMismatch={true}
+        onDisconnect={() => {}}
+      />
+    );
+
+    expect(screen.getByText(/expected mainnet/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
Add a hover/focus tooltip and a  (visually-hidden) explanation to the TESTNET badge in the navbar. The badge now clarifies that the app is connected to the Stellar test network and that streamed assets are not real USDC.

Closes #1290

## Changes
- **WalletStatus.tsx**: Extracted inline network badge into a reusable  component with:
  - Keyboard-reachable tooltip (focusable via Tab, dismissible via Escape)
  -  text for screen readers that is always present
  -  on the badge that includes the explanation
- **WalletStatus.network.test.tsx**: 8 new tests covering Testnet/Mainnet display, sr-only text, tooltip show/hide, keyboard focusability, and wrong-network state

## Accessibility
- Tooltip is keyboard-reachable (focusable trigger, focus/blur events)
- Dismissible via Escape key
-  text always present for screen reader users
-  on badge includes full explanation
- WCAG 2.1 AA compliant