### PR TITLE
feat: personalize Dashboard welcome empty state with wallet address (Closes #1272)

### DIFF
--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -1,4 +1,5 @@
 import React, { RefObject } from "react";
+import { formatAddress } from "./common/TruncatedAddress";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -14,6 +15,8 @@ export interface EmptyStateProps {
   variant: EmptyStateVariant;
   /** Whether a Stellar wallet is connected */
   walletConnected?: boolean;
+  /** Connected wallet address for personalized headline */
+  walletAddress?: string;
   /** Show skeleton/loading treatment instead of empty content */
   loading?: boolean;
   /** Show error treatment with optional retry */
@@ -206,6 +209,7 @@ function LoadingSkeleton() {
 export default function EmptyState({
   variant,
   walletConnected = false,
+  walletAddress,
   loading = false,
   error = null,
   onRetry,
@@ -225,7 +229,13 @@ export default function EmptyState({
 
   if (loading) return <LoadingSkeleton />;
 
-  const title = isConnected ? cfg.connectedTitle : cfg.anonymousTitle;
+  // Personalize the connected title when a wallet address is available.
+  // Use the same formatAddress utility from TruncatedAddress for consistency.
+  let title = isConnected ? cfg.connectedTitle : cfg.anonymousTitle;
+  if (isConnected && walletAddress) {
+    const truncated = formatAddress(walletAddress);
+    title = `Welcome, ${truncated} — no streams yet`;
+  }
   // For the error variant, allow an override message via errorMessage prop
   const description =
     effectiveVariant === "error" && errorMessage

--- a/src/components/TreasuryEmptyState.tsx
+++ b/src/components/TreasuryEmptyState.tsx
@@ -4,6 +4,7 @@ import EmptyState from "./EmptyState";
 interface TreasuryEmptyStateProps {
   onCreateStream: () => void;
   walletConnected?: boolean;
+  walletAddress?: string;
   loading?: boolean;
   error?: string | null;
   onRetry?: () => void;
@@ -12,6 +13,7 @@ interface TreasuryEmptyStateProps {
 const TreasuryEmptyState: React.FC<TreasuryEmptyStateProps> = ({
   onCreateStream,
   walletConnected = true,
+  walletAddress,
   loading = false,
   error = null,
   onRetry,
@@ -19,6 +21,7 @@ const TreasuryEmptyState: React.FC<TreasuryEmptyStateProps> = ({
   <EmptyState
     variant="treasury"
     walletConnected={walletConnected}
+    walletAddress={walletAddress}
     loading={loading}
     error={error}
     onRetry={onRetry}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -242,7 +242,7 @@ export default function Dashboard() {
           onDismiss={handleDismissOnboarding}
         />
       ) : (
-        <TreasuryEmptyState onCreateStream={() => setIsModalOpen(true)} />
+        <TreasuryEmptyState onCreateStream={() => setIsModalOpen(true)} walletAddress={walletAddress ?? undefined} />
       )}
 
       <CreateStreamModal

--- a/src/pages/__tests__/Dashboard.test.tsx
+++ b/src/pages/__tests__/Dashboard.test.tsx
@@ -10,6 +10,34 @@ vi.mock("@stellar/freighter-api", () => ({
   getAddress: vi.fn(),
 }));
 
+const mockWalletState = {
+  address: null,
+  network: null,
+  connected: false,
+  loading: false,
+  error: null,
+  expectedNetwork: "TESTNET",
+  expectedNetworkLabel: "Testnet",
+  isNetworkMismatch: false,
+  connect: vi.fn(),
+  disconnect: vi.fn(),
+};
+vi.mock("../../components/wallet-connect/Walletcontext", () => ({
+  useWallet: () => mockWalletState,
+  WalletProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock("../../components/toast/ToastProvider", () => ({
+  ToastProvider: ({ children }: { children: React.ReactNode }) => children,
+  useToast: () => ({ addToast: vi.fn() }),
+  useOptionalToast: () => ({ addToast: vi.fn() }),
+}));
+
+vi.mock("../../i18n", () => ({
+  I18nProvider: ({ children }: { children: React.ReactNode }) => children,
+  useI18n: () => ({ t: (s: string) => s, locale: "en" }),
+}));
+
 const mockUseTreasury = vi.fn(() => ({
   metrics: [],
   streams: [],
@@ -32,6 +60,14 @@ describe("Dashboard page accessibility and announcements", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     localStorage.clear();
+    mockUseTreasury.mockReset();
+    mockUseTreasury.mockReturnValue({
+      metrics: [],
+      streams: [],
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
   });
 
   afterEach(() => {
@@ -122,6 +158,14 @@ describe("Dashboard page accessibility - landmarks and heading hierarchy", () =>
   beforeEach(() => {
     vi.useFakeTimers();
     localStorage.clear();
+    mockUseTreasury.mockReset();
+    mockUseTreasury.mockReturnValue({
+      metrics: [],
+      streams: [],
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Summary

Personalize the Dashboard's zero-streams empty state headline to include the connected wallet's truncated address, so the empty state feels like a first-run moment tied to the actual session.

## Changes

- **EmptyState.tsx**: Added `walletAddress` prop. When a wallet is connected and an address is provided, the headline changes from "No streams yet" to "Welcome, GABCDE...6789 — no streams yet" using the `formatAddress` utility from `TruncatedAddress.tsx` for consistent truncation.
- **TreasuryEmptyState.tsx**: Added `walletAddress` prop and passes it through to `EmptyState`.
- **Dashboard.tsx**: Passes `walletAddress` from `useWallet()` to `TreasuryEmptyState`.
- **Dashboard.test.tsx**: Added proper WalletContext, ToastProvider, and i18n mocking. Fixed `mockUseTreasury` leakage between tests by resetting in `beforeEach`.

## Behavior

| Scenario | Headline |
|:---|:---|
| Wallet connected, 0 streams | "Welcome, GABCDE...6789 — no streams yet" |
| Wallet disconnected, 0 streams | "No streams yet" (unchanged) |
| Wallet connected, >0 streams | RecentStreams shown (unchanged) |

## Testing

```
✓ Dashboard.test.tsx (9 tests) — all passing
```

Closes #1272