### PR TITLE
perf: throttle scroll and debounce resize in VirtualList

### DIFF
--- a/src/components/VirtualList.tsx
+++ b/src/components/VirtualList.tsx
@@ -8,6 +8,7 @@ import {
   type ReactNode,
 } from "react";
 import { usePrefersReducedMotion } from "../hooks/usePrefersReducedMotion";
+import { VIEWPORT_RESIZE_DEBOUNCE_MS } from "../lib/breakpoints";
 import "./VirtualList.css";
 
 interface VirtualRange {
@@ -72,6 +73,8 @@ export default function VirtualList<T>({
   const containerRef = useRef<HTMLDivElement | null>(null);
   const focusedRowIndexRef = useRef<number | null>(null);
   const focusableOffsetRef = useRef<number | null>(null);
+  const rafRef = useRef<number | null>(null);
+  const resizeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const shouldVirtualize = items.length > threshold;
   const safeEstimate = Math.max(estimateSize, 1);
   const effectiveOverscan = Math.max(prefersReducedMotion ? 1 : overscan, 0);
@@ -125,12 +128,43 @@ export default function VirtualList<T>({
     }
 
     updateRange();
-    window.addEventListener("scroll", updateRange, { passive: true });
-    window.addEventListener("resize", updateRange);
+
+    const handleScroll = () => {
+      if (typeof requestAnimationFrame === "undefined") {
+        updateRange();
+        return;
+      }
+      if (rafRef.current !== null) return;
+      rafRef.current = requestAnimationFrame(() => {
+        rafRef.current = null;
+        updateRange();
+      });
+    };
+
+    const handleResize = () => {
+      if (resizeTimerRef.current !== null) {
+        clearTimeout(resizeTimerRef.current);
+      }
+      resizeTimerRef.current = setTimeout(() => {
+        resizeTimerRef.current = null;
+        updateRange();
+      }, VIEWPORT_RESIZE_DEBOUNCE_MS);
+    };
+
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    window.addEventListener("resize", handleResize);
 
     return () => {
-      window.removeEventListener("scroll", updateRange);
-      window.removeEventListener("resize", updateRange);
+      window.removeEventListener("scroll", handleScroll);
+      window.removeEventListener("resize", handleResize);
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+      if (resizeTimerRef.current !== null) {
+        clearTimeout(resizeTimerRef.current);
+        resizeTimerRef.current = null;
+      }
     };
   }, [shouldVirtualize, updateRange]);
 

--- a/src/components/__tests__/VirtualList.test.tsx
+++ b/src/components/__tests__/VirtualList.test.tsx
@@ -25,6 +25,7 @@ function renderVirtualList(count = items.length) {
 
 describe("VirtualList", () => {
   beforeEach(() => {
+    vi.useFakeTimers();
     vi.spyOn(window, "scrollTo").mockImplementation(() => {});
     vi.spyOn(Element.prototype, "getBoundingClientRect").mockImplementation(
       () =>
@@ -54,6 +55,7 @@ describe("VirtualList", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.useRealTimers();
   });
 
   it("skips virtualization below the configured threshold", () => {
@@ -89,6 +91,7 @@ describe("VirtualList", () => {
     act(() => {
       fireEvent.scroll(window);
     });
+    act(() => { vi.advanceTimersToNextFrame(); });
 
     expect(screen.queryByText("Stream 0")).not.toBeInTheDocument();
     expect(screen.getByText("Stream 8")).toBeInTheDocument();
@@ -136,6 +139,7 @@ describe("VirtualList", () => {
     act(() => {
       fireEvent.scroll(window);
     });
+    act(() => { vi.advanceTimersToNextFrame(); });
 
     expect(screen.queryByTestId("button-0")).not.toBeInTheDocument();
 
@@ -182,6 +186,7 @@ describe("VirtualList", () => {
     act(() => {
       fireEvent.scroll(window);
     });
+    act(() => { vi.advanceTimersToNextFrame(); });
 
     expect(screen.queryByTestId("button-0")).not.toBeInTheDocument();
 
@@ -229,6 +234,7 @@ describe("VirtualList", () => {
     act(() => {
       fireEvent.scroll(window);
     });
+    act(() => { vi.advanceTimersToNextFrame(); });
 
     expect(screen.queryByTestId("button-0")).not.toBeInTheDocument();
 


### PR DESCRIPTION
## Summary

Throttle the `scroll` event listener in `VirtualList.tsx` using `requestAnimationFrame` so `updateRange` runs at most once per frame during fling-scroll. Debounce the `resize` listener using the shared `VIEWPORT_RESIZE_DEBOUNCE_MS` (150ms) constant, consistent with the codebase's established pattern in `Sidebar.tsx`.

## Changes

- **`src/components/VirtualList.tsx`**: Added `rafRef` and `resizeTimerRef` to track pending animation frames and resize timeouts. Created `handleScroll` (rAF-throttled) and `handleResize` (debounced) closures. The cleanup function cancels any pending rAF or timeout to prevent state updates on unmounted components. Falls back to synchronous execution when `requestAnimationFrame` is unavailable (jsdom/SSR).

- **`src/components/__tests__/VirtualList.test.tsx`**: Updated scroll tests to use `vi.useFakeTimers()` and `vi.advanceTimersToNextFrame()` after `fireEvent.scroll`, so the throttled rAF callback fires and test assertions pass. All 6 existing tests remain green.

## Testing

- All 6 VirtualList tests pass: `NODE_ENV=development npx vitest run src/components/__tests__/VirtualList.test.tsx`
- RecipientStreams filter tests that use VirtualList also pass.
- TypeScript build: `tsc -b --noEmit` shows no VirtualList-related errors.

Closes #711