### PR TITLE
feat: add treasury-balance-derived at-risk health state to StreamDetail sidebar (Closes #1280)

### DIFF
--- a/src/pages/StreamDetail.tsx
+++ b/src/pages/StreamDetail.tsx
@@ -12,7 +12,44 @@ import { MetaTags } from "../components/MetaTags";
 import { usePresenceViewers } from "../hooks/usePresenceViewers";
 import { PresenceBadge, PresenceCursorOverlay } from "../components/presence";
 import { StreamOGPreviewModal } from "../components/StreamOGPreviewModal";
-import { Share2 } from "lucide-react";
+import { Share2, AlertTriangle } from "lucide-react";
+
+/**
+ * Threshold in hours below which the stream's remaining funding runway is
+ * considered "at risk". Can be tuned without hunting through the component.
+ */
+export const AT_RISK_RUNWAY_HOURS = 48;
+
+/**
+ * Assumed hours per month for funding-runway calculations.
+ * Uses 30 days per month (720 hours) as a conservative baseline.
+ */
+export const HOURS_PER_MONTH = 720;
+
+/**
+ * Compute the remaining funding runway in hours based on the stream's
+ * remaining balance and monthly accrual rate.
+ * Returns `Infinity` when the rate is zero (no accrual → no risk of running out).
+ */
+export function computeFundingRunwayHours(
+  remainingAmount: number,
+  monthlyRate: number,
+): number {
+  if (monthlyRate <= 0) return Infinity;
+  if (remainingAmount <= 0) return 0;
+  return (remainingAmount / monthlyRate) * HOURS_PER_MONTH;
+}
+
+/**
+ * Returns true when the stream's remaining funding runway is below the
+ * at-risk threshold. Excludes completed streams (they are already settled).
+ */
+export function isFundingAtRisk(stream: Pick<StreamRecord, "status" | "remainingAmount" | "monthlyRate">): boolean {
+  if (stream.status === "Completed") return false;
+  if (stream.monthlyRate <= 0) return false;
+  const runwayHours = computeFundingRunwayHours(stream.remainingAmount, stream.monthlyRate);
+  return runwayHours < AT_RISK_RUNWAY_HOURS;
+}
 
 /**
  * StreamDetail page
@@ -373,6 +410,30 @@ export default function StreamDetail() {
           <span aria-hidden="true">●</span>
           {stream.health} — {stream.healthNote}
         </span>
+
+        {isFundingAtRisk(stream) && (
+          <span
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: "0.375rem",
+              padding: "0.25rem 0.75rem",
+              borderRadius: "9999px",
+              fontSize: "0.8125rem",
+              fontWeight: 600,
+              marginLeft: "0.5rem",
+              background: "var(--color-error-subtle, #fef2f2)",
+              color: "var(--color-error, #b91c1c)",
+              border: "1px solid var(--color-error-border, #fca5a5)",
+            }}
+            role="alert"
+            aria-label="Funding at risk"
+            data-testid="funding-at-risk-badge"
+          >
+            <AlertTriangle size={14} aria-hidden="true" />
+            <span>Funding at risk — less than {AT_RISK_RUNWAY_HOURS}h of runway</span>
+          </span>
+        )}
       </div>
 
       {/* Metrics grid */}

--- a/src/pages/__tests__/StreamDetail.edgeCases.test.tsx
+++ b/src/pages/__tests__/StreamDetail.edgeCases.test.tsx
@@ -3,7 +3,12 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { HelmetProvider } from "react-helmet-async";
-import StreamDetail from "../StreamDetail";
+import StreamDetail, {
+  AT_RISK_RUNWAY_HOURS,
+  HOURS_PER_MONTH,
+  computeFundingRunwayHours,
+  isFundingAtRisk,
+} from "../StreamDetail";
 import * as streamsService from "../../lib/api/streamsService";
 import type { StreamRecord } from "../../data/streamRecords";
 
@@ -585,6 +590,110 @@ describe("StreamDetail - Edge Cases and Error States", () => {
       
       // Amount formatted as 0 USDC
       expect(screen.getByText("0.00 USDC")).toBeInTheDocument();
+    });
+  });
+
+  describe("Funding runway calculation", () => {
+    it("computes runway hours as remainingAmount / monthlyRate * HOURS_PER_MONTH", () => {
+      // 6000 remaining / 1000 monthly = 6 months = 4320 hours
+      expect(computeFundingRunwayHours(6000, 1000)).toBeCloseTo(6 * HOURS_PER_MONTH, 5);
+    });
+
+    it("returns Infinity when monthlyRate is zero (no accrual → no risk)", () => {
+      expect(computeFundingRunwayHours(6000, 0)).toBe(Infinity);
+    });
+
+    it("returns Infinity when monthlyRate is negative", () => {
+      expect(computeFundingRunwayHours(6000, -100)).toBe(Infinity);
+    });
+
+    it("returns 0 when remainingAmount is zero", () => {
+      expect(computeFundingRunwayHours(0, 1000)).toBe(0);
+    });
+
+    it("returns 0 when remainingAmount is negative", () => {
+      expect(computeFundingRunwayHours(-5, 1000)).toBe(0);
+    });
+  });
+
+  describe("isFundingAtRisk", () => {
+    it("is true when remaining runway is below AT_RISK_RUNWAY_HOURS", () => {
+      // remaining 100 / monthly 5000 → 100/5000 = 0.02 months = 14.4 hours < 48
+      expect(isFundingAtRisk({ status: "Active", remainingAmount: 100, monthlyRate: 5000 })).toBe(true);
+    });
+
+    it("is false when remaining runway equals or exceeds AT_RISK_RUNWAY_HOURS", () => {
+      // remaining 7000 / monthly 1000 = 7 months = 5040 hours ≥ 48
+      expect(isFundingAtRisk({ status: "Active", remainingAmount: 7000, monthlyRate: 1000 })).toBe(false);
+    });
+
+    it("is false for completed streams regardless of balance", () => {
+      expect(isFundingAtRisk({ status: "Completed", remainingAmount: 0, monthlyRate: 1000 })).toBe(false);
+      expect(isFundingAtRisk({ status: "Completed", remainingAmount: 6000, monthlyRate: 1200 })).toBe(false);
+    });
+
+    it("is false when monthlyRate is zero", () => {
+      expect(isFundingAtRisk({ status: "Active", remainingAmount: 100, monthlyRate: 0 })).toBe(false);
+    });
+  });
+
+  describe("Funding at-risk badge rendering", () => {
+    it("renders the at-risk badge when remaining runway is below threshold", async () => {
+      const atRiskStream = {
+        ...mockStream,
+        remainingAmount: 100,
+        monthlyRate: 5000,
+      };
+      vi.spyOn(streamsService, "getStreamById").mockResolvedValue(atRiskStream);
+
+      renderWithHelmet(
+        <MemoryRouter initialEntries={["/app/streams/STR-001"]}>
+          <Routes>
+            <Route path="/app/streams/:streamId" element={<StreamDetail />} />
+          </Routes>
+        </MemoryRouter>
+      );
+
+      await screen.findByRole("heading", { name: "Test Stream" });
+      const badge = screen.getByTestId("funding-at-risk-badge");
+      expect(badge).toBeInTheDocument();
+      expect(badge).toHaveTextContent("Funding at risk");
+      expect(badge).toHaveTextContent(String(AT_RISK_RUNWAY_HOURS));
+    });
+
+    it("does not render the at-risk badge when remaining runway is sufficient", async () => {
+      vi.spyOn(streamsService, "getStreamById").mockResolvedValue(mockStream);
+
+      renderWithHelmet(
+        <MemoryRouter initialEntries={["/app/streams/STR-001"]}>
+          <Routes>
+            <Route path="/app/streams/:streamId" element={<StreamDetail />} />
+          </Routes>
+        </MemoryRouter>
+      );
+
+      await screen.findByRole("heading", { name: "Test Stream" });
+      expect(screen.queryByTestId("funding-at-risk-badge")).not.toBeInTheDocument();
+    });
+
+    it("does not render the at-risk badge for completed streams even with low balance", async () => {
+      const completedStream = {
+        ...mockStream,
+        status: "Completed" as const,
+        remainingAmount: 0,
+      };
+      vi.spyOn(streamsService, "getStreamById").mockResolvedValue(completedStream);
+
+      renderWithHelmet(
+        <MemoryRouter initialEntries={["/app/streams/STR-001"]}>
+          <Routes>
+            <Route path="/app/streams/:streamId" element={<StreamDetail />} />
+          </Routes>
+        </MemoryRouter>
+      );
+
+      await screen.findByRole("heading", { name: "Test Stream" });
+      expect(screen.queryByTestId("funding-at-risk-badge")).not.toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
Closes #1280

## Description

Add a treasury-balance-derived **"At risk"** funding health state to the `StreamDetail` sidebar. The existing health pill reflects the stream's own status (active/paused/completed); this adds a distinct, layered indicator that surfaces when the remaining balance only covers under 48 hours of accrual at the stream's monthly rate.

## Changes

- **`src/pages/StreamDetail.tsx`**
  - Added `AT_RISK_RUNWAY_HOURS = 48` named constant (single, tunable threshold).
  - Added `HOURS_PER_MONTH = 720` (30-day month) for the runway calculation.
  - Added `computeFundingRunwayHours(remainingAmount, monthlyRate)` — returns `Infinity` when the monthly rate is zero (no accrual → no funding risk) and `0` when the remaining balance is exhausted.
  - Added `isFundingAtRisk(stream)` — true when the computed runway is below the 48-hour threshold, and **excludes completed streams** (already settled).
  - Rendered an "At risk" badge (alert-triangle icon + label, not color alone) next to the existing health pill when `isFundingAtRisk` is true. It uses design tokens (`--color-error-subtle`, `--color-error`, `--color-error-border`), is `role="alert"` for screen readers, and is responsive (inline-flex, wraps alongside the pill).

- **`src/pages/__tests__/StreamDetail.edgeCases.test.tsx`**
  - Unit tests for `computeFundingRunwayHours` (happy path, zero/negative rate, zero/negative balance).
  - Unit tests for `isFundingAtRisk` (below/above threshold, completed streams, zero rate).
  - Integration tests asserting the at-risk badge renders when runway < 48h, and does **not** render for sufficient runway or completed streams.

## Verification

- New tests pass: 12/12 (`vitest run ... -t "Funding"`).
- `tsc --noEmit` reports no new errors in `StreamDetail.tsx` / its tests.
- The threshold is a single named constant so it can be tuned without hunting through the component.
- WCAG 2.1 AA: the badge is announced via `role="alert"` and relies on an icon + label (not color alone).

## Screenshots / a11y notes

- At-risk badge: red-tinted pill with an alert-triangle icon and "Funding at risk — less than 48h of runway" text, shown inline next to the stream's health pill.
- Non-at-risk streams: unchanged (no badge).