### PR TITLE
feat: add per-section Edit links to CreateStreamModal step-3 summary [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/src/components/CreateStreamModal.tsx
+++ b/src/components/CreateStreamModal.tsx
@@ -576,6 +576,27 @@ export default function CreateStreamModal({
     });
   }, [queuedSubmission?.id]);
 
+  // Focus the primary input field when stepping back from step 3 via the
+  // review-card "Edit" buttons, so the user can immediately start typing.
+  const prevStepRef = useRef(currentStep);
+  useEffect(() => {
+    const prev = prevStepRef.current;
+    prevStepRef.current = currentStep;
+    // Only focus when transitioning *backward* from step 3.
+    if (prev !== 3 || currentStep >= prev) return;
+    requestAnimationFrame(() => {
+      if (currentStep === 1) {
+        recipientInputRef.current?.focus();
+      } else if (currentStep === 2) {
+        // InputWithUnit doesn't forward refs, so we use the id instead.
+        const rateInput = document.getElementById('create-stream-accrual-rate');
+        if (rateInput instanceof HTMLInputElement) {
+          rateInput.focus();
+        }
+      }
+    });
+  }, [currentStep]);
+
   const resetTransactionState = () => {
     transactionStatus.reset();
     setSubmittedTxHash(null);


### PR DESCRIPTION
## Summary

When the user clicks an Edit button on a step-3 review card, the focus now moves to the primary input field on the target step so the user can start typing immediately without an extra click.

## Changes

- **Recipient/Deposit Edit** → focuses recipient input on step 1
- **Rate/Schedule Edit** → focuses accrual rate input on step 2
- Focus only fires on backward transitions from step 3 (not when navigating forward)

## Related

Closes #1278

## Testing

- Focus management is triggered on `currentStep` change
- Only fires when transitioning backward from step 3 (prev !== 3 || currentStep >= prev)
- Uses `requestAnimationFrame` to ensure the DOM has rendered before focusing