### PR TITLE
feat: add at-risk funding health state to StreamDetail sidebar

### DIFF
--- a/docs/COMPONENT_GUIDELINES.md
+++ b/docs/COMPONENT_GUIDELINES.md
@@ -130,3 +130,44 @@ Read wallet address and network exclusively through `useWallet()` from
 - `docs/SR_ONLY_REVEAL_PATTERN_SPEC.md` — screen-reader-only reveal patterns
 - `src/styles/accessibility.css` — shared focus-ring and sr-only utilities
 - `CONTRIBUTING.md` — branch naming, commit conventions, and CI requirements
+
+---
+
+## StreamDetail at-risk health state
+
+The `StreamDetail` page's health badge has been extended with an "At risk" overlay that
+warns when the stream's remaining treasury runway is critically low.
+
+### Implementation
+
+- **`AT_RISK_RUNWAY_HOURS`** (exported constant, currently `48`): the threshold in hours.
+  When the stream's remaining funds will run out within this window at the current
+  monthly accrual rate, the "At risk" badge is shown.
+- **`computeIsAtRisk(stream)`**: a pure function that calculates the remaining runway
+  as `remainingAmount / (monthlyRate / 30)` and converts the result to hours. Returns
+  `true` only for **Active** streams with a positive monthly rate whose runway is
+  below the threshold.
+
+### Visual design
+
+- The existing health status pill (Healthy / Attention / Settled) is always shown.
+- The "At risk" badge is a **red pill** with a warning icon (`⚠️`), layered **next to**
+  (not replacing) the existing health pill.
+- Uses `var(--color-error)` / `var(--color-error-subtle)` tokens so it respects the
+  active theme.
+
+### Accessibility
+
+- The "At risk" badge has `role="status"` so screen readers announce it.
+- The badge has an `aria-label` describing the exact condition.
+- Color is not the only differentiator — the warning icon and bold text provide
+  a secondary cue.
+
+### Edge cases
+
+| Scenario | Behaviour |
+|----------|-----------|
+| Monthly rate is 0 or negative | No "At risk" badge (defensive guard) |
+| `remainingAmount` is 0 | Badge appears (runway is 0 hours) |
+| Stream is not Active (Completed / Paused) | No "At risk" badge (non-active streams are settled) |
+| Stream has very large remaining amount | No "At risk" badge (runway is sufficient) |

--- a/src/pages/StreamDetail.tsx
+++ b/src/pages/StreamDetail.tsx
@@ -15,6 +15,33 @@ import { StreamOGPreviewModal } from "../components/StreamOGPreviewModal";
 import { Share2 } from "lucide-react";
 
 /**
+ * Runway threshold expressed in hours. When the stream's remaining treasury
+ * balance divided by its daily accrual rate drops below this value, the health
+ * badge shows an "At risk" overlay state.
+ *
+ * Exported so tests can reference the same constant without duplicating the
+ * magic number, and so the threshold can be tuned in a single location.
+ */
+export const AT_RISK_RUNWAY_HOURS = 48;
+
+/**
+ * Returns `true` when the stream's remaining funds will run out within
+ * {@link AT_RISK_RUNWAY_HOURS} at the current monthly accrual rate.
+ *
+ * The calculation treats a month as 30 days. A zero or negative monthly rate
+ * is treated as "not at risk" (defensive guard against malformed data).
+ */
+function computeIsAtRisk(stream: StreamRecord): boolean {
+  // Only active streams can be at risk — completed/paused streams are settled
+  if (stream.status !== "Active") return false;
+  if (stream.monthlyRate <= 0) return false;
+  const dailyRate = stream.monthlyRate / 30;
+  if (dailyRate <= 0) return false;
+  const remainingHours = (stream.remainingAmount / dailyRate) * 24;
+  return remainingHours < AT_RISK_RUNWAY_HOURS;
+}
+
+/**
  * StreamDetail page
  * ─────────────────────────────────────────────────────────────────────────────
  * Dedicated route for `/app/streams/:streamId`. Fetches a single
@@ -286,6 +313,8 @@ export default function StreamDetail() {
     Settled: "var(--color-text-secondary, #6b7280)",
   };
 
+  const isAtRisk = computeIsAtRisk(stream);
+
   // ── Single-stream detail ──────────────────────────────────────────────────
   return (
     <div data-testid="stream-detail-page" style={{ padding: "1.5rem" }}>
@@ -355,7 +384,7 @@ export default function StreamDetail() {
       )}
 
       {/* Health badge */}
-      <div style={{ marginBottom: "1.5rem" }}>
+      <div style={{ marginBottom: "1.5rem", display: "flex", alignItems: "center", gap: "0.5rem" }}>
         <span
           style={{
             display: "inline-flex",
@@ -373,6 +402,27 @@ export default function StreamDetail() {
           <span aria-hidden="true">●</span>
           {stream.health} — {stream.healthNote}
         </span>
+        {isAtRisk && (
+          <span
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: "0.375rem",
+              padding: "0.25rem 0.75rem",
+              borderRadius: "9999px",
+              fontSize: "0.8125rem",
+              fontWeight: 600,
+              background: "var(--color-error-subtle, #fef2f2)",
+              color: "var(--color-error, #b91c1c)",
+              border: "1px solid var(--color-error, #b91c1c)",
+            }}
+            role="status"
+            aria-label="At risk: Treasury runway below 48 hours"
+          >
+            <span aria-hidden="true" style={{ fontSize: "1rem" }}>⚠️</span>
+            At risk
+          </span>
+        )}
       </div>
 
       {/* Metrics grid */}

--- a/src/pages/__tests__/StreamDetail.atRisk.test.tsx
+++ b/src/pages/__tests__/StreamDetail.atRisk.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { HelmetProvider } from "react-helmet-async";
+import StreamDetail, { AT_RISK_RUNWAY_HOURS } from "../StreamDetail";
+import * as streamsService from "../../lib/api/streamsService";
+import type { StreamRecord } from "../../data/streamRecords";
+
+const mockStream = (overrides: Partial<StreamRecord> = {}): StreamRecord => ({
+  id: "STR-123",
+  name: "Engineering Grant",
+  summary: "Monthly allocation for core developers",
+  recipientName: "Alice",
+  recipientAddress: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+  treasuryName: "Treasury",
+  treasuryAddress: "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBWHF",
+  depositAmount: 10000,
+  streamedAmount: 4000,
+  withdrawableAmount: 2000,
+  remainingAmount: 6000,
+  monthlyRate: 1000,
+  startDate: "2026-01-01T00:00:00Z",
+  endDate: "2026-10-01T00:00:00Z",
+  cliffDate: undefined,
+  status: "Active",
+  health: "Healthy",
+  healthNote: "Stream is running normally",
+  asset: "USDC",
+  progress: 40,
+  auditNote: "",
+  tags: [],
+  timeline: [],
+  ...overrides,
+});
+
+const renderStreamDetail = (stream: StreamRecord) => {
+  vi.spyOn(streamsService, "getStreamById").mockResolvedValue(stream);
+  return render(
+    <HelmetProvider>
+      <MemoryRouter initialEntries={["/app/streams/STR-123"]}>
+        <Routes>
+          <Route path="/app/streams/:streamId" element={<StreamDetail />} />
+        </Routes>
+      </MemoryRouter>
+    </HelmetProvider>,
+  );
+};
+
+describe("StreamDetail at-risk health state", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders the 'At risk' badge when the remaining runway is below 48 hours", async () => {
+    // 1000 monthlyRate = 33.33/day = 1.39/hr
+    // 50 remainingAmount / 33.33 = 1.5 days = 36 hours < 48 ✓
+    renderStreamDetail(
+      mockStream({ remainingAmount: 50, monthlyRate: 1000 }),
+    );
+
+    expect(await screen.findByText("At risk")).toBeInTheDocument();
+    expect(
+      screen.getByRole("status", { name: /treasury runway below 48 hours/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("does NOT render the 'At risk' badge when the runway is above 48 hours", async () => {
+    // 5000 remainingAmount / 33.33 = 150 days = 3600 hours > 48 ✓
+    renderStreamDetail(
+      mockStream({ remainingAmount: 5000, monthlyRate: 1000 }),
+    );
+
+    expect(await screen.findByText("Healthy — Stream is running normally")).toBeInTheDocument();
+    expect(screen.queryByText("At risk")).not.toBeInTheDocument();
+  });
+
+  it("does NOT render the 'At risk' badge when monthlyRate is zero", async () => {
+    renderStreamDetail(
+      mockStream({ remainingAmount: 1, monthlyRate: 0 }),
+    );
+
+    expect(await screen.findByText("Healthy — Stream is running normally")).toBeInTheDocument();
+    expect(screen.queryByText("At risk")).not.toBeInTheDocument();
+  });
+
+  it("does NOT render the 'At risk' badge when the stream is settled", async () => {
+    // 50 remainingAmount / 33.33 = 36 hours < 48, but not active
+    renderStreamDetail(
+      mockStream({ remainingAmount: 50, monthlyRate: 1000, status: "Completed", health: "Settled", healthNote: "Stream has ended" }),
+    );
+
+    expect(await screen.findByText(/Settled/)).toBeInTheDocument();
+    expect(screen.queryByText("At risk")).not.toBeInTheDocument();
+  });
+
+  it("exports AT_RISK_RUNWAY_HOURS as a named constant", () => {
+    expect(AT_RISK_RUNWAY_HOURS).toBe(48);
+  });
+});


### PR DESCRIPTION
## Summary

Adds an "At risk" overlay to the StreamDetail health badge that warns when the stream's remaining treasury runway drops below **48 hours**.

## Changes

### `src/pages/StreamDetail.tsx`
- Added `AT_RISK_RUNWAY_HOURS` (exported constant = 48) — the threshold in hours
- Added `computeIsAtRisk(stream)` — pure function that calculates remaining runway from `remainingAmount / (monthlyRate / 30)`, returns `true` only for **Active** streams below the threshold
- Updated health badge section to render a red "At risk" pill with warning icon alongside the existing health status pill

### `src/pages/__tests__/StreamDetail.atRisk.test.tsx` (new)
- 5 tests covering:
  - "At risk" badge appears when runway < 48 hours
  - "At risk" badge is hidden when runway > 48 hours
  - "At risk" badge is hidden when monthlyRate is 0
  - "At risk" badge is hidden when stream is not Active (Settled)
  - `AT_RISK_RUNWAY_HOURS` constant is exported correctly

### `docs/COMPONENT_GUIDELINES.md`
- Added section documenting the at-risk health state, visual design, accessibility, and edge cases

## Testing

All 5 new tests pass. Existing StreamDetail tests are unaffected.
