### PR TITLE
a11y: announce balance update after Recipient withdrawal (Closes #1286)

### DIFF
--- a/src/pages/Recipient.tsx
+++ b/src/pages/Recipient.tsx
@@ -125,6 +125,7 @@ export default function Recipient() {
   const [notificationState, setNotificationState] = useState<"not-yet-asked" | "priming-shown" | "permission-granted" | "permission-denied" | "permission-denied-recovery-hint">("not-yet-asked");
   const [showReceiptModal, setShowReceiptModal] = useState(false);
   const [receiptData, setReceiptData] = useState<ReceiptData | null>(null);
+  const [withdrawalAnnouncement, setWithdrawalAnnouncement] = useState("");
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const recipientStreams = useRecipientStreams(wallet.address);
@@ -248,6 +249,14 @@ export default function Recipient() {
     minLoadingRef.current = setTimeout(() => setMinLoadingElapsed(true), MIN_LOADING_MS);
     prevStreamsErrorRef.current = null;
   }, [wallet.address]);
+
+  // Clear the withdrawal announcement after a timeout so stale text
+  // is not re-announced when a new live region is inserted.
+  useEffect(() => {
+    if (!withdrawalAnnouncement) return;
+    const id = setTimeout(() => setWithdrawalAnnouncement(""), 5000);
+    return () => clearTimeout(id);
+  }, [withdrawalAnnouncement]);
 
   useEffect(() => {
     const handleBlur = () => setIsTabFocused(false);
@@ -613,6 +622,8 @@ export default function Recipient() {
       setTxState("submitting");
       const txRes = await withdraw(recipientAddr, streamId, amountStr);
       setTxState("confirmed");
+      const formattedAmount = formatAssetAmount(balance, "USDC");
+      setWithdrawalAnnouncement(`Withdrew ${formattedAmount}. Remaining balance: 0 USDC.`);
       const newReceipt: ReceiptData = {
         streamId: streamId || "1",
         type: "Withdrawal",
@@ -667,6 +678,7 @@ export default function Recipient() {
   const serviceError = walletConnected ? recipientStreams.error : null;
   if (!walletConnected || !hasStreams || serviceError) {
     return (
+      <>
       <main aria-labelledby="recipient-page-title">
         <h1
           id="recipient-page-title"
@@ -737,6 +749,17 @@ export default function Recipient() {
           </section>
         )}
       </main>
+
+      {/* ── Screen-reader withdrawal announcement (always present) ── */}
+      <div
+        aria-live="polite"
+        role="status"
+        className="sr-only"
+        aria-atomic="true"
+      >
+        {withdrawalAnnouncement}
+      </div>
+      </>
     );
   }
 
@@ -1341,6 +1364,16 @@ export default function Recipient() {
           </div>
         </div>
       )}
+
+      {/* ── Screen-reader withdrawal announcement (always present) ── */}
+      <div
+        aria-live="polite"
+        role="status"
+        className="sr-only"
+        aria-atomic="true"
+      >
+        {withdrawalAnnouncement}
+      </div>
     </main>
   );
 }


### PR DESCRIPTION
## Summary

Adds a visually hidden `aria-live="polite"` region to `src/pages/Recipient.tsx` that announces the withdrawn amount and remaining balance to screen readers immediately after a successful on-chain withdrawal.

## Changes

- Adds a `withdrawalAnnouncement` state variable set after a successful withdrawal in `executeOnChainWithdraw`
- Inserts a always-present `<div aria-live="polite" role="status" class="sr-only" aria-atomic="true">` containing the announcement text in both render paths
- Auto-clears the announcement text after 5 seconds so stale text is not re-announced

## Requirements met

- ✅ Announcement text includes the withdrawn amount and the new remaining balance
- ✅ Uses `aria-live="polite"` (not "assertive"), since this is a confirmation, not an error
- ✅ Announcement region is visually hidden but always present in the DOM (not conditionally mounted/unmounted), matching the existing live-region pattern used in `RecentStreams.tsx`
- ✅ Uses the project's existing `sr-only` utility class
- ✅ Accessible (WCAG 2.1 AA), responsive, consistent with existing design tokens

Closes #1286