### PR TITLE
feat: add Copy Stream Link action to StreamDetail hero header (Closes #1282)

### DIFF
--- a/src/pages/StreamDetail.tsx
+++ b/src/pages/StreamDetail.tsx
@@ -12,7 +12,9 @@ import { MetaTags } from "../components/MetaTags";
 import { usePresenceViewers } from "../hooks/usePresenceViewers";
 import { PresenceBadge, PresenceCursorOverlay } from "../components/presence";
 import { StreamOGPreviewModal } from "../components/StreamOGPreviewModal";
-import { Share2 } from "lucide-react";
+import { Check, Copy, Share2 } from "lucide-react";
+import { useClipboard } from "../hooks/useClipboard";
+import { useOptionalToast } from "../components/toast/ToastProvider";
 
 /**
  * StreamDetail page
@@ -55,6 +57,8 @@ export default function StreamDetail() {
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const currentDate = useTickingNow();
+  const { copy, status: copyStatus } = useClipboard();
+  const toast = useOptionalToast();
 
   useEffect(() => {
     // In compare mode the individual panes manage their own fetches
@@ -321,28 +325,74 @@ export default function StreamDetail() {
         </div>
 
         {/* Share & Social Preview Card Trigger */}
-        <button
-          onClick={() => setIsOgModalOpen(true)}
-          data-testid="share-og-preview-btn"
-          aria-label={`Share ${stream.name} and preview social card`}
-          style={{
-            display: "inline-flex",
-            alignItems: "center",
-            gap: "0.5rem",
-            padding: "0.5rem 1rem",
-            borderRadius: "8px",
-            border: "1px solid var(--color-border, #e5e7eb)",
-            background: "var(--color-surface-1, #fff)",
-            color: "var(--color-text-primary, #111827)",
-            fontSize: "0.875rem",
-            fontWeight: 600,
-            cursor: "pointer",
-            boxShadow: "0 1px 2px rgba(0, 0, 0, 0.05)",
-          }}
-        >
-          <Share2 size={16} />
-          <span>Share / Preview Card</span>
-        </button>
+        <div style={{ display: "flex", gap: "0.5rem", flexWrap: "wrap" }}>
+          <button
+            onClick={() => setIsOgModalOpen(true)}
+            data-testid="share-og-preview-btn"
+            aria-label={`Share ${stream.name} and preview social card`}
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: "0.5rem",
+              padding: "0.5rem 1rem",
+              borderRadius: "8px",
+              border: "1px solid var(--color-border, #e5e7eb)",
+              background: "var(--color-surface-1, #fff)",
+              color: "var(--color-text-primary, #111827)",
+              fontSize: "0.875rem",
+              fontWeight: 600,
+              cursor: "pointer",
+              boxShadow: "0 1px 2px rgba(0, 0, 0, 0.05)",
+            }}
+          >
+            <Share2 size={16} />
+            <span>Share / Preview Card</span>
+          </button>
+          <button
+            onClick={async () => {
+              const success = await copy(window.location.href);
+              if (!success) {
+                toast?.addToast?.("Failed to copy link. Please copy the URL manually.", "error");
+              }
+            }}
+            data-testid="copy-stream-link-btn"
+            aria-label={
+              copyStatus === "copied"
+                ? "Stream link copied"
+                : "Copy stream link to clipboard"
+            }
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: "0.5rem",
+              padding: "0.5rem 1rem",
+              borderRadius: "8px",
+              border: "1px solid var(--color-border, #e5e7eb)",
+              background: "var(--color-surface-1, #fff)",
+              color:
+                copyStatus === "copied"
+                  ? "var(--color-success, #16a34a)"
+                  : "var(--color-text-primary, #111827)",
+              fontSize: "0.875rem",
+              fontWeight: 600,
+              cursor: "pointer",
+              boxShadow: "0 1px 2px rgba(0, 0, 0, 0.05)",
+              transition: "color 0.2s ease",
+            }}
+          >
+            {copyStatus === "copied" ? (
+              <>
+                <Check size={16} aria-hidden="true" />
+                <span>Copied</span>
+              </>
+            ) : (
+              <>
+                <Copy size={16} aria-hidden="true" />
+                <span>Copy Link</span>
+              </>
+            )}
+          </button>
+        </div>
       </div>
 
       {/* Presence Badge Container */}

--- a/src/pages/__tests__/StreamDetail.test.tsx
+++ b/src/pages/__tests__/StreamDetail.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { HelmetProvider } from "react-helmet-async";
 import StreamDetail from "../StreamDetail";
@@ -236,5 +237,68 @@ describe("StreamDetail Page", () => {
     });
 
     expect(container.firstChild).toBeNull();
+  });
+
+  it("renders a Copy Link button that copies the current URL to the clipboard", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+      writable: true,
+    });
+
+    vi.spyOn(streamsService, "getStreamById").mockResolvedValue(mockStream);
+
+    renderWithHelmet(
+      <MemoryRouter initialEntries={["/app/streams/STR-123"]}>
+        <Routes>
+          <Route path="/app/streams/:streamId" element={<StreamDetail />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    const copyBtn = await screen.findByTestId("copy-stream-link-btn");
+    expect(copyBtn).toBeInTheDocument();
+    expect(copyBtn).toHaveTextContent("Copy Link");
+
+    await userEvent.click(copyBtn);
+
+    // In jsdom, window.location.href defaults to http://localhost:3000/
+    // MemoryRouter does not update the actual window.location, so we just
+    // verify that the clipboard API was called with a URL string.
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledOnce();
+      expect(typeof writeText.mock.calls[0][0]).toBe("string");
+      expect(writeText.mock.calls[0][0]).toContain("http");
+    });
+
+    // After copy, the button should show "Copied" state
+    expect(copyBtn).toHaveTextContent("Copied");
+  });
+
+  it("shows 'Copied' text on the Copy Link button after successful copy", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+      writable: true,
+    });
+
+    vi.spyOn(streamsService, "getStreamById").mockResolvedValue(mockStream);
+
+    renderWithHelmet(
+      <MemoryRouter initialEntries={["/app/streams/STR-123"]}>
+        <Routes>
+          <Route path="/app/streams/:streamId" element={<StreamDetail />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    const copyBtn = await screen.findByTestId("copy-stream-link-btn");
+    await userEvent.click(copyBtn);
+
+    await waitFor(() => {
+      expect(copyBtn).toHaveTextContent("Copied");
+    });
   });
 });


### PR DESCRIPTION
## Summary

Adds a **Copy Link** icon button beside the existing Share button in the StreamDetail page header. When clicked, it copies the current page URL (including the `:streamId`) to the clipboard.

## Changes

- **`src/pages/StreamDetail.tsx`** — Added Copy Link button with `useClipboard` hook integration. Shows a brief 'Copied' confirmation state (green Check icon + text), then reverts. Falls back to a toast notification on clipboard-write failure.
- **`src/pages/__tests__/StreamDetail.test.tsx`** — Added 2 test cases verifying the copy button renders with correct label, copies the URL to clipboard, and shows the 'Copied' state after a successful copy.

## Requirements coverage

- [x] Button shows a brief 'Copied' confirmation state, then reverts (via `useClipboard`'s built-in 2s reset delay)
- [x] Handles clipboard-write failure by surfacing a fallback toast
- [x] Button has a distinct `aria-label` from the nearby Share button so screen reader users can tell them apart
- [x] Accessible (WCAG 2.1 AA) — keyboard actionable, ARIA labels, color contrast
- [x] Responsive — wrapped in a flex container with the existing Share button
- [x] Consistent with existing design tokens and patterns (uses `useClipboard` hook, `useOptionalToast`, and Lucide icons already in the codebase)

## Testing

```
✓ src/pages/__tests__/StreamDetail.test.tsx (12 tests) — all passing
```