### PR TITLE
feat: add IntersectionObserver staggered fade-in to ValuePropositionSection (Closes #1267)

### DIFF
--- a/src/components/ValuePropositionSection.tsx
+++ b/src/components/ValuePropositionSection.tsx
@@ -1,66 +1,138 @@
+import { useRef, useState, useEffect } from "react";
 import type { LucideIcon } from "lucide-react";
 import { Clock, PauseCircle, Settings, Star } from "lucide-react";
 
-export default function ValuePropositionSection() {
-	return (
-		<section className='px-6 py-24 transition-colors duration-300'>
-			<div className='max-w-6xl mx-auto text-center'>
-				<h2 className='text-4xl font-semibold font-jakarta-sans text-slate-900 dark:text-white'>
-					Treasury streaming infrastructure
-				</h2>
-				<p className='mt-4 text-lg text-slate-500 dark:text-slate-400'>
-					Everything you need to manage continuous capital flow on Stellar
-				</p>
+/**
+ * Fires once when the referenced element enters the viewport.
+ * Disconnects the observer after the first intersection, so the
+ * animation only ever plays once per page load.
+ */
+function useIntersectionOnce(ref: React.RefObject<HTMLElement | null>) {
+  const [inView, setInView] = useState(false);
 
-				<div className='mt-16 grid grid-cols-1 md:grid-cols-2 gap-8'>
-					<FeatureCard
-						icon={Clock}
-						title='Real-time USDC streaming'
-						description='Funds accrue per second; recipients withdraw anytime. No batch delays, no waiting for payment cycles—continuous capital flow.'
-					/>
-					<FeatureCard
-						icon={Settings}
-						title='Configurable rate & cliff'
-						description='Set streaming rate, start/end timestamps, and optional cliff periods. Vesting schedules and grant programs in one primitive.'
-					/>
-					<FeatureCard
-						icon={PauseCircle}
-						title='Pause and cancel controls'
-						description='Treasury or admin can pause or cancel active streams. Unstreamed amounts return to sender automatically. Full control, always.'
-					/>
-					<FeatureCard
-						icon={Star}
-						title='Built on Stellar & Soroban'
-						description='Native Stellar infrastructure. Soroban smart contracts. Native USDC support. Built specifically for the Stellar ecosystem.'
-					/>
-				</div>
-			</div>
-		</section>
-	);
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setInView(true);
+          observer.disconnect();
+        }
+      },
+      { threshold: 0.1 },
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [ref]);
+
+  return inView;
+}
+
+export default function ValuePropositionSection() {
+  const sectionRef = useRef<HTMLElement>(null);
+  const inView = useIntersectionOnce(sectionRef);
+
+  return (
+    <section
+      ref={sectionRef}
+      className="px-6 py-24 transition-colors duration-300"
+    >
+      <div className="max-w-6xl mx-auto text-center">
+        <h2
+          className="text-4xl font-semibold font-jakarta-sans text-slate-900 dark:text-white"
+          style={{
+            transition: "opacity var(--transition-base), transform var(--transition-base)",
+            transitionDelay: "0ms",
+            opacity: inView ? 1 : 0,
+            transform: inView ? "translateY(0)" : "translateY(12px)",
+          }}
+        >
+          Treasury streaming infrastructure
+        </h2>
+        <p
+          className="mt-4 text-lg text-slate-500 dark:text-slate-400"
+          style={{
+            transition: "opacity var(--transition-base), transform var(--transition-base)",
+            transitionDelay: "80ms",
+            opacity: inView ? 1 : 0,
+            transform: inView ? "translateY(0)" : "translateY(12px)",
+          }}
+        >
+          Everything you need to manage continuous capital flow on Stellar
+        </p>
+
+        <div className="mt-16 grid grid-cols-1 md:grid-cols-2 gap-8">
+          <FeatureCard
+            icon={Clock}
+            title="Real-time USDC streaming"
+            description="Funds accrue per second; recipients withdraw anytime. No batch delays, no waiting for payment cycles—continuous capital flow."
+            staggerDelay={0}
+            inView={inView}
+          />
+          <FeatureCard
+            icon={Settings}
+            title="Configurable rate & cliff"
+            description="Set streaming rate, start/end timestamps, and optional cliff periods. Vesting schedules and grant programs in one primitive."
+            staggerDelay={80}
+            inView={inView}
+          />
+          <FeatureCard
+            icon={PauseCircle}
+            title="Pause and cancel controls"
+            description="Treasury or admin can pause or cancel active streams. Unstreamed amounts return to sender automatically. Full control, always."
+            staggerDelay={160}
+            inView={inView}
+          />
+          <FeatureCard
+            icon={Star}
+            title="Built on Stellar & Soroban"
+            description="Native Stellar infrastructure. Soroban smart contracts. Native USDC support. Built specifically for the Stellar ecosystem."
+            staggerDelay={240}
+            inView={inView}
+          />
+        </div>
+      </div>
+    </section>
+  );
 }
 
 function FeatureCard({
-	icon,
-	title,
-	description,
+  icon,
+  title,
+  description,
+  staggerDelay,
+  inView,
 }: {
-	icon: LucideIcon;
-	title: string;
-	description: string;
+  icon: LucideIcon;
+  title: string;
+  description: string;
+  staggerDelay: number;
+  inView: boolean;
 }) {
-	const Icon = icon;
+  const Icon = icon;
 
-	return (
-		<div className='rounded-2xl border border-slate-200 bg-white p-8 text-left transition-all duration-300 hover:shadow-lg dark:border-cyan-500/10 dark:bg-slate-900/60 dark:hover:border-cyan-500/25 dark:hover:shadow-[0_8px_30px_rgba(8,145,178,0.12)]'>
-			<div className='mb-6 flex h-12 w-12 items-center justify-center rounded-xl bg-cyan-50 text-cyan-500 dark:bg-cyan-500/15 dark:text-cyan-300'>
-				<Icon className='h-6 w-6 stroke-2' />
-			</div>
-			<h3 className='text-lg font-semibold font-jakarta-sans text-slate-700 dark:text-slate-100'>
-				{title}
-			</h3>
-			<p className='mt-3 text-sm leading-relaxed font-jakarta-sans text-slate-500 dark:text-slate-400'>
-				{description}
-			</p>
-		</div>
-	);
+  return (
+    <div
+      className="rounded-2xl border border-slate-200 bg-white p-8 text-left transition-all duration-300 hover:shadow-lg dark:border-cyan-500/10 dark:bg-slate-900/60 dark:hover:border-cyan-500/25 dark:hover:shadow-[0_8px_30px_rgba(8,145,178,0.12)]"
+      style={{
+        transition: `opacity var(--transition-base), transform var(--transition-base)`,
+        transitionDelay: `${staggerDelay}ms`,
+        opacity: inView ? 1 : 0,
+        transform: inView ? "translateY(0)" : "translateY(20px)",
+      }}
+    >
+      <div className="mb-6 flex h-12 w-12 items-center justify-center rounded-xl bg-cyan-50 text-cyan-500 dark:bg-cyan-500/15 dark:text-cyan-300">
+        <Icon className="h-6 w-6 stroke-2" />
+      </div>
+      <h3 className="text-lg font-semibold font-jakarta-sans text-slate-700 dark:text-slate-100">
+        {title}
+      </h3>
+      <p className="mt-3 text-sm leading-relaxed font-jakarta-sans text-slate-500 dark:text-slate-400">
+        {description}
+      </p>
+    </div>
+  );
 }

--- a/src/components/__tests__/ValuePropositionSection.test.tsx
+++ b/src/components/__tests__/ValuePropositionSection.test.tsx
@@ -1,16 +1,60 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, act } from "@testing-library/react";
 import ValuePropositionSection from "../ValuePropositionSection";
-import { vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-// Mock lucide-react icons
-vi.mock('lucide-react', () => ({
-  Clock: () => <svg data-testid="icon" />,
-  Settings: () => <svg data-testid="icon" />,
-  PauseCircle: () => <svg data-testid="icon" />,
-  Star: () => <svg data-testid="icon" />, 
-}));
+/**
+ * Tracks the active IntersectionObserver callback so we can
+ * manually trigger it from tests.
+ */
+let activeObserver: {
+  callback: IntersectionObserverCallback;
+  disconnect: ReturnType<typeof vi.fn>;
+} | null = null;
+
+beforeEach(() => {
+  activeObserver = null;
+
+  class MockObserver implements IntersectionObserver {
+    readonly root: Element | null = null;
+    readonly rootMargin: string = "";
+    readonly thresholds: ReadonlyArray<number> = [0.1];
+    callback: IntersectionObserverCallback;
+    observe = vi.fn();
+    disconnect = vi.fn();
+    unobserve = vi.fn();
+    takeRecords = vi.fn(() => []);
+
+    constructor(cb: IntersectionObserverCallback) {
+      this.callback = cb;
+      activeObserver = { callback: cb, disconnect: this.disconnect };
+    }
+  }
+
+  vi.stubGlobal("IntersectionObserver", MockObserver);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  activeObserver = null;
+});
+
+/**
+ * Simulates the section scrolling into view.
+ */
+async function triggerIntersection() {
+  if (!activeObserver) {
+    throw new Error("No IntersectionObserver was created — did the component render?");
+  }
+  await act(async () => {
+    activeObserver!.callback(
+      [{ isIntersecting: true } as IntersectionObserverEntry],
+      activeObserver! as unknown as IntersectionObserver,
+    );
+  });
+}
+
 describe("ValuePropositionSection", () => {
-  test("renders headline, subhead and all feature cards", () => {
+  it("renders headline, subhead and all feature cards", () => {
     render(<ValuePropositionSection />);
 
     // Headline and subhead
@@ -39,5 +83,48 @@ describe("ValuePropositionSection", () => {
       const matches = screen.getAllByText((_content, element) => Boolean(element?.textContent?.includes(desc)));
       expect(matches.length).toBeGreaterThan(0);
     });
+  });
+
+  it("starts with feature cards hidden (opacity 0, translateY 20px)", () => {
+    render(<ValuePropositionSection />);
+
+    // All four feature cards should begin invisible
+    const cards = screen.getAllByRole("heading", { level: 3 });
+    expect(cards).toHaveLength(4);
+
+    cards.forEach((heading) => {
+      const card = heading.closest(".rounded-2xl");
+      expect(card).toBeInTheDocument();
+      expect(card).toHaveStyle("opacity: 0");
+    });
+  });
+
+  it("reveals cards with staggered animation when section scrolls into view", async () => {
+    render(<ValuePropositionSection />);
+
+    // Verify hidden before intersection
+    const heading = screen.getByRole("heading", { level: 2, name: /Treasury streaming infrastructure/i });
+    const parentSection = heading.closest("section");
+    expect(parentSection).toBeInTheDocument();
+
+    // Trigger intersection
+    await triggerIntersection();
+
+    // After intersection, all cards should be visible
+    const cards = screen.getAllByRole("heading", { level: 3 });
+    cards.forEach((h3) => {
+      const card = h3.closest(".rounded-2xl");
+      expect(card).toHaveStyle("opacity: 1");
+    });
+  });
+
+  it("disconnects observer after first intersection (fires once)", async () => {
+    render(<ValuePropositionSection />);
+
+    // Trigger first intersection
+    await triggerIntersection();
+
+    // Verify disconnect was called
+    expect(activeObserver?.disconnect).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary

Adds IntersectionObserver-driven staggered fade-in animation to the four feature cards in ValuePropositionSection.tsx. Each card animates independently with an 80ms incremental delay (0, 80, 160, 240ms) so the reveal reads left-to-right/top-to-bottom. The animation fires once per page load when the section scrolls into view.

## Changes

- **src/components/ValuePropositionSection.tsx**: Added useIntersectionOnce hook using IntersectionObserver; headline/subhead/cards now fade in from translateY(12px/20px) to translateY(0) using var(--transition-base) (200ms ease-in-out); each card has staggered transitionDelay.
- **src/components/__tests__/ValuePropositionSection.test.tsx**: Mock IntersectionObserver; tests for start-hidden, reveal-on-intersection, and one-shot disconnect behavior.

Closes #1267