### PR TITLE
feat: add compact variant to MetricCard for condensed single-line KPI display [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/src/components/treasuryOverviewPage/MetricCard.test.tsx
+++ b/src/components/treasuryOverviewPage/MetricCard.test.tsx
@@ -9,7 +9,7 @@
 
 import { render, screen } from "@testing-library/react";
 import { describe, it, expect, afterEach } from "vitest";
-import MetricCard from "./MetricCard";
+import MetricCard, { MetricCardVariant } from "./MetricCard";
 
 describe("MetricCard", () => {
   const mockMetric = {
@@ -101,5 +101,39 @@ describe("MetricCard", () => {
         expect(screen.getByText("Available in treasury")).toBeInTheDocument();
       });
     }
+  });
+
+  describe("compact variant", () => {
+    it("renders label and value in a single row when variant is compact", () => {
+      render(<MetricCard {...mockMetric} variant="compact" />);
+      expect(screen.getByText("Total Balance")).toBeInTheDocument();
+      expect(screen.getByText("$100,000")).toBeInTheDocument();
+      // Description should not appear in compact mode
+      expect(screen.queryByText("Available in treasury")).not.toBeInTheDocument();
+    });
+
+    it("uses reduced padding and row layout for compact variant", () => {
+      const { container } = render(<MetricCard {...mockMetric} variant="compact" />);
+      const card = container.firstChild as HTMLElement;
+      const inlineStyle = card.getAttribute("style") || "";
+      // Compact variant uses row flex direction (hyphenated in DOM)
+      expect(inlineStyle).toContain("flex-direction: row");
+      // Compact variant uses smaller padding tokens
+      expect(inlineStyle).toContain("var(--space-sm) var(--space-md)");
+    });
+
+    it("defaults to default variant when no variant prop is passed", () => {
+      const { container } = render(<MetricCard {...mockMetric} />);
+      const card = container.firstChild as HTMLElement;
+      const inlineStyle = card.getAttribute("style") || "";
+      expect(inlineStyle).toContain("flex-direction: column");
+      expect(inlineStyle).toContain("var(--space-xl)");
+    });
+
+    it("renders icon and value in compact mode", () => {
+      render(<MetricCard {...mockMetric} variant="compact" />);
+      expect(screen.getByText("💰")).toBeInTheDocument();
+      expect(screen.getByText("$100,000")).toBeInTheDocument();
+    });
   });
 });

--- a/src/components/treasuryOverviewPage/MetricCard.tsx
+++ b/src/components/treasuryOverviewPage/MetricCard.tsx
@@ -25,6 +25,8 @@ import { useOptionalTheme } from "../../theme/ThemeProvider";
 import { GripVertical, MoreVertical } from "lucide-react";
 import React, { useState, useEffect } from "react";
 
+export type MetricCardVariant = "default" | "compact";
+
 export interface MetricCardProps extends Metric {
   draggable?: boolean;
   onDragStart?: (e: React.DragEvent<HTMLDivElement>) => void;
@@ -39,6 +41,7 @@ export interface MetricCardProps extends Metric {
   onResize?: (size: "1x1" | "2x1") => void;
   onHide?: () => void;
   currentSize?: "1x1" | "2x1";
+  variant?: MetricCardVariant;
   reorderButtons?: React.ReactNode;
   moveMenuOptions?: {
     onMoveLeft?: () => void;
@@ -71,6 +74,7 @@ export default function MetricCard({
   onResize,
   onHide,
   currentSize = "1x1",
+  variant = "default",
   reorderButtons,
   moveMenuOptions,
 }: MetricCardProps) {
@@ -159,12 +163,13 @@ export default function MetricCard({
       onDrop={onDrop}
       style={{
         display: "flex",
-        flexDirection: "column",
+        flexDirection: variant === "compact" ? "row" : "column",
+        alignItems: variant === "compact" ? "center" : undefined,
         backgroundColor: "var(--color-surface-default)",
         border: "1px solid var(--color-border-default)",
         borderRadius: "var(--radius-xl)",
-        padding: "var(--space-xl)",
-        height: "100%",
+        padding: variant === "compact" ? "var(--space-sm) var(--space-md)" : "var(--space-xl)",
+        height: variant === "compact" ? "auto" : "100%",
         position: "relative",
         minWidth: 0,
         overflow: "hidden",
@@ -417,67 +422,123 @@ export default function MetricCard({
         )}
       </div>
 
-      <div
-        className="cyberpunk-scanlines flex items-center justify-center w-10 h-10 text-3xl leading-none mb-4 shrink-0"
-        style={{ color: "var(--color-text-secondary)", pointerEvents: "none" }}
-      >
-        {icon}
-      </div>
-
-      <div
-        className="font-medium text-sm leading-5 mb-2"
-        style={{
-          color: "var(--color-text-primary)",
-          pointerEvents: "none",
-          overflow: "hidden",
-          minWidth: 0,
-        }}
-      >
-        {label}
-      </div>
-
-      <div
-        className="text-2xl font-semibold leading-8 mb-2 flex flex-col gap-1"
-        style={{
-          color: "var(--color-text-vivid)",
-          pointerEvents: "none",
-          overflow: "hidden",
-          wordBreak: "break-word",
-          minWidth: 0,
-        }}
-      >
-        {tokens && tokens.length > 0 ? (
-          tokens.map((t, i) => (
-            <div
-              key={t.asset}
-              className={i === 0 ? "" : "text-base font-medium"}
-              style={
-                i === 0 ? {} : { color: "var(--color-text-secondary)" }
-              }
-            >
-              {formatAssetAmount(t.amount, t.asset)}
-            </div>
-          ))
-        ) : (
-          <div>{value}</div>
-        )}
-      </div>
-
-      {trend && trend.length >= 2 && (
+      {variant === "compact" ? (
+        /* ── Compact variant: single-row layout ── */
         <div
-          style={{ marginBottom: "var(--space-sm)" }}
-          aria-label="Rate of change sparkline"
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "var(--space-sm)",
+            minWidth: 0,
+            flex: 1,
+          }}
         >
-          <Sparkline data={trend} />
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              color: "var(--color-text-secondary)",
+              fontSize: "var(--font-size-base)",
+              flexShrink: 0,
+            }}
+            aria-hidden="true"
+          >
+            {icon}
+          </div>
+          <span
+            style={{
+              color: "var(--color-text-primary)",
+              font: "var(--font-body-sm)",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+              minWidth: 0,
+            }}
+          >
+            {label}
+          </span>
+          <span
+            style={{
+              color: "var(--color-text-vivid)",
+              font: "var(--font-label-sm)",
+              fontWeight: 600,
+              marginLeft: "auto",
+              whiteSpace: "nowrap",
+              flexShrink: 0,
+            }}
+          >
+            {tokens && tokens.length > 0
+              ? formatAssetAmount(tokens[0].amount, tokens[0].asset)
+              : value}
+          </span>
         </div>
-      )}
+      ) : (
+        /* ── Default variant: full multi-line layout ── */
+        <>
+          <div
+            className="cyberpunk-scanlines flex items-center justify-center w-10 h-10 text-3xl leading-none mb-4 shrink-0"
+            style={{ color: "var(--color-text-secondary)", pointerEvents: "none" }}
+          >
+            {icon}
+          </div>
 
-      <p
-        className="text-sm leading-5 mt-auto"
-        style={{ color: "var(--color-text-secondary)", pointerEvents: "none" }}
-      >
-        {desc}
-      </p>
+          <div
+            className="font-medium text-sm leading-5 mb-2"
+            style={{
+              color: "var(--color-text-primary)",
+              pointerEvents: "none",
+              overflow: "hidden",
+              minWidth: 0,
+            }}
+          >
+            {label}
+          </div>
+
+          <div
+            className="text-2xl font-semibold leading-8 mb-2 flex flex-col gap-1"
+            style={{
+              color: "var(--color-text-vivid)",
+              pointerEvents: "none",
+              overflow: "hidden",
+              wordBreak: "break-word",
+              minWidth: 0,
+            }}
+          >
+            {tokens && tokens.length > 0 ? (
+              tokens.map((t, i) => (
+                <div
+                  key={t.asset}
+                  className={i === 0 ? "" : "text-base font-medium"}
+                  style={
+                    i === 0 ? {} : { color: "var(--color-text-secondary)" }
+                  }
+                >
+                  {formatAssetAmount(t.amount, t.asset)}
+                </div>
+              ))
+            ) : (
+              <div>{value}</div>
+            )}
+          </div>
+
+          {trend && trend.length >= 2 && (
+            <div
+              style={{ marginBottom: "var(--space-sm)" }}
+              aria-label="Rate of change sparkline"
+            >
+              <Sparkline data={trend} />
+            </div>
+          )}
+
+          <p
+            className="text-sm leading-5 mt-auto"
+            style={{ color: "var(--color-text-secondary)", pointerEvents: "none" }}
+          >
+            {desc}
+          </p>
+        </>
+      )}
 
       {/* Shared Kebab / Context Menu Popup */}
       {menuState.isOpen && (


### PR DESCRIPTION
## Summary

Adds a `variant="compact"` prop to the `MetricCard` component that collapses the full multi-line layout to a single-row label/value pair for use in tighter layouts such as a condensed dashboard header strip.

## Changes

- **`src/components/treasuryOverviewPage/MetricCard.tsx`**:
  - Added `MetricCardVariant` type (`"default" | "compact"`)
  - Added `variant` prop to `MetricCardProps` (defaults to `"default"`)
  - Compact variant renders icon + label + value in a single `flex-row` layout
  - Compact variant uses reduced padding (`var(--space-sm) var(--space-md)`)
  - Description, trend/sparkline are hidden in compact mode
  - Default variant unchanged

- **`src/components/treasuryOverviewPage/MetricCard.test.tsx`**:
  - Added 4 tests for compact variant behaviour

## Design Decisions

- Uses existing design tokens only (no hardcoded values)
- `aria-label` on the card wrapper is preserved for screen readers
- Icon is marked `aria-hidden="true"` in compact mode (decorative)
- Label uses `text-overflow: ellipsis` for long labels in constrained spaces

Closes #1271